### PR TITLE
Add documentationIdentifier value to aws.api#service trait

### DIFF
--- a/docs/source-1.0/spec/aws/aws-core.rst
+++ b/docs/source-1.0/spec/aws/aws-core.rst
@@ -26,12 +26,12 @@ Value type
     * :ref:`service-cloudformation-name`
     * :ref:`service-arn-namespace`
     * :ref:`service-cloudtrail-event-source`
-    * :ref:`service-documentation-identifier`
+    * :ref:`service-doc-id`
     * :ref:`service-endpoint-prefix`
 
 The following example defines an AWS service that uses the default values of
 ``cloudFormationService``, ``arnNamespace``, ``cloudTrailEventSource`` and
-``documentationIdentifier``:
+``docId``:
 
 .. tabs::
 
@@ -80,7 +80,7 @@ The following example provides explicit values for all properties:
             cloudFormationName: "FooBaz",
             arnNamespace: "myservice",
             cloudTrailEventSource: "myservice.amazon.aws",
-            documentationIdentifier: "some-value-2018-03-17",
+            docId: "some-value-2018-03-17",
             endpointPrefix: "my-endpoint"
         )
         service FooBaz {
@@ -100,7 +100,7 @@ The following example provides explicit values for all properties:
                             "sdkId": "Some Value",
                             "cloudFormationName": "FooBaz",
                             "arnNamespace": "myservice",
-                            "documentationIdentifier": "some-value-2018-03-17",
+                            "docId": "some-value-2018-03-17",
                             "cloudTrailEventSource": "myservice.amazon.aws"
                         }
                     }
@@ -237,17 +237,17 @@ Amazon CloudWatch is ``monitoring.amazonaws.com``. Such services will
 need to explicitly configure the ``cloudTrailEventSource`` setting.
 
 
-.. _service-documentation-identifier:
+.. _service-doc-id:
 
-``documentationIdentifier``
+``docId``
 ===========================
 
-The ``documentationIdentifier`` property is a ``string`` value that is used to
-implement linking between service and SDK documentation for AWS services.
+The ``docId`` property is a ``string`` value that is used to implement linking
+between service and SDK documentation for AWS services.
 
 This value MAY be provided, but if it's missing it will default to the ``sdkId``
 value in lower case followed by the service ``version`` property, separated by
-dashes. For the example beloe the value for this property would default to
+dashes. For the example below the value for this property would default to
 ``some-value-2018-03-17``.
 
 .. code-block:: smithy

--- a/docs/source-1.0/spec/aws/aws-core.rst
+++ b/docs/source-1.0/spec/aws/aws-core.rst
@@ -26,10 +26,12 @@ Value type
     * :ref:`service-cloudformation-name`
     * :ref:`service-arn-namespace`
     * :ref:`service-cloudtrail-event-source`
+    * :ref:`service-documentation-identifier`
     * :ref:`service-endpoint-prefix`
 
 The following example defines an AWS service that uses the default values of
-``cloudFormationService``, ``arnNamespace``, and ``cloudTrailEventSource``:
+``cloudFormationService``, ``arnNamespace``, ``cloudTrailEventSource`` and
+``documentationIdentifier``:
 
 .. tabs::
 
@@ -78,6 +80,7 @@ The following example provides explicit values for all properties:
             cloudFormationName: "FooBaz",
             arnNamespace: "myservice",
             cloudTrailEventSource: "myservice.amazon.aws",
+            documentationIdentifier: "some-value-2018-03-17",
             endpointPrefix: "my-endpoint"
         )
         service FooBaz {
@@ -97,6 +100,7 @@ The following example provides explicit values for all properties:
                             "sdkId": "Some Value",
                             "cloudFormationName": "FooBaz",
                             "arnNamespace": "myservice",
+                            "documentationIdentifier": "some-value-2018-03-17",
                             "cloudTrailEventSource": "myservice.amazon.aws"
                         }
                     }
@@ -231,6 +235,32 @@ This value SHOULD follow the convention of ``{arnNamespace}.amazonaws.com``,
 but there are some exceptions. For example, the event source for
 Amazon CloudWatch is ``monitoring.amazonaws.com``. Such services will
 need to explicitly configure the ``cloudTrailEventSource`` setting.
