### PR TITLE
Update docId resolution method

### DIFF
--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
@@ -19,8 +19,8 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Logger;
-import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceException;
+import software.amazon.smithy.model.node.ExpectationNotMetException;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
@@ -40,7 +40,6 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
     public static final ShapeId ID = ShapeId.from("aws.api#service");
     private static final Logger LOGGER = Logger.getLogger(ServiceTrait.class.getName());
 
-    private final ShapeId target;
     private final String cloudFormationName;
     private final String arnNamespace;
     private final String sdkId;
@@ -50,7 +49,6 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
 
     private ServiceTrait(Builder builder) {
         super(ID, builder.getSourceLocation());
-        this.target = SmithyBuilder.requiredState("target", builder.target);
         this.sdkId = SmithyBuilder.requiredState("sdkId", builder.sdkId);
         this.arnNamespace = SmithyBuilder.requiredState("arnNamespace", builder.arnNamespace);
         this.cloudFormationName = SmithyBuilder.requiredState("cloudFormationName", builder.cloudFormationName);
@@ -149,25 +147,30 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
     }
 
     /**
-     * Returns the documentation identifier value for the service.
+     * Resolves the doc id value for the service.
      *
      * <p> When value on trait is not set, this method defaults to the lower
      * cased value of the sdkId followed by the service version, separated by
      * dashes.
      *
+     * @param serviceShape the shape which this trait targets
      * @return Returns the documentation identifier value for the service name.
      */
-    public String getDocId(Model model) {
-        return getDocId().orElseGet(() -> buildDefaultDocId(model));
+    public String resolveDocId(ServiceShape serviceShape) {
+        return getDocId().orElseGet(() -> buildDefaultDocId(serviceShape));
     }
 
     protected Optional<String> getDocId() {
         return Optional.ofNullable(docId);
     }
 
-    private String buildDefaultDocId(Model model) {
-        String version = model.expectShape(target, ServiceShape.class).getVersion();
-        return sdkId.replace(" ", "-").toLowerCase(Locale.US) + "-" + version;
+    private String buildDefaultDocId(ServiceShape serviceShape) {
+        if (!serviceShape.expectTrait(ServiceTrait.class).equals(this)) {
+            throw new ExpectationNotMetException(String.format(
+                    "Provided service shape `%s` is not the target of this trait.", serviceShape.getId()), this);
+        }
+
+        return sdkId.replace(" ", "-").toLowerCase(Locale.US) + "-" + serviceShape.getVersion();
     }
 
     /**
@@ -192,7 +195,6 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
     @Override
     public Builder toBuilder() {
         return new Builder()
-                .target(target)
                 .sdkId(sdkId)
                 .sourceLocation(getSourceLocation())
                 .cloudFormationName(cloudFormationName)
@@ -206,7 +208,6 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
     protected Node createNode() {
         return Node.objectNodeBuilder()
                 .sourceLocation(getSourceLocation())
-                .withMember("target", Node.from(target.toString()))
                 .withMember("sdkId", Node.from(sdkId))
                 .withMember("arnNamespace", Node.from(getArnNamespace()))
                 .withMember("cloudFormationName", Node.from(getCloudFormationName()))
@@ -227,7 +228,6 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
         } else {
             ServiceTrait os = (ServiceTrait) other;
             return sdkId.equals(os.sdkId)
-                    && target.equals(os.target)
                     && arnNamespace.equals(os.arnNamespace)
                     && cloudFormationName.equals(os.cloudFormationName)
                     && cloudTrailEventSource.equals(os.cloudTrailEventSource)
@@ -240,13 +240,12 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
 
     @Override
     public int hashCode() {
-        return Objects.hash(toShapeId(), target, sdkId, arnNamespace, cloudFormationName,
+        return Objects.hash(toShapeId(), sdkId, arnNamespace, cloudFormationName,
                             cloudTrailEventSource, docId, endpointPrefix);
     }
 
     /** Builder for {@link ServiceTrait}. */
     public static final class Builder extends AbstractTraitBuilder<ServiceTrait, Builder> {
-        private ShapeId target;
         private String sdkId;
         private String cloudFormationName;
         private String arnNamespace;
@@ -266,8 +265,6 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
         }
 
         public ServiceTrait build(ShapeId target) {
-            this.target = target;
-
             // Fill in default values if they weren't set.
             if (arnNamespace == null) {
                 arnNamespace(target.getName().toLowerCase(Locale.US));
@@ -286,17 +283,6 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
             }
 
             return new ServiceTrait(this);
-        }
-
-        /**
-         * Sets the target shape to which the trait is applied.
-         *
-         * @param target the ShapeId targeted by the trait.
-         * @return Returns the builder.
-         */
-        private Builder target(ShapeId target) {
-            this.target = target;
-            return this;
         }
 
         /**

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ServiceTrait.java
@@ -155,6 +155,7 @@ public final class ServiceTrait extends AbstractTrait implements ToSmithyBuilder
      *
      * @param serviceShape the shape which this trait targets
      * @return Returns the documentation identifier value for the service name.
+     * @throws ExpectationNotMetException if the shape is not the target of this trait.
      */
     public String resolveDocId(ServiceShape serviceShape) {
         return getDocId().orElseGet(() -> buildDefaultDocId(serviceShape));

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/EventSourceValidatorTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/EventSourceValidatorTest.java
@@ -10,22 +10,20 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
 public class EventSourceValidatorTest {
     @Test
     public void detectsWhenEventSourceIsUnexpected() {
-        ShapeId id = ShapeId.from("smithy.example#Foo");
         ServiceTrait trait = ServiceTrait.builder()
                 .sdkId("Foo")
                 .arnNamespace("foo")
                 .cloudTrailEventSource("REPLACE_ME_LATER")
                 .cloudFormationName("AWS::Foo")
-                .build(id);
+                .build();
         ServiceShape service = ServiceShape.builder()
-                .id(id)
+                .id("smithy.example#Foo")
                 .version("123")
                 .addTrait(trait)
                 .build();
@@ -41,15 +39,14 @@ public class EventSourceValidatorTest {
 
     @Test
     public void detectsWhenEventSourceIsPlaceholder() {
-        ShapeId id = ShapeId.from("smithy.example#Foo");
         ServiceTrait trait = ServiceTrait.builder()
                 .sdkId("Foo")
                 .arnNamespace("foo")
                 .cloudTrailEventSource("notfoo.amazonaws.com")
                 .cloudFormationName("AWS::Foo")
-                .build(id);
+                .build();
         ServiceShape service = ServiceShape.builder()
-                .id(id)
+                .id("smithy.example#Foo")
                 .version("123")
                 .addTrait(trait)
                 .build();
@@ -66,15 +63,14 @@ public class EventSourceValidatorTest {
 
     @Test
     public void ignoresKnownExceptions() {
-        ShapeId id = ShapeId.from("smithy.example#Foo");
         ServiceTrait trait = ServiceTrait.builder()
                 .sdkId("Foo")
                 .arnNamespace("cloudwatch")
                 .cloudTrailEventSource("monitoring.amazonaws.com")
                 .cloudFormationName("AWS::Foo")
-                .build(id);
+                .build();
         ServiceShape service = ServiceShape.builder()
-                .id(id)
+                .id("smithy.example#Foo")
                 .version("123")
                 .addTrait(trait)
                 .build();


### PR DESCRIPTION
*Description of changes:* This commit changes the resolution of the default docId property of the service trait by removing the reference to the target from the trait and passing the targeted shape itself as a parameter.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
