### PR TITLE
Omit unrecognized models from sources

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/plugins/SourcesPlugin.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/plugins/SourcesPlugin.java
@@ -145,8 +145,16 @@ public final class SourcesPlugin implements SmithyBuildPlugin {
                     + ValidationUtils.tickedList(manifest.getFiles()));
         }
 
-        manifest.writeFile(target, contents);
-        names.add(target.toString());
+        String filename = target.toString();
+
+        // Even though sources are filtered in SmithyBuild, it's theoretically possible that someone could call this
+        // plugin manually. In that case, refuse to write unsupported files to the manifest.
+        if (filename.endsWith(".smithy") || filename.endsWith(".json")) {
+            manifest.writeFile(target, contents);
+            names.add(target.toString());
+        } else {
+            LOGGER.warning("Omitting unrecognized file from Smithy model manifest: " + filename);
+        }
     }
 
     private static void projectSources(PluginContext context) {

--- a/smithy-build/src/test/java/software/amazon/smithy/build/plugins/SourcesPluginTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/plugins/SourcesPluginTest.java
@@ -208,4 +208,28 @@ public class SourcesPluginTest {
         assertThat(manifest.hasFile("a.smithy"), is(true));
         assertThat(manifest.hasFile("d.smithy"), is(false));
     }
+
+    // When the sources plugin sees a file it does not support, it is ignored.
+    @Test
+    public void omitsUnsupportedFilesFromManifest() throws URISyntaxException {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("sources-ignores-unrecognized-files/a.smithy"))
+                .addImport(getClass().getResource("sources-ignores-unrecognized-files/foo.md"))
+                .assemble()
+                .unwrap();
+        MockManifest manifest = new MockManifest();
+        PluginContext context = PluginContext.builder()
+                .fileManifest(manifest)
+                .model(model)
+                .originalModel(model)
+                .sources(ListUtils.of(Paths.get(getClass().getResource("sources-ignores-unrecognized-files").toURI())))
+                .build();
+        new SourcesPlugin().execute(context);
+        String manifestString = manifest.getFileString("manifest").get();
+        // Normalize for Windows.
+        manifestString = manifestString.replace("\\", "/");
+
+        assertThat(manifestString, containsString("a.smithy\n"));
+        assertThat(manifestString, not(containsString("foo.md")));
+    }
 }

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/plugins/sources-ignores-unrecognized-files/a.smithy
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/plugins/sources-ignores-unrecognized-files/a.smithy
@@ -1,0 +1,5 @@
+$version: "2.0"
+
+namespace smithy.example
+
+string MyString

--- a/smithy-build/src/test/resources/software/amazon/smithy/build/plugins/sources-ignores-unrecognized-files/foo.md
+++ b/smithy-build/src/test/resources/software/amazon/smithy/build/plugins/sources-ignores-unrecognized-files/foo.md
@@ -1,0 +1,4 @@
+# Ignore me!
+
+The sources plugin should ignore unsupported files so that they don't show up
+in places like JARs.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelLoader.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelLoader.java
@@ -82,7 +82,7 @@ final class ModelLoader {
                     return loadParsedNode(Node.parse(inputStream, filename), operationConsumer);
                 }
             } else {
-                LOGGER.warning(() -> "Ignoring unrecognized file: " + filename);
+                LOGGER.warning(() -> "Ignoring unrecognized Smithy model file: " + filename);
                 return false;
             }
         } catch (IOException e) {


### PR DESCRIPTION
*Description of changes:*

Smithy-Build is often invoked from the Smithy CLI, and developers often provide directories that contain model files. If a directory contains files other than recognized Smithy models, those unknown files are treated as "sources" and ultimately wind up in the sources plugin manifest file. Files that are not Smithy model files should not show up in the manifest as this can cause invalid JARs to get created by tooling like the Smithy Gradle plugin.

Sources are now eagerly filtered when they are added to SmithyBuild. If someone, somehow, manually configures the sources plugin to use unrecognized Smithy model files, the plugin will skip those files and log a warning rather than create an invalid manifest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.