+
+
+.. _service-documentation-identifier:
+
+``documentationIdentifier``
+===========================
+
+The ``documentationIdentifier`` property is a ``string`` value that is used to
+implement linking between service and SDK documentation for AWS services.
+
+This value MAY be provided, but if it's missing it will default to the ``sdkId``
+value in lower case followed by the service ``version`` property, separated by
+dashes. For the example beloe the value for this property would default to
+``some-value-2018-03-17``.
+
+.. code-block:: smithy
+
+    $version: "1.0"
+    namespace aws.fooBaz
+
+    use aws.api#service
+
+    @service(sdkId: "Some Value")
+    service FooBaz {
+        version: "2018-03-17",
+    }
 
 
 .. _service-endpoint-prefix:

--- a/docs/source-1.0/spec/aws/aws-core.rst
+++ b/docs/source-1.0/spec/aws/aws-core.rst
@@ -245,10 +245,9 @@ need to explicitly configure the ``cloudTrailEventSource`` setting.
 The ``docId`` property is a ``string`` value that is used to implement linking
 between service and SDK documentation for AWS services.
 
-This value MAY be provided, but if it's missing it will default to the ``sdkId``
-value in lower case followed by the service ``version`` property, separated by
-dashes. For the example below the value for this property would default to
-``some-value-2018-03-17``.
+This will default to the ``sdkId`` value in lower case followed by the service
+``version`` property, separated by dashes. For the example below, the value
+for this property would default to ``some-value-2018-03-17``.
 
 .. code-block:: smithy
 

--- a/docs/source-2.0/aws/aws-core.rst
+++ b/docs/source-2.0/aws/aws-core.rst
@@ -25,12 +25,12 @@ Value type
     * :ref:`service-cloudformation-name`
     * :ref:`service-arn-namespace`
     * :ref:`service-cloudtrail-event-source`
-    * :ref:`service-documentation-identifier`
+    * :ref:`service-doc-id`
     * :ref:`service-endpoint-prefix`
 
 The following example defines an AWS service that uses the default values of
 ``cloudFormationService``, ``arnNamespace``, ``cloudTrailEventSource`` and
-``documentationIdentifier``:
+``docId``:
 
 .. code-block:: smithy
 
@@ -60,7 +60,7 @@ The following example provides explicit values for all properties:
         cloudFormationName: "FooBaz"
         arnNamespace: "myservice"
         cloudTrailEventSource: "myservice.amazon.aws"
