### PR TITLE
Expand valid targets of httpPayload

### DIFF
--- a/docs/source-1.0/spec/core/http-traits.rst
+++ b/docs/source-1.0/spec/core/http-traits.rst
@@ -707,13 +707,9 @@ the body of the response.
 Summary
     Binds a single structure member to the body of an HTTP message.
 Trait selector
-    .. code-block:: none
+    ``structure > member``
 
-        structure > :test(member > :test(string, blob, structure, union, document, list, set, map))
-
-    The ``httpPayload`` trait can be applied to ``structure`` members that
-    target a ``string``, ``blob``, ``structure``, ``union``, ``document``,
-    ``set``, ``map``, or ``list``.
+    *Any structure member*
 Value type
     Annotation trait.
 Conflicts with
@@ -777,10 +773,9 @@ or :ref:`httpPrefixHeaders-trait`.
 
 #. When a string or blob member is referenced, the raw value is serialized
    as the body of the message.
-#. When a :ref:`structure <structure>`, :ref:`union <union>`, :ref:`list <list>`,
-   :ref:`set <set>`, :ref:`map <map>`, or document type is targeted,
-   the shape value is serialized as a :ref:`protocol-specific <protocolDefinition-trait>`
-   document that is sent as the body of the message.
+#. When any other type of member is referenced, the shape value is serialized
+   as a :ref:`protocol-specific <protocolDefinition-trait>` value that is sent
+   as the body of the message.
 
 
 .. smithy-trait:: smithy.api#httpPrefixHeaders

--- a/docs/source-2.0/spec/http-bindings.rst
+++ b/docs/source-2.0/spec/http-bindings.rst
@@ -709,14 +709,9 @@ the body of the response.
 Summary
     Binds a single structure member to the body of an HTTP message.
 Trait selector
-    .. code-block:: none
+    ``structure > member``
 
-        structure > :test(member > :test(string, blob, structure, union, document, list, map))
-
-    The ``httpPayload`` trait can be applied to ``structure`` members that
-    target a ``string``, ``blob``, ``structure``, ``union``, ``document``,
-    ``map``, or ``list``.
-
+    *Any structure member*
 Value type
     Annotation trait.
 Conflicts with
@@ -781,9 +776,8 @@ or :ref:`httpPrefixHeaders-trait`.
 
 #. When a string or blob member is referenced, the raw value is serialized
    as the body of the message.
-#. When a :ref:`structure <structure>`, :ref:`union <union>`, :ref:`list <list>`,
-   :ref:`map <map>`, or document type is targeted, the shape value is serialized
-   as a :ref:`protocol-specific <protocolDefinition-trait>` document that is sent
+#. When any other type of member is referenced, the shape value is serialized
+   as a :ref:`protocol-specific <protocolDefinition-trait>` value that is sent
    as the body of the message.
 
 

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/protocols/aws-protocols-do-not-support-list-set-map-payloads.errors
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/protocols/aws-protocols-do-not-support-list-set-map-payloads.errors
@@ -1,3 +1,6 @@
 [ERROR] smithy.example#InvalidBindingOperationInput$listBinding: AWS Protocols only support binding the following shape types to the payload: string, blob, structure, union, and document | ProtocolHttpPayload
 [ERROR] smithy.example#InvalidBindingOperationOutput$mapBinding: AWS Protocols only support binding the following shape types to the payload: string, blob, structure, union, and document | ProtocolHttpPayload
 [ERROR] smithy.example#InvalidBindingError$setBinding: AWS Protocols only support binding the following shape types to the payload: string, blob, structure, union, and document | ProtocolHttpPayload
+[ERROR] smithy.example#InvalidSimpleBindingOperationInput$booleanBinding: AWS Protocols only support binding the following shape types to the payload: string, blob, structure, union, and document | ProtocolHttpPayload
+[ERROR] smithy.example#InvalidSimpleBindingOperationOutput$integerBinding: AWS Protocols only support binding the following shape types to the payload: string, blob, structure, union, and document | ProtocolHttpPayload
+[ERROR] smithy.example#InvalidSimpleBindingError$doubleBinding: AWS Protocols only support binding the following shape types to the payload: string, blob, structure, union, and document | ProtocolHttpPayload

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/protocols/aws-protocols-do-not-support-list-set-map-payloads.smithy
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/protocols/aws-protocols-do-not-support-list-set-map-payloads.smithy
@@ -13,7 +13,10 @@ use smithy.api#httpPayload
 @restJson1
 service InvalidExample {
     version: "2020-12-29",
-    operations: [InvalidBindingOperation],
+    operations: [
+        InvalidBindingOperation,
+        InvalidSimpleBindingOperation
+    ],
 }
 
 @http(method: "POST", uri: "/invalid-payload")
@@ -39,6 +42,31 @@ structure InvalidBindingOperationOutput {
 structure InvalidBindingError {
     @httpPayload
     setBinding: StringSet
+}
+
+@http(method: "POST", uri: "/invalid-simple-payload")
+operation InvalidSimpleBindingOperation {
+    input: InvalidSimpleBindingOperationInput,
+    output: InvalidSimpleBindingOperationOutput,
+    errors: [InvalidSimpleBindingError],
+}
+
+@input
+structure InvalidSimpleBindingOperationInput {
+    @httpPayload
+    booleanBinding: Boolean,
+}
+
+@output
+structure InvalidSimpleBindingOperationOutput {
+    @httpPayload
+    integerBinding: Integer,
+}
+
+@error("client")
+structure InvalidSimpleBindingError {
+    @httpPayload
+    doubleBinding: Double
 }
 
 list StringList {

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -832,7 +832,7 @@ string httpPrefixHeaders
 
 /// Binds a single structure member to the body of an HTTP request.
 @trait(
-    selector: "structure > :test(member > :test(string, blob, structure, union, document, list, map))",
+    selector: "structure > member",
     conflicts: [httpLabel, httpQuery, httpHeader, httpPrefixHeaders, httpResponseCode, httpQueryParams],
     structurallyExclusive: "member",
     breakingChanges: [{change: "presence"}]


### PR DESCRIPTION
This commit updates the httpPayload trait to allow targeting a structure member that targets any type. Documentation is updated to clarify how the values of other types are serialized.

AWS protocol support for new types of httpPayload marked member targets is unchanged.

Resolves #1528 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
