### PR TITLE
Fix ServiceTrait serialization

### DIFF
--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
@@ -206,7 +206,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
     protected Node createNode() {
         return Node.objectNodeBuilder()
                 .sourceLocation(getSourceLocation())
-                .withMember("target", Node.from(target.getName()))
+                .withMember("target", Node.from(target.toString()))
                 .withMember("sdkId", Node.from(sdkId))
                 .withMember("arnNamespace", Node.from(getArnNamespace()))
                 .withMember("cloudFormationName", Node.from(getCloudFormationName()))

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ServiceTraitTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/ServiceTraitTest.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.aws.traits;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -49,6 +50,8 @@ public class ServiceTraitTest {
         assertThat(serviceTrait.getEndpointPrefix(), equalTo("foo"));
         assertThat(serviceTrait.toBuilder().build(), equalTo(serviceTrait));
         assertFalse(serviceTrait.getDocId().isPresent());
+        assertThat(Node.prettyPrintJson(serviceTrait.createNode()),
+                containsString("\"target\": \"ns.foo#Foo\","));
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*
This commit fixes the serialization of the target property of ServiceTrait by serializing the ShapeId with it's namespace qualifier.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