-        documentationIdentifier: "some-value-2018-03-17"
+        docId: "some-value-2018-03-17"
         endpointPrefix: "my-endpoint"
     )
     service FooBaz {
@@ -197,17 +197,17 @@ Amazon CloudWatch is ``monitoring.amazonaws.com``. Such services will
 need to explicitly configure the ``cloudTrailEventSource`` setting.
 
 
-.. _service-documentation-identifier:
+.. _service-doc-id:
 
-``documentationIdentifier``
+``docId``
 ===========================
 
-The ``documentationIdentifier`` property is a ``string`` value that is used to
-implement linking between service and SDK documentation for AWS services.
+The ``docId`` property is a ``string`` value that is used to implement linking
+between service and SDK documentation for AWS services.
 
 This value MAY be provided, but if it's missing it will default to the ``sdkId``
 value in lower case followed by the service ``version`` property, separated by
-dashes. For the example beloe the value for this property would default to
+dashes. For the example below the value for this property would default to
 ``some-value-2018-03-17``.
 
 .. code-block:: smithy

--- a/docs/source-2.0/aws/aws-core.rst
+++ b/docs/source-2.0/aws/aws-core.rst
@@ -25,10 +25,12 @@ Value type
     * :ref:`service-cloudformation-name`
     * :ref:`service-arn-namespace`
     * :ref:`service-cloudtrail-event-source`
+    * :ref:`service-documentation-identifier`
     * :ref:`service-endpoint-prefix`
 
 The following example defines an AWS service that uses the default values of
-``cloudFormationService``, ``arnNamespace``, and ``cloudTrailEventSource``:
+``cloudFormationService``, ``arnNamespace``, ``cloudTrailEventSource`` and
+``documentationIdentifier``:
 
 .. code-block:: smithy
 
@@ -58,6 +60,7 @@ The following example provides explicit values for all properties:
         cloudFormationName: "FooBaz"
         arnNamespace: "myservice"
         cloudTrailEventSource: "myservice.amazon.aws"
+        documentationIdentifier: "some-value-2018-03-17"
         endpointPrefix: "my-endpoint"
     )
     service FooBaz {
@@ -192,6 +195,33 @@ This value SHOULD follow the convention of ``{arnNamespace}.amazonaws.com``,
 but there are some exceptions. For example, the event source for
 Amazon CloudWatch is ``monitoring.amazonaws.com``. Such services will
 need to explicitly configure the ``cloudTrailEventSource`` setting.
+
+
+.. _service-documentation-identifier:
+
+``documentationIdentifier``
+===========================
+
+The ``documentationIdentifier`` property is a ``string`` value that is used to
+implement linking between service and SDK documentation for AWS services.
+
+This value MAY be provided, but if it's missing it will default to the ``sdkId``
+value in lower case followed by the service ``version`` property, separated by
+dashes. For the example beloe the value for this property would default to
+``some-value-2018-03-17``.
+
+.. code-block:: smithy
+
+    $version: "2"
+
+    namespace aws.fooBaz
+
+    use aws.api#service
+
+    @service(sdkId: "Some Value")
+    service FooBaz {
+        version: "2018-03-17"
+    }
 
 
 .. _service-endpoint-prefix:

--- a/docs/source-2.0/aws/aws-core.rst
+++ b/docs/source-2.0/aws/aws-core.rst
@@ -205,10 +205,9 @@ need to explicitly configure the ``cloudTrailEventSource`` setting.
 The ``docId`` property is a ``string`` value that is used to implement linking
 between service and SDK documentation for AWS services.
 
-This value MAY be provided, but if it's missing it will default to the ``sdkId``
-value in lower case followed by the service ``version`` property, separated by
-dashes. For the example below the value for this property would default to
-``some-value-2018-03-17``.
+This will default to the ``sdkId`` value in lower case followed by the service
+``version`` property, separated by dashes. For the example below, the value
+for this property would default to ``some-value-2018-03-17``.
 
 .. code-block:: smithy
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
@@ -69,7 +69,6 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
         public Trait createTrait(ShapeId target, Node value) {
             ObjectNode objectNode = value.expectObjectNode();
             Builder builder = builder().sourceLocation(value);
-            builder.target(target);
             String sdkId = objectNode.getStringMember("sdkId")
                     .map(StringNode::getValue)
                     .orElseThrow(() -> new SourceException(String.format(
@@ -100,15 +99,6 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
      */
     public static Builder builder() {
         return new Builder();
-    }
-
-    /**
-     * Get the ShapeId of the target of this trait.
-     *
-     * @return Returns the ShapeId which this trait targets.
-     */
-    public ShapeId getTarget() {
-        return target;
     }
 
     /**
@@ -304,7 +294,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
          * @param target the ShapeId targeted by the trait.
          * @return Returns the builder.
          */
-        public Builder target(ShapeId target) {
+        private Builder target(ShapeId target) {
             this.target = target;
             return this;
         }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
@@ -103,6 +103,15 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
     }
 
     /**
+     * Get the ShapeId of the target of this trait.
+     *
+     * @return Returns the ShapeId which this trait targets.
+     */
+    public ShapeId getTarget() {
+        return target;
+    }
+
+    /**
      * Get the AWS ARN service namespace of the service.
      *
      * <p>If not set, this value defaults to the name of the service shape
@@ -149,6 +158,14 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
         return cloudTrailEventSource;
     }
 
+    /**
+     * Returns the documentation identifier value for the service.
+     *
+     * <p> When not set, this value defaults to the lower cased value of
+     * the sdkId followed by the service version, separated by dashes.
+     *
+     * @return Returns the documentation identifier value for the service name.
+     */
     public String getDocumentationIdentifier(Model model) {
         return getDocumentationIdentifier().orElse(buildDefaultDocumentationIdentifier(model));
     }
@@ -280,6 +297,12 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
             return new ServiceTrait(this);
         }
 
+        /**
+         * Sets the target shape to which the trait is applied.
+         *
+         * @param target the ShapeId targeted by the trait.
+         * @return Returns the builder.
+         */
         public Builder target(ShapeId target) {
             this.target = target;
             return this;
@@ -335,6 +358,12 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
             return this;
         }
 
+        /**
+         * Set the documentation identifier for the service.
+         *
+         * @param documentationIdentifier documentation identifier for the service.
+         * @return Returns the builder.
+         */
         public Builder documentationIdentifier(String documentationIdentifier) {
             this.documentationIdentifier = documentationIdentifier;
             return this;

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
@@ -233,7 +233,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
     @Override
     public int hashCode() {
         return Objects.hash(toShapeId(), target, sdkId, arnNamespace, cloudFormationName,
-                            cloudTrailEventSource, endpointPrefix);
+                            cloudTrailEventSource, documentationIdentifier, endpointPrefix);
     }
 
     /** Builder for {@link ServiceTrait}. */

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
@@ -153,7 +153,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
         return getDocumentationIdentifier().orElse(buildDefaultDocumentationIdentifier(model));
     }
 
-    protected Optional<String> getDocumentationIdentifier() {
+    private Optional<String> getDocumentationIdentifier() {
         return Optional.ofNullable(documentationIdentifier);
     }
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
@@ -161,8 +161,9 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
     /**
      * Returns the documentation identifier value for the service.
      *
-     * <p> When not set, this value defaults to the lower cased value of
-     * the sdkId followed by the service version, separated by dashes.
+     * <p> When value on trait is not set, this method defaults to the lower
+     * cased value of the sdkId followed by the service version, separated by
+     * dashes.
      *
      * @return Returns the documentation identifier value for the service name.
      */
@@ -170,7 +171,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
         return getDocId().orElse(buildDefaultDocId(model));
     }
 
-    private Optional<String> getDocId() {
+    protected Optional<String> getDocId() {
         return Optional.ofNullable(docId);
     }
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
@@ -45,7 +45,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
     private final String arnNamespace;
     private final String sdkId;
     private final String cloudTrailEventSource;
-    private final String documentationIdentifier;
+    private final String docId;
     private final String endpointPrefix;
 
     private ServiceTrait(Builder builder) {
@@ -56,7 +56,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
         this.cloudFormationName = SmithyBuilder.requiredState("cloudFormationName", builder.cloudFormationName);
         this.cloudTrailEventSource = SmithyBuilder.requiredState(
                 "cloudTrailEventSource", builder.cloudTrailEventSource);
-        this.documentationIdentifier = builder.documentationIdentifier;
+        this.docId = builder.docId;
         this.endpointPrefix = SmithyBuilder.requiredState("endpointPrefix", builder.endpointPrefix);
     }
 
@@ -84,8 +84,8 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
                     .ifPresent(builder::cloudFormationName);
             objectNode.getStringMember("cloudTrailEventSource").map(StringNode::getValue)
                     .ifPresent(builder::cloudTrailEventSource);
-            objectNode.getStringMember("documentationIdentifier").map(StringNode::getValue)
-                    .ifPresent(builder::documentationIdentifier);
+            objectNode.getStringMember("docId").map(StringNode::getValue)
+                    .ifPresent(builder::docId);
             objectNode.getStringMember("endpointPrefix")
                     .map(StringNode::getValue)
                     .ifPresent(builder::endpointPrefix);
@@ -166,15 +166,15 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
      *
      * @return Returns the documentation identifier value for the service name.
      */
-    public String getDocumentationIdentifier(Model model) {
-        return getDocumentationIdentifier().orElse(buildDefaultDocumentationIdentifier(model));
+    public String getDocId(Model model) {
+        return getDocId().orElse(buildDefaultDocId(model));
     }
 
-    private Optional<String> getDocumentationIdentifier() {
-        return Optional.ofNullable(documentationIdentifier);
+    private Optional<String> getDocId() {
+        return Optional.ofNullable(docId);
     }
 
-    private String buildDefaultDocumentationIdentifier(Model model) {
+    private String buildDefaultDocId(Model model) {
         String version = model.expectShape(target, ServiceShape.class).getVersion();
         return sdkId.replace(" ", "-").toLowerCase(Locale.US) + "-" + version;
     }
@@ -207,7 +207,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
                 .cloudFormationName(cloudFormationName)
                 .arnNamespace(arnNamespace)
                 .cloudTrailEventSource(cloudTrailEventSource)
-                .documentationIdentifier(documentationIdentifier)
+                .docId(docId)
                 .endpointPrefix(endpointPrefix);
     }
 
@@ -220,7 +220,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
                 .withMember("arnNamespace", Node.from(getArnNamespace()))
                 .withMember("cloudFormationName", Node.from(getCloudFormationName()))
                 .withMember("cloudTrailEventSource", Node.from(getCloudTrailEventSource()))
-                .withOptionalMember("documentationIdentifier", getDocumentationIdentifier().map(Node::from))
+                .withOptionalMember("docId", getDocId().map(Node::from))
                 .withMember("endpointPrefix", Node.from(getEndpointPrefix()))
                 .build();
     }
@@ -240,9 +240,9 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
                     && arnNamespace.equals(os.arnNamespace)
                     && cloudFormationName.equals(os.cloudFormationName)
                     && cloudTrailEventSource.equals(os.cloudTrailEventSource)
-                    && documentationIdentifier == null
-                        ? os.documentationIdentifier == null
-                        : documentationIdentifier.equals(os.documentationIdentifier)
+                    && docId == null
+                        ? os.docId == null
+                        : docId.equals(os.docId)
                     && endpointPrefix.equals(os.endpointPrefix);
         }
     }
@@ -250,7 +250,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
     @Override
     public int hashCode() {
         return Objects.hash(toShapeId(), target, sdkId, arnNamespace, cloudFormationName,
-                            cloudTrailEventSource, documentationIdentifier, endpointPrefix);
+                            cloudTrailEventSource, docId, endpointPrefix);
     }
 
     /** Builder for {@link ServiceTrait}. */
@@ -260,7 +260,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
         private String cloudFormationName;
         private String arnNamespace;
         private String cloudTrailEventSource;
-        private String documentationIdentifier;
+        private String docId;
         private String endpointPrefix;
 
         private Builder() {}
@@ -361,11 +361,11 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
         /**
          * Set the documentation identifier for the service.
          *
-         * @param documentationIdentifier documentation identifier for the service.
+         * @param docId documentation identifier for the service.
          * @return Returns the builder.
          */
-        public Builder documentationIdentifier(String documentationIdentifier) {
-            this.documentationIdentifier = documentationIdentifier;
+        public Builder docId(String docId) {
+            this.docId = docId;
             return this;
         }
 

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.smithy
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.smithy
@@ -186,12 +186,11 @@ structure service {
     /// to the `arnNamespace` plus `.amazonaws.com`.
     cloudTrailEventSource: String
 
-    /// The `documentatioIdentifier` property is a string value that defines the
-    /// identifiers used to implemention linking between service and SDK
-    /// documentation for AWS services. If not specified, this value defaults
-    /// to the `sdkId` in lower case plus the service `version` property, separated
-    /// by dashes.
-    documentationIdentifier: String
+    /// The `docId` property is a string value that defines the identifier
+    /// used to implemention linking between service and SDK documentation for
+    /// AWS services. If not specified, this value defaults to the `sdkId` in
+    /// lower case plus the service `version` property, separated by dashes.
+    docId: String
 
     /// The `endpointPrefix` property is a string value that identifies which
     /// endpoint in a given region should be used to connect to the service.

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.smithy
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.smithy
@@ -186,6 +186,8 @@ structure service {
     /// to the `arnNamespace` plus `.amazonaws.com`.
     cloudTrailEventSource: String
 
+    documentationIdentifier: String
+
     /// The `endpointPrefix` property is a string value that identifies which
     /// endpoint in a given region should be used to connect to the service.
     /// For example, most services in the AWS standard partition have endpoints

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.smithy
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.api.smithy
@@ -186,6 +186,11 @@ structure service {
     /// to the `arnNamespace` plus `.amazonaws.com`.
     cloudTrailEventSource: String
 
+    /// The `documentatioIdentifier` property is a string value that defines the
+    /// identifiers used to implemention linking between service and SDK
+    /// documentation for AWS services. If not specified, this value defaults
+    /// to the `sdkId` in lower case plus the service `version` property, separated
+    /// by dashes.
     documentationIdentifier: String
 
     /// The `endpointPrefix` property is a string value that identifies which

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/EventSourceValidatorTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/EventSourceValidatorTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
@@ -21,7 +22,7 @@ public class EventSourceValidatorTest {
                 .arnNamespace("foo")
                 .cloudTrailEventSource("REPLACE_ME_LATER")
                 .cloudFormationName("AWS::Foo")
-                .build();
+                .build(ShapeId.from("smithy.example#Foo"));
         ServiceShape service = ServiceShape.builder()
                 .id("smithy.example#Foo")
                 .version("123")
@@ -44,7 +45,7 @@ public class EventSourceValidatorTest {
                 .arnNamespace("foo")
                 .cloudTrailEventSource("notfoo.amazonaws.com")
                 .cloudFormationName("AWS::Foo")
-                .build();
+                .build(ShapeId.from("smithy.example#Foo"));
         ServiceShape service = ServiceShape.builder()
                 .id("smithy.example#Foo")
                 .version("123")
@@ -68,7 +69,7 @@ public class EventSourceValidatorTest {
                 .arnNamespace("cloudwatch")
                 .cloudTrailEventSource("monitoring.amazonaws.com")
                 .cloudFormationName("AWS::Foo")
-                .build();
+                .build(ShapeId.from("smithy.example#Foo"));
         ServiceShape service = ServiceShape.builder()
                 .id("smithy.example#Foo")
                 .version("123")

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/EventSourceValidatorTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/EventSourceValidatorTest.java
@@ -17,14 +17,15 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 public class EventSourceValidatorTest {
     @Test
     public void detectsWhenEventSourceIsUnexpected() {
+        ShapeId id = ShapeId.from("smithy.example#Foo");
         ServiceTrait trait = ServiceTrait.builder()
                 .sdkId("Foo")
                 .arnNamespace("foo")
                 .cloudTrailEventSource("REPLACE_ME_LATER")
                 .cloudFormationName("AWS::Foo")
-                .build(ShapeId.from("smithy.example#Foo"));
+                .build(id);
         ServiceShape service = ServiceShape.builder()
-                .id("smithy.example#Foo")
+                .id(id)
                 .version("123")
                 .addTrait(trait)
                 .build();
@@ -40,14 +41,15 @@ public class EventSourceValidatorTest {
 
     @Test
     public void detectsWhenEventSourceIsPlaceholder() {
+        ShapeId id = ShapeId.from("smithy.example#Foo");
         ServiceTrait trait = ServiceTrait.builder()
                 .sdkId("Foo")
                 .arnNamespace("foo")
                 .cloudTrailEventSource("notfoo.amazonaws.com")
                 .cloudFormationName("AWS::Foo")
-                .build(ShapeId.from("smithy.example#Foo"));
+                .build(id);
         ServiceShape service = ServiceShape.builder()
-                .id("smithy.example#Foo")
+                .id(id)
                 .version("123")
                 .addTrait(trait)
                 .build();
@@ -64,14 +66,15 @@ public class EventSourceValidatorTest {
 
     @Test
     public void ignoresKnownExceptions() {
+        ShapeId id = ShapeId.from("smithy.example#Foo");
         ServiceTrait trait = ServiceTrait.builder()
                 .sdkId("Foo")
                 .arnNamespace("cloudwatch")
                 .cloudTrailEventSource("monitoring.amazonaws.com")
                 .cloudFormationName("AWS::Foo")
-                .build(ShapeId.from("smithy.example#Foo"));
+                .build(id);
         ServiceShape service = ServiceShape.builder()
-                .id("smithy.example#Foo")
+                .id(id)
                 .version("123")
                 .addTrait(trait)
                 .build();


### PR DESCRIPTION
*Description of changes:* Add documentationIdentifier value to aws.api#service trait. This value is used to implement linking between service and sdk documentation for AWS services.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
