### PR TITLE
Check for existing directory when creating template with init

### DIFF
--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
 
 public class InitCommandTest {
     private static final String PROJECT_NAME = "smithy-templates";
@@ -204,6 +205,30 @@ public class InitCommandTest {
 
                 assertThat(result.getOutput(), containsString(expectedOutput));
                 assertThat(result.getExitCode(), is(0));
+            });
+        });
+    }
+
+    @Test
+    public void outputDirectoryAlreadyExists() {
+        IntegUtils.withProject(PROJECT_NAME, templatesDir -> {
+            setupTemplatesDirectory(templatesDir);
+
+            IntegUtils.withTempDir("existingOutputDir", dir -> {
+                Path existingPath = null;
+                RunResult result;
+                try {
+                    existingPath = Files.createDirectory(dir.resolve("quickstart-cli"));
+                    result = IntegUtils.run(
+                            dir, ListUtils.of("init", "-t", "quickstart-cli", "-u", templatesDir.toString()));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    IoUtils.rmdir(existingPath);
+                }
+
+                assertThat(result.getOutput(), containsString("Output directory `quickstart-cli` already exists."));
+                assertThat(result.getExitCode(), is(1));
             });
         });
     }

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
@@ -13,7 +13,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
 
 public class InitCommandTest {
     private static final String PROJECT_NAME = "smithy-templates";

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
@@ -166,7 +166,7 @@ final class InitCommand implements Command {
         }
         final Path dest = Paths.get(directory);
         if (Files.exists(dest)) {
-            throw new RuntimeException("Output directory `" + directory + "` already exists.");
+            throw new CliException("Output directory `" + directory + "` already exists.");
         }
 
         ObjectNode templatesNode = getTemplatesNode(smithyTemplatesNode);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
@@ -166,7 +166,7 @@ final class InitCommand implements Command {
         }
         final Path dest = Paths.get(directory);
         if (Files.exists(dest)) {
-            throw new RuntimeException("Output directory `" + directory + "` already exists." );
+            throw new RuntimeException("Output directory `" + directory + "` already exists.");
         }
 
         ObjectNode templatesNode = getTemplatesNode(smithyTemplatesNode);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
@@ -166,7 +166,7 @@ final class InitCommand implements Command {
         }
         final Path dest = Paths.get(directory);
         if (Files.exists(dest)) {
-            throw new CliException("Output directory `" + directory + "` already exists.");
+            throw new CliError("Output directory `" + directory + "` already exists.");
         }
 
         ObjectNode templatesNode = getTemplatesNode(smithyTemplatesNode);

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
@@ -160,6 +160,15 @@ final class InitCommand implements Command {
             throw new IllegalArgumentException("Please specify a template name using `--template` or `-t`");
         }
 
+        // Use templateName if directory is not specified
+        if (directory == null) {
+            directory = template;
+        }
+        final Path dest = Paths.get(directory);
+        if (Files.exists(dest)) {
+            throw new RuntimeException("Output directory `" + directory + "` already exists." );
+        }
+
         ObjectNode templatesNode = getTemplatesNode(smithyTemplatesNode);
         if (!templatesNode.containsMember(template)) {
             throw new IllegalArgumentException(String.format(
@@ -180,12 +189,8 @@ final class InitCommand implements Command {
         }
         exec(ListUtils.of("git", "checkout"), temp);
 
-        // Use templateName if directory is not specified
-        if (directory == null) {
-            directory = template;
-        }
 
-        final Path dest = Paths.get(directory);
+
         IoUtils.copyDir(Paths.get(temp.toString(), templatePath), dest);
         copyIncludedFiles(temp.toString(), dest.toString(), includedFiles, template, env);
 


### PR DESCRIPTION
*Description of changes:*
Updates the smithy init command to fail fast if the directory it is attempting to use as an output directory already exists.

Previously the command did not fail until after cloning the repo to a temp directory

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
