### PR TITLE
Add protocol tests for Content-Type and Content-Length for empty body

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/empty-input-output.smithy
@@ -27,7 +27,13 @@ apply NoInputAndNoOutput @httpRequestTests([
         protocol: restJson1,
         method: "POST",
         uri: "/NoInputAndNoOutput",
-        body: ""
+        body: "",
+        headers: {
+            "Content-Length": "0"
+        },
+        forbidHeaders: [
+            "Content-Type"
+        ],
     },
     {
         id: "RestJsonNoInputAllowsAccept",
@@ -39,8 +45,12 @@ apply NoInputAndNoOutput @httpRequestTests([
         uri: "/NoInputAndNoOutput",
         body: "",
         headers: {
-            "Accept": "application/json"
+            "Accept": "application/json",
+            "Content-Length": "0"
         },
+        forbidHeaders: [
+            "Content-Type"
+        ],
         appliesTo: "server",
     }
 ])
@@ -54,8 +64,35 @@ apply NoInputAndNoOutput @httpResponseTests([
             header.""",
        protocol: restJson1,
        code: 200,
-       body: ""
+       body: "",
+       headers: {
+           "Content-Length": "0"
+       },
+       forbidHeaders: [
+           "Content-Type"
+       ],
    }
+])
+
+@http(uri: "/NoInputAndNoOutputGet", method: "GET")
+operation NoInputAndNoOutputGet {}
+
+apply NoInputAndNoOutputGet @httpRequestTests([
+    {
+        id: "RestJsonNoInputAndNoOutputGet",
+        documentation: """
+                No input serializes no payload. When clients do not need to
+                serialize any data in the payload, they should omit a payload
+                altogether.""",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/NoInputAndNoOutputGet",
+        body: "",
+        forbidHeaders: [
+            "Content-Length",
+            "Content-Type"
+        ],
+    },
 ])
 
 /// This test is similar to NoInputAndNoOutput, but uses explicit Unit types.
@@ -75,7 +112,13 @@ apply UnitInputAndOutput @httpRequestTests([
         protocol: restJson1,
         method: "POST",
         uri: "/UnitInputAndOutput",
-        body: ""
+        body: "",
+        headers: {
+            "Content-Length": "0"
+        },
+        forbidHeaders: [
+            "Content-Type"
+        ],
     },
     {
         id: "RestJsonUnitInputAllowsAccept",
@@ -87,8 +130,12 @@ apply UnitInputAndOutput @httpRequestTests([
         uri: "/UnitInputAndOutput",
         body: "",
         headers: {
-            "Accept": "application/json"
+            "Accept": "application/json",
+            "Content-Length": "0"
         },
+        forbidHeaders: [
+            "Content-Type"
+        ],
         appliesTo: "server",
     }
 ])
@@ -126,6 +173,12 @@ apply NoInputAndOutput @httpRequestTests([
         method: "POST",
         uri: "/NoInputAndOutputOutput",
         body: "",
+        headers: {
+            "Content-Length": "0"
+        },
+        forbidHeaders: [
+            "Content-Type"
+        ],
     },
     {
         id: "RestJsonNoInputAndOutputAllowsAccept",
@@ -137,8 +190,12 @@ apply NoInputAndOutput @httpRequestTests([
         uri: "/NoInputAndOutputOutput",
         body: "",
         headers: {
-            "Accept": "application/json"
+            "Accept": "application/json",
+            "Content-Length": "0"
         },
+        forbidHeaders: [
+            "Content-Type"
+        ],
         appliesTo: "server"
     }
 ])
@@ -194,6 +251,12 @@ apply EmptyInputAndEmptyOutput @httpRequestTests([
         method: "POST",
         uri: "/EmptyInputAndEmptyOutput",
         body: "",
+        headers: {
+            "Content-Length": "0"
+        },
+        forbidHeaders: [
+            "Content-Type"
+        ],
     },
     {
         id: "RestJsonEmptyInputAndEmptyOutputWithJson",
@@ -236,6 +299,31 @@ apply EmptyInputAndEmptyOutput @httpResponseTests([
         code: 200,
         body: "",
         appliesTo: "client",
+    },
+])
+
+
+@http(uri: "/EmptyInputAndEmptyOutputGet", method: "GET")
+operation EmptyInputAndEmptyOutputGet {
+    input: EmptyInputAndEmptyOutputInput,
+    output: EmptyInputAndEmptyOutputOutput
+}
+
+apply EmptyInputAndEmptyOutputGet @httpRequestTests([
+    {
+        id: "RestJsonEmptyInputAndEmptyOutputGet",
+        documentation: """
+                Clients should not serialize a JSON payload when no parameters
+                are given that are sent in the body. A service will tolerate
+                clients that omit a payload or that send a JSON object.""",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/EmptyInputAndEmptyOutputGet",
+        body: "",
+        forbidHeaders: [
+            "Content-Length",
+            "Content-Type"
+        ],
     },
 ])
 

--- a/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
@@ -280,6 +280,51 @@ apply TestNoPayload @httpRequestTests([
     }
 ])
 
+@http(uri: "/no_payload_post", method: "POST")
+operation TestNoPayloadPost {
+    input: TestNoPayloadInputOutput,
+    output: TestNoPayloadInputOutput
+}
+
+apply TestNoPayloadPost @httpRequestTests([
+    {
+        id: "RestJsonHttpWithNoModeledBodyPost",
+        documentation: "Serializes a POST request with no modeled body",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/no_payload_post",
+        body: "",
+        headers: {
+            "Content-Length": "0"
+        },
+        forbidHeaders: [
+            "Content-Type"
+        ],
+        params: {}
+    }
+])
+
+apply TestNoPayloadPost @httpRequestTests([
+    {
+        id: "RestJsonHttpWithHeaderMemberNoModeledBodyPost",
+        documentation: "Serializes a POST request with header member but no modeled body",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/no_payload_post",
+        body: "",
+        headers: {
+            "X-Amz-Test-Id": "t-12345",
+            "Content-Length": "0"
+        },
+        forbidHeaders: [
+            "Content-Type"
+        ],
+        params: {
+            testId: "t-12345"
+        }
+    }
+])
+
 structure TestNoPayloadInputOutput {
     @httpHeader("X-Amz-Test-Id")
     testId: String,

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -19,8 +19,10 @@ service RestJson {
     operations: [
         // Basic input and output tests
         NoInputAndNoOutput,
+        NoInputAndNoOutputGet,
         NoInputAndOutput,
         EmptyInputAndEmptyOutput,
+        EmptyInputAndEmptyOutputGet,
         UnitInputAndOutput,
 
         // @httpHeader tests
@@ -136,5 +138,6 @@ service RestJson {
         TestPayloadStructure,
         TestPayloadBlob,
         TestNoPayload,
+        TestNoPayloadPost,
     ]
 }


### PR DESCRIPTION
https://github.com/awslabs/smithy-typescript/issues/552 is reported in smithy-typescript with proposed fix https://github.com/awslabs/smithy-typescript/pull/553. We are missing protocol tests that specify these behaviors. 

I've added a bunch of test cases. I've just written them quickly without building the package, so there may be typos, bad naming, bad documentation, mistakes in these. And some might be repetitive. But I wanted to get started on these, so pushing this PR out so someone can pick it up. I think having these would require the fix from https://github.com/awslabs/smithy-typescript/pull/553 and maybe more, and maybe across other smithy generators too.

For reference, earlier PR that added the forbidHeader cases in http-content-type, for GET only. The Content-Length assertions in these tests are based on https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2

>   A user agent SHOULD send a Content-Length in a request message when
   no Transfer-Encoding is sent and the request method defines a meaning
   for an enclosed payload body.  For example, a Content-Length header
   field is normally sent in a POST request even when the value is 0
   (indicating an empty payload body).  A user agent SHOULD NOT send a
   Content-Length header field when the request message does not contain
   a payload body and the method semantics do not anticipate such a
   body.

** This could change existing behavior of some SDKs. Double check if this is all good.

I also found this related open PR in our repo - https://github.com/awslabs/smithy/pull/1399.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
