### PR TITLE
Fix indentation when formatting text blocks

### DIFF
--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/node-text-blocks.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/node-text-blocks.formatted.smithy
@@ -1,0 +1,21 @@
+$version: "2.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector"
+        id: "MissingStringInputLengthValidation"
+        severity: "DANGER"
+        message: "This string is missing required length trait"
+        configuration: {
+            selector: """
+                operation -[input]-> structure > member
+                :test(member > string:not([trait|enum]))
+                :test(member > string:not([trait|length]))
+                :test(member > string:not([trait|aws.api#arnReference]))
+                :test(member > string:not([trait|aws.api#providesPassRole]))
+                """
+        }
+    }
+]
+
+namespace smithy.example

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/node-text-blocks.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/node-text-blocks.smithy
@@ -1,0 +1,21 @@
+$version: "2.0"
+
+metadata validators = [
+    {
+        name: "EmitEachSelector"
+        id: "MissingStringInputLengthValidation"
+        severity: "DANGER"
+        message: "This string is missing required length trait"
+        configuration: {
+            selector: """
+operation -[input]-> structure > member
+    :test(member > string:not([trait|enum]))
+:test(member > string:not([trait|length]))
+:test(member > string:not([trait|aws.api#arnReference]))
+:test(member > string:not([trait|aws.api#providesPassRole]))
+"""
+        }
+    }
+]
+
+namespace smithy.example

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/trait-textblock.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/trait-textblock.formatted.smithy
@@ -18,9 +18,9 @@ string Foo
 string Bar
 
 @documentation(
-"""
-This is the documentation for Baz.
-Lorem ipsum dolor.
-"""
+    """
+    This is the documentation for Baz.
+    Lorem ipsum dolor.
+    """
 )
 string Baz


### PR DESCRIPTION
Updates the formatter to indent the node value of a node kvp when they are text blocks.

A test case was added for a text block as the node value of a node kvp, and a test case was updated for when text blocks are in traits.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
