### PR TITLE
Fix off-by-one issues in TokenTree and TreeCursor

### DIFF
--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/CapturingTokenizer.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/CapturingTokenizer.java
@@ -132,8 +132,16 @@ final class CapturingTokenizer implements IdlTokenizer {
         if (getToken().getIdlToken() == IdlToken.EOF) {
             throw new NoSuchElementException();
         }
-        trees.getFirst().appendChild(TokenTree.of(CapturedToken.from(this, this.stringTable)));
+        appendCurrentTokenToFirstTree();
         return tokens.get(++cursor).getIdlToken();
+    }
+
+    void eof() {
+        appendCurrentTokenToFirstTree();
+    }
+
+    private void appendCurrentTokenToFirstTree() {
+        trees.getFirst().appendChild(TokenTree.of(CapturedToken.from(this, this.stringTable)));
     }
 
     CapturedToken peekPastSpaces() {

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TreeCursor.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TreeCursor.java
@@ -304,7 +304,7 @@ public final class TreeCursor implements FromSourceLocation {
                     isMatch = column >= startColumn && column < endColumn;
                 } else if (line == startLine && column >= startColumn) {
                     isMatch = true;
-                } else if (line == endLine && column <= endColumn) {
+                } else if (line == endLine && column < endColumn) {
                     isMatch = true;
                 } else if (line > startLine && line < endLine) {
                     isMatch = true;

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TreeType.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TreeType.java
@@ -1012,6 +1012,8 @@ public enum TreeType {
                         optionalWs(tokenizer);
                         break;
                     case EOF:
+                        tokenizer.eof();
+                        break;
                     default:
                         break;
                 }

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/incorrect-indentation.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/incorrect-indentation.formatted.smithy
@@ -1,0 +1,11 @@
+$version: "2.0"
+
+namespace smithy.example
+
+structure Foo {}
+
+structure Bar {}
+
+// Comment
+@input
+structure Baz {}

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/incorrect-indentation.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/incorrect-indentation.smithy
@@ -1,0 +1,11 @@
+$version: "2.0"
+
+namespace smithy.example
+
+structure Foo {}
+
+    structure Bar {}
+
+// Comment
+    @input
+structure Baz {}

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/missing-trailing-newline.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/missing-trailing-newline.formatted.smithy
@@ -1,0 +1,9 @@
+$version: "2.0"
+
+namespace smithy.example
+
+@trait
+structure foo {}
+
+@foo
+structure Bar {}

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/missing-trailing-newline.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/missing-trailing-newline.smithy
@@ -1,0 +1,9 @@
+$version: "2.0"
+
+namespace smithy.example
+
+@trait
+structure foo {}
+
+@foo
+structure Bar {}


### PR DESCRIPTION
Fixes an issue in TokenTree where if the smithy file was missing a trailing newline, any trees containing the last piece of text in the file would have an end location of (0, 0). This happened because the BR TreeType didn't append any tokens for the EOF case, so the BR tree had no end location.

Fixes an issue in TreeCursor::findAt where if you tried to get the tree at a location right at the start of a tree, you would get the previous tree.

Tests were added for both of these cases in TreeCursorTest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
