### PR TITLE
Fix IDL serialization of enums with mixins

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -477,12 +477,17 @@ public final class SmithyIdlModelSerializer {
 
         private void applyIntroducedTraits(Collection<MemberShape> members) {
             for (MemberShape member : members) {
+                Map<ShapeId, Trait> introducedTraits = new LinkedHashMap<>(member.getIntroducedTraits());
+
+                // The @enumValue trait is serialized using the `=` IDL syntax, so remove it here.
+                introducedTraits.remove(EnumValueTrait.ID);
+
                 // Use short form for a single trait, and block form for multiple traits.
-                if (member.getIntroducedTraits().size() == 1) {
+                if (introducedTraits.size() == 1) {
                     codeWriter.writeInline("apply $I ", member.getId());
                     serializeTraits(member.getIntroducedTraits(), TraitFeature.NO_SPECIAL_DOCS_SYNTAX);
                     codeWriter.write("");
-                } else if (!member.getIntroducedTraits().isEmpty()) {
+                } else if (!introducedTraits.isEmpty()) {
                     codeWriter.openBlock("apply $I {", "}", member.getId(), () -> {
                         // Only serialize local traits, and don't use special documentation syntax here.
                         serializeTraits(member.getIntroducedTraits(), TraitFeature.NO_SPECIAL_DOCS_SYNTAX);

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializerTest.java
@@ -243,4 +243,20 @@ public class SmithyIdlModelSerializerTest {
 
         assertThat(modelResult, equalTo(IoUtils.readUtf8Url(resource).replace("\r\n", "\n")));
     }
+
+    @Test
+    public void handlesEnumMixins() {
+        URL resource = getClass().getResource("idl-serialization/enum-mixin-input.smithy");
+        Model model = Model.assembler().addImport(resource).assemble().unwrap();
+        Map<Path, String> serialized = SmithyIdlModelSerializer.builder().build().serialize(model);
+
+        if (serialized.size() != 1) {
+            throw new RuntimeException("Exactly one smithy file should be output for generated tests.");
+        }
+
+        String expectedOutput = IoUtils.readUtf8Resource(getClass(), "idl-serialization/enum-mixin-output.smithy")
+                .replaceAll("\\R", "\n");
+        String serializedString = serialized.entrySet().iterator().next().getValue();
+        Assertions.assertEquals(expectedOutput, serializedString);
+    }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/enum-mixin-input.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/enum-mixin-input.smithy
@@ -1,0 +1,23 @@
+$version: "2.0"
+
+namespace ns.foo
+
+@mixin
+intEnum IntMixin {
+    FOO = 1
+    BAR = 2
+}
+
+intEnum IntEnum with [IntMixin] {
+    FOO = 1
+    BAR = 2
+}
+
+@mixin
+enum StringMixin {
+    BAZ = "baz"
+}
+
+enum StringEnum with [StringMixin] {
+    BAZ = "baz"
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/enum-mixin-output.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/enum-mixin-output.smithy
@@ -1,0 +1,18 @@
+$version: "2.0"
+
+namespace ns.foo
+
+intEnum IntEnum with [IntMixin] {}
+
+@mixin
+intEnum IntMixin {
+    FOO = 1
+    BAR = 2
+}
+
+enum StringEnum with [StringMixin] {}
+
+@mixin
+enum StringMixin {
+    BAZ = "baz"
+}


### PR DESCRIPTION
Fixes #1864 

This commit fixes an issue where the IDL serializer would write an empty apply statement on an enum member that was mixed in, as the value was written using the special IDL syntax for enum values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
