### PR TITLE
Fix building models in subdirs

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/SmithyBuild.java
@@ -15,8 +15,6 @@
 
 package software.amazon.smithy.build;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -199,23 +197,10 @@ public final class SmithyBuild {
     //
     // Ignores and logs when an unsupported model file is encountered.
     private void addSource(Path path) {
-        try {
-            if (Files.isDirectory(path)) {
-                // Pre-emptively crawl the given models to filter them up front into a flat, file-only, list.
-                Files.list(path).filter(Files::isRegularFile).forEach(this::addSourceFile);
-            } else {
-                addSourceFile(path);
-            }
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    private void addSourceFile(Path file) {
-        if (!VALID_MODELS.matches(file.getFileName())) {
-            LOGGER.warning("Omitting unsupported Smithy model file from model sources: " + file);
+        if (Files.isRegularFile(path) && !VALID_MODELS.matches(path.getFileName())) {
+            LOGGER.warning("Omitting unsupported Smithy model file from model sources: " + path);
         } else {
-            sources.add(file.toAbsolutePath());
+            sources.add(path.toAbsolutePath());
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

Fixes #1859 

*Description of changes:*

Modifies the changes in https://github.com/smithy-lang/smithy/pull/1851, specifically `SmithyBuild::addSources`, to not check subdirectories for Smithy files. The previous behavior was to just add whatever path was given to the method, *not* everything in subdirectories. However, the change didn't recursively search subdirectores, so you could get build errors due to missing shapes when running the sources plugin.

This change reverts the behavior of `SmithyBuild::addSource` to only add whichever path it was given, but still checks to see if the path is a valid Smithy model.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
