### PR TITLE
Cache template directory in init command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
       - name: Disable git file system on windows machines
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == windows-latest
         run: git config --global core.useBuiltinFSMonitor false
 
       - name: CLI integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,15 @@ jobs:
       - name: Clean, build and javadoc
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
-      - name: CLI integration tests non-windows
-        if: matrix.java >= 17 && matrix.os != 'windows-latest'
-        run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace
+      - name: Override temp directory for windows runners
+        if: matrix.os == 'windows-latest'
+        run: |
+          set TMP=%USERPROFILE%\AppData\Local\Temp
+          set TEMP=%USERPROFILE%\AppData\Local\Temp
 
-      # Overrides the temp directory used by windows runners
-      - name: CLI integration tests windows
-        if: matrix.java >= 17 && matrix.os == 'windows-latest'
-        run: ./gradlew :smithy-cli:integ -Djava.io.tmpdir=%USERPROFILE%\AppData\Local\Temp -Plog-tests --stacktrace
+      - name: CLI integration tests
+        if: matrix.java >= 17
+        run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace
 
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,6 @@ jobs:
       - name: Clean, build and javadoc
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
-      - name: Disable fsmonitor daemon on Windows
-        if: matrix.os == 'windows-latest'
-        shell: bash
-        run: git config --global core.fsmonitor false
-
       - name: CLI integration tests
         if: matrix.java >= 17
         run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Clean, build and javadoc
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
+      - name: Disable fsmonitor daemon on Windows
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: git config --global core.fsmonitor false
+
       - name: CLI integration tests
         if: matrix.java >= 17
         run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,16 +28,6 @@ jobs:
       - name: Clean, build and javadoc
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
-      # Workaround to handle that the init templates git directory
-      # packfiles created on windows are created with READONLY permissions within
-      # the temp directory.
-      - name: Take ownership of windows temp directory
-        if: matrix.os == 'windows-latest'
-        run: |
-          takeown /f %TEMP% /r /d y
-          icacls %TEMP% /grant "*S-1-5-32-544:F" /inheritance:d /T
-        shell: powershell
-
       - name: CLI integration tests
         if: matrix.java >= 17
         run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
         if: matrix.java >= 17
         run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace
 
+      - name: Allow long file names in git for windows
+        if: matrix.os == 'windows-latest'
+        run: git config --system core.longpaths true
+
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,14 @@ jobs:
       - name: Clean, build and javadoc
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
-      - name: Override temp directory for windows runners
-        if: matrix.os == 'windows-latest'
-        run: |
-          set TMP=%USERPROFILE%\AppData\Local\Temp
-          set TEMP=%USERPROFILE%\AppData\Local\Temp
-
-      - name: CLI integration tests
-        if: matrix.java >= 17
+      - name: CLI integration tests non-windows
+        if: matrix.java >= 17 && matrix.os != 'windows-latest'
         run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace
+
+      # Overrides the temp directory used by windows runners
+      - name: CLI integration tests windows
+        if: matrix.java >= 17 && matrix.os == 'windows-latest'
+        run: ./gradlew :smithy-cli:integ -Djava.io.tmpdir=%USERPROFILE%\AppData\Local\Temp -Plog-tests --stacktrace
 
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,15 @@ jobs:
       - name: Clean, build and javadoc
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
+      # Workaround to handle that the init templates git directory
+      # packfiles created on windows are created with READONLY permissions within
+      # the temp directory.
       - name: Take ownership of windows temp directory
         if: matrix.os == 'windows-latest'
-        run: takeown /f %TEMP% /r /d y
+        run: |
+          takeown /f %TEMP% /r /d y
+          icacls %TEMP% /grant "*S-1-5-32-544:F" /inheritance:d /T
+        shell: powershell
 
       - name: CLI integration tests
         if: matrix.java >= 17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,6 @@ jobs:
       - name: Clean, build and javadoc
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
-      - name: Override temp directory for windows runners
-        if: matrix.os == 'windows-latest'
-        run: |
-          set TMP=%USERPROFILE%\AppData\Local\Temp
-          set TEMP=%USERPROFILE%\AppData\Local\Temp
-
       - name: CLI integration tests
         if: matrix.java >= 17
         run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
       - name: Disable git file system on windows machines
-        if: matrix.os == windows-latest
+        if: matrix.os == 'windows-latest'
         run: git config --global core.useBuiltinFSMonitor false
 
       - name: CLI integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Clean, build and javadoc
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
+      - name: Take ownership of windows temp directory
+        if: matrix.os == 'windows-latest'
+        run: takeown /f %TEMP% /r /d y
+
       - name: CLI integration tests
         if: matrix.java >= 17
         run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Clean, build and javadoc
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
+      - name: Disable git file system on windows machines
+        if: matrix.os == windows-latest
+        run: git config --global core.useBuiltinFSMonitor false
+
       - name: CLI integration tests
         if: matrix.java >= 17
         run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,13 @@ jobs:
       - name: Clean, build and javadoc
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
-      - name: CLI integration tests
-        if: matrix.java >= 17
-        run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace
-
       - name: Allow long file names in git for windows
         if: matrix.os == 'windows-latest'
         run: git config --system core.longpaths true
+
+      - name: CLI integration tests
+        if: matrix.java >= 17
+        run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace
 
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Clean, build and javadoc
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
+      - name: Override temp directory for windows runners
+        if: matrix.os == 'windows-latest'
+        run: |
+          set TMP=%USERPROFILE%\AppData\Local\Temp
+          set TEMP=%USERPROFILE%\AppData\Local\Temp
+
       - name: CLI integration tests
         if: matrix.java >= 17
         run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,6 @@ jobs:
       - name: Clean, build and javadoc
         run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
-      - name: Disable git file system on windows machines
-        if: matrix.os == windows-latest
-        run: git config --global core.useBuiltinFSMonitor false
-
       - name: CLI integration tests
         if: matrix.java >= 17
         run: ./gradlew :smithy-cli:integ -Plog-tests --stacktrace

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/CleanCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/CleanCommandTest.java
@@ -19,8 +19,6 @@ import software.amazon.smithy.utils.ListUtils;
 
 
 public class CleanCommandTest {
-    private static final Path SMITHY_ROOT_CACHE_PATH = Paths.get(System.getProperty("java.io.tmpdir")).resolve("smithy-cache");
-    private static final Path SMITHY_TEMPLATE_CACHE_PATH = SMITHY_ROOT_CACHE_PATH.resolve("templates");
     private static final String PROJECT_NAME = "simple-config-sources";
     @Test
     public void exitNormallyIfBuildDirMissing() {
@@ -47,28 +45,28 @@ public class CleanCommandTest {
 
     @Test
     public void cleanRemovesAllCacheDirectories() throws IOException {
-        clearCacheDirIfExists();
+        IntegUtils.clearCacheDirIfExists();
         try {
-            Files.createDirectories(SMITHY_TEMPLATE_CACHE_PATH);
-            assertTrue(Files.exists(SMITHY_TEMPLATE_CACHE_PATH)
-                    && Files.isDirectory(SMITHY_ROOT_CACHE_PATH));
+            Files.createDirectories(IntegUtils.SMITHY_TEMPLATE_CACHE_PATH);
+            assertTrue(Files.exists(IntegUtils.SMITHY_TEMPLATE_CACHE_PATH)
+                    && Files.isDirectory(IntegUtils.SMITHY_ROOT_CACHE_PATH));
             IntegUtils.run(PROJECT_NAME, ListUtils.of("clean"), result -> {
                 assertThat(result.getExitCode(), equalTo(0));
                 assertThat(result.getOutput(), hasLength(0));
-                assertFalse(Files.exists(SMITHY_ROOT_CACHE_PATH));
+                assertFalse(Files.exists(IntegUtils.SMITHY_ROOT_CACHE_PATH));
             });
         } finally {
-            IoUtils.rmdir(SMITHY_ROOT_CACHE_PATH);
+            IntegUtils.clearCacheDirIfExists();
         }
     }
 
     @Test
     public void cleanWithTemplateOptionRemovesOnlyTemplateDir() throws IOException {
-        clearCacheDirIfExists();
+        IntegUtils.clearCacheDirIfExists();
         try {
-            Files.createDirectories(SMITHY_TEMPLATE_CACHE_PATH);
-            assertTrue(Files.exists(SMITHY_TEMPLATE_CACHE_PATH)
-                    && Files.isDirectory(SMITHY_ROOT_CACHE_PATH));
+            Files.createDirectories(IntegUtils.SMITHY_TEMPLATE_CACHE_PATH);
+            assertTrue(Files.exists(IntegUtils.SMITHY_TEMPLATE_CACHE_PATH)
+                    && Files.isDirectory(IntegUtils.SMITHY_ROOT_CACHE_PATH));
 
             IntegUtils.withProject(PROJECT_NAME, root -> {
                 Path created = null;
@@ -78,8 +76,8 @@ public class CleanCommandTest {
                     RunResult result = IntegUtils.run(root, ListUtils.of("clean", "--templates"));
                     assertThat(Files.exists(created), is(true));
                     assertThat(result.getExitCode(), is(0));
-                    assertTrue(Files.exists(SMITHY_ROOT_CACHE_PATH));
-                    assertFalse(Files.exists(SMITHY_TEMPLATE_CACHE_PATH));
+                    assertTrue(Files.exists(IntegUtils.SMITHY_ROOT_CACHE_PATH));
+                    assertFalse(Files.exists(IntegUtils.SMITHY_TEMPLATE_CACHE_PATH));
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 } finally {
@@ -89,11 +87,7 @@ public class CleanCommandTest {
                 }
             });
         } finally {
-            IoUtils.rmdir(SMITHY_ROOT_CACHE_PATH);
+            IntegUtils.clearCacheDirIfExists();
         }
-    }
-
-    private void clearCacheDirIfExists() {
-        IoUtils.rmdir(SMITHY_ROOT_CACHE_PATH);
     }
 }

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/CleanCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/CleanCommandTest.java
@@ -4,18 +4,27 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasLength;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.ListUtils;
 
+
 public class CleanCommandTest {
+    private static final Path SMITHY_ROOT_CACHE_PATH = Paths.get(System.getProperty("java.io.tmpdir")).resolve("smithy-cache");
+    private static final Path SMITHY_TEMPLATE_CACHE_PATH = SMITHY_ROOT_CACHE_PATH.resolve("templates");
+    private static final String PROJECT_NAME = "simple-config-sources";
     @Test
     public void exitNormallyIfBuildDirMissing() {
-        IntegUtils.run("simple-config-sources", ListUtils.of("clean"), result -> {
+        IntegUtils.run(PROJECT_NAME, ListUtils.of("clean"), result -> {
             assertThat(result.getExitCode(), equalTo(0));
             assertThat(result.getOutput(), hasLength(0));
         });
@@ -23,7 +32,7 @@ public class CleanCommandTest {
 
     @Test
     public void deletesContentsOfBuildDir() {
-        IntegUtils.withProject("simple-config-sources", root -> {
+        IntegUtils.withProject(PROJECT_NAME, root -> {
             try {
                 Path created = Files.createDirectories(root.resolve("build").resolve("smithy").resolve("foo"));
                 assertThat(Files.exists(created), is(true));
@@ -34,5 +43,57 @@ public class CleanCommandTest {
                 throw new UncheckedIOException(e);
             }
         });
+    }
+
+    @Test
+    public void cleanRemovesAllCacheDirectories() throws IOException {
+        clearCacheDirIfExists();
+        try {
+            Files.createDirectories(SMITHY_TEMPLATE_CACHE_PATH);
+            assertTrue(Files.exists(SMITHY_TEMPLATE_CACHE_PATH)
+                    && Files.isDirectory(SMITHY_ROOT_CACHE_PATH));
+            IntegUtils.run(PROJECT_NAME, ListUtils.of("clean"), result -> {
+                assertThat(result.getExitCode(), equalTo(0));
+                assertThat(result.getOutput(), hasLength(0));
+                assertFalse(Files.exists(SMITHY_ROOT_CACHE_PATH));
+            });
+        } finally {
+            IoUtils.rmdir(SMITHY_ROOT_CACHE_PATH);
+        }
+    }
+
+    @Test
+    public void cleanWithTemplateOptionRemovesOnlyTemplateDir() throws IOException {
+        clearCacheDirIfExists();
+        try {
+            Files.createDirectories(SMITHY_TEMPLATE_CACHE_PATH);
+            assertTrue(Files.exists(SMITHY_TEMPLATE_CACHE_PATH)
+                    && Files.isDirectory(SMITHY_ROOT_CACHE_PATH));
+
+            IntegUtils.withProject(PROJECT_NAME, root -> {
+                Path created = null;
+                try {
+                    created = Files.createDirectories(root.resolve("build").resolve("smithy").resolve("foo"));
+                    assertThat(Files.exists(created), is(true));
+                    RunResult result = IntegUtils.run(root, ListUtils.of("clean", "--templates"));
+                    assertThat(Files.exists(created), is(true));
+                    assertThat(result.getExitCode(), is(0));
+                    assertTrue(Files.exists(SMITHY_ROOT_CACHE_PATH));
+                    assertFalse(Files.exists(SMITHY_TEMPLATE_CACHE_PATH));
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                } finally {
+                    if (created != null) {
+                        IoUtils.rmdir(created);
+                    }
+                }
+            });
+        } finally {
+            IoUtils.rmdir(SMITHY_ROOT_CACHE_PATH);
+        }
+    }
+
+    private void clearCacheDirIfExists() {
+        IoUtils.rmdir(SMITHY_ROOT_CACHE_PATH);
     }
 }

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
@@ -308,11 +308,6 @@ public class InitCommandTest {
                 RunResult resultFirst = IntegUtils.run(root, ListUtils.of("init", "-o", "hello-world"));
                 assertTrue(Files.exists(IntegUtils.SMITHY_TEMPLATE_CACHE_PATH)
                         && Files.isDirectory(IntegUtils.SMITHY_TEMPLATE_CACHE_PATH));
-
-                if (resultFirst.getExitCode() != 0) {
-                    throw new RuntimeException("RESULT FAILED WITH: " + resultFirst.getOutput());
-                };
-
                 assertThat(resultFirst.getExitCode(), equalTo(0));
                 assertThat(resultFirst.getOutput(),
                         containsString("template repo cloned"));

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
@@ -10,8 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.ListUtils;
 
@@ -303,7 +301,6 @@ public class InitCommandTest {
     }
 
     @Test
-    @Execution(ExecutionMode.SAME_THREAD)
     public void cacheCreatedOnFirstCreationOfTemplate() {
         IntegUtils.clearCacheDirIfExists();
         IntegUtils.withProject(PROJECT_NAME, root -> {
@@ -332,7 +329,6 @@ public class InitCommandTest {
     }
 
     @Test
-    @Execution(ExecutionMode.SAME_THREAD)
     public void noCacheCreatedWhenLocalRepo() {
         IntegUtils.clearCacheDirIfExists();
         IntegUtils.withProject(PROJECT_NAME, templatesDir -> {

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
@@ -308,7 +308,11 @@ public class InitCommandTest {
                 RunResult resultFirst = IntegUtils.run(root, ListUtils.of("init", "-o", "hello-world"));
                 assertTrue(Files.exists(IntegUtils.SMITHY_TEMPLATE_CACHE_PATH)
                         && Files.isDirectory(IntegUtils.SMITHY_TEMPLATE_CACHE_PATH));
-                System.out.println("RESULT: " + resultFirst.getOutput());
+
+                if (resultFirst.getExitCode() != 0) {
+                    throw new RuntimeException("RESULT FAILED WITH: " + resultFirst.getOutput());
+                };
+
                 assertThat(resultFirst.getExitCode(), equalTo(0));
                 assertThat(resultFirst.getOutput(),
                         containsString("template repo cloned"));

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
@@ -10,8 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.ListUtils;
 

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
@@ -10,6 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.ListUtils;
 
@@ -301,6 +303,7 @@ public class InitCommandTest {
     }
 
     @Test
+    @Execution(ExecutionMode.SAME_THREAD)
     public void cacheCreatedOnFirstCreationOfTemplate() {
         IntegUtils.clearCacheDirIfExists();
         IntegUtils.withProject(PROJECT_NAME, root -> {
@@ -329,6 +332,7 @@ public class InitCommandTest {
     }
 
     @Test
+    @Execution(ExecutionMode.SAME_THREAD)
     public void noCacheCreatedWhenLocalRepo() {
         IntegUtils.clearCacheDirIfExists();
         IntegUtils.withProject(PROJECT_NAME, templatesDir -> {

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
@@ -308,6 +308,7 @@ public class InitCommandTest {
                 RunResult resultFirst = IntegUtils.run(root, ListUtils.of("init", "-o", "hello-world"));
                 assertTrue(Files.exists(IntegUtils.SMITHY_TEMPLATE_CACHE_PATH)
                         && Files.isDirectory(IntegUtils.SMITHY_TEMPLATE_CACHE_PATH));
+                System.out.println("RESULT: " + resultFirst.getOutput());
                 assertThat(resultFirst.getExitCode(), equalTo(0));
                 assertThat(resultFirst.getOutput(),
                         containsString("template repo cloned"));

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
@@ -303,7 +303,6 @@ public class InitCommandTest {
     }
 
     @Test
-    @Execution(ExecutionMode.SAME_THREAD)
     public void cacheCreatedOnFirstCreationOfTemplate() {
         IntegUtils.clearCacheDirIfExists();
         IntegUtils.withProject(PROJECT_NAME, root -> {
@@ -332,7 +331,6 @@ public class InitCommandTest {
     }
 
     @Test
-    @Execution(ExecutionMode.SAME_THREAD)
     public void noCacheCreatedWhenLocalRepo() {
         IntegUtils.clearCacheDirIfExists();
         IntegUtils.withProject(PROJECT_NAME, templatesDir -> {

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
@@ -150,6 +150,8 @@ public final class IntegUtils {
     }
 
     public static void clearCacheDirIfExists() {
-        IoUtils.rmdir(SMITHY_ROOT_CACHE_PATH);
+        if (Files.exists(SMITHY_ROOT_CACHE_PATH)) {
+            IoUtils.rmdir(SMITHY_ROOT_CACHE_PATH);
+        }
     }
 }

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
@@ -39,8 +39,9 @@ import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.MapUtils;
 
 public final class IntegUtils {
-
     private static final Logger LOGGER = Logger.getLogger(IntegUtils.class.getName());
+    public static final Path SMITHY_ROOT_CACHE_PATH = Paths.get(System.getProperty("java.io.tmpdir")).resolve("smithy-cache");
+    public static final Path SMITHY_TEMPLATE_CACHE_PATH = SMITHY_ROOT_CACHE_PATH.resolve("templates");
 
     private IntegUtils() {}
 
@@ -145,5 +146,9 @@ public final class IntegUtils {
                 return FileVisitResult.CONTINUE;
             }
         });
+    }
+
+    public static void clearCacheDirIfExists() {
+        IoUtils.rmdir(SMITHY_ROOT_CACHE_PATH);
     }
 }

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
@@ -150,8 +150,6 @@ public final class IntegUtils {
     }
 
     public static void clearCacheDirIfExists() {
-        if (Files.exists(SMITHY_ROOT_CACHE_PATH)) {
-            IoUtils.rmdir(SMITHY_ROOT_CACHE_PATH);
-        }
+        IoUtils.rmdir(SMITHY_ROOT_CACHE_PATH);
     }
 }

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
@@ -150,6 +150,6 @@ public final class IntegUtils {
     }
 
     public static void clearCacheDirIfExists() {
-        IoUtils.rmd ir(SMITHY_ROOT_CACHE_PATH);
+        IoUtils.rmdir(SMITHY_ROOT_CACHE_PATH);
     }
 }

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
@@ -39,9 +39,10 @@ import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.MapUtils;
 
 public final class IntegUtils {
-    private static final Logger LOGGER = Logger.getLogger(IntegUtils.class.getName());
-    public static final Path SMITHY_ROOT_CACHE_PATH = Paths.get(System.getProperty("java.io.tmpdir")).resolve("smithy-cache");
+    public static final Path SMITHY_ROOT_CACHE_PATH = Paths.get(System.getProperty("java.io.tmpdir"))
+            .resolve("smithy-cache");
     public static final Path SMITHY_TEMPLATE_CACHE_PATH = SMITHY_ROOT_CACHE_PATH.resolve("templates");
+    private static final Logger LOGGER = Logger.getLogger(IntegUtils.class.getName());
 
     private IntegUtils() {}
 

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/IntegUtils.java
@@ -150,6 +150,6 @@ public final class IntegUtils {
     }
 
     public static void clearCacheDirIfExists() {
-        IoUtils.rmdir(SMITHY_ROOT_CACHE_PATH);
+        IoUtils.rmd ir(SMITHY_ROOT_CACHE_PATH);
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CleanCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CleanCommand.java
@@ -20,8 +20,10 @@ import java.nio.file.Paths;
 import java.util.logging.Logger;
 import software.amazon.smithy.build.SmithyBuild;
 import software.amazon.smithy.build.model.SmithyBuildConfig;
+import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
 import software.amazon.smithy.cli.Command;
+import software.amazon.smithy.cli.HelpPrinter;
 import software.amazon.smithy.utils.IoUtils;
 
 final class CleanCommand implements Command {
@@ -40,20 +42,32 @@ final class CleanCommand implements Command {
 
     @Override
     public String getSummary() {
-        return "Removes Smithy build artifacts.";
+        return "Removes Smithy build artifacts and caches.";
     }
 
     @Override
     public int execute(Arguments arguments, Env env) {
         arguments.addReceiver(new ConfigOptions());
+        arguments.addReceiver(new Options());
 
         CommandAction action = HelpActionWrapper.fromCommand(this, parentCommandName, this::run);
         return action.apply(arguments, env);
     }
 
     private int run(Arguments arguments, Env env) {
-        ConfigOptions options = arguments.getReceiver(ConfigOptions.class);
-        SmithyBuildConfig config = options.createSmithyBuildConfig();
+        ConfigOptions configOptions = arguments.getReceiver(ConfigOptions.class);
+        Options options = arguments.getReceiver(Options.class);
+
+        if (options.cleanTemplateCache) {
+            LOGGER.fine(() -> "Clearing template cache.");
+            if (CliCache.getTemplateCache().clear()) {
+                LOGGER.fine(() -> "No template cache found.");
+            }
+            return 0;
+        }
+
+
+        SmithyBuildConfig config = configOptions.createSmithyBuildConfig();
         Path dir = config.getOutputDirectory()
                 .map(Paths::get)
                 .orElseGet(SmithyBuild::getDefaultOutputDirectory);
@@ -62,6 +76,35 @@ final class CleanCommand implements Command {
             LOGGER.fine(() -> "Directory does not exist: " + dir);
         }
         LOGGER.fine(() -> "Deleted directory " + dir);
+
+        LOGGER.fine(() -> "Clearing all caches.");
+        if (!CliCache.clearAll()) {
+            LOGGER.fine(() -> "No caches found.");
+        }
+
         return 0;
+    }
+
+
+    private static final class Options implements ArgumentReceiver {
+        private Boolean cleanTemplateCache = false;
+
+        @Override
+        public boolean testOption(String name) {
+            switch (name) {
+                case "--templates":
+                case "-t":
+                    cleanTemplateCache = true;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        @Override
+        public void registerHelp(HelpPrinter printer) {
+            printer.param("--templates", "-t", null,
+                    "Clean only the templates cache.");
+        }
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CliCache.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/CliCache.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.cli.commands;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import software.amazon.smithy.cli.CliError;
+import software.amazon.smithy.utils.IoUtils;
+
+interface CliCache {
+    Path DEFAULT_TEMP_DIR = Paths.get(System.getProperty("java.io.tmpdir"));
+    Path ROOT_CACHE_DIR = DEFAULT_TEMP_DIR.resolve("smithy-cache");
+
+    static CliCache getTemplateCache() {
+        return () -> ROOT_CACHE_DIR.resolve("templates");
+    }
+
+    Path getPath();
+
+    default boolean clear() {
+        return IoUtils.rmdir(getPath());
+    }
+
+    default Path get() {
+        Path cachePath = getPath();
+        if (Files.exists(cachePath)) {
+            return cachePath;
+        }
+        // If cache dir does not exist, create it and all required parent directories
+        try {
+            return Files.createDirectories(cachePath);
+        } catch (IOException e) {
+            throw new CliError("Could not create cache at path: " + cachePath);
+        }
+    }
+
+    static boolean clearAll() {
+        return IoUtils.rmdir(ROOT_CACHE_DIR);
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
@@ -45,8 +45,6 @@ import software.amazon.smithy.utils.StringUtils;
 
 
 final class InitCommand implements Command {
-    private static final Path DEFAULT_TEMP_DIR_PATH = Paths.get(System.getProperty("java.io.tmpdir"));
-    private static final Path SMITHY_INIT_CACHE_DIR = DEFAULT_TEMP_DIR_PATH.resolve("smithy-templates");
     private static final String SMITHY_TEMPLATE_JSON = "smithy-templates.json";
     private static final String DEFAULT_REPOSITORY_URL = "https://github.com/smithy-lang/smithy-examples.git";
     private static final String DEFAULT_TEMPLATE_NAME = "quickstart-cli";
@@ -99,10 +97,11 @@ final class InitCommand implements Command {
                     ProgressStyle.dots("cloning template repo", "template repo cloned"),
                     standardOptions.quiet()
             )) {
-                String relativeTemplateDir = SMITHY_INIT_CACHE_DIR.relativize(templateRepoDirPath).toString();
+                Path templateCachePath = CliCache.getTemplateCache().get();
+                String relativeTemplateDir = templateCachePath.relativize(templateRepoDirPath).toString();
                 // Only clone the latest commit from HEAD. Do not include history
                 exec(ListUtils.of("git", "clone", "--depth", "1", "--single-branch",
-                        options.repositoryUrl, relativeTemplateDir), SMITHY_INIT_CACHE_DIR);
+                        options.repositoryUrl, relativeTemplateDir), templateCachePath);
             }
         }
 
@@ -153,9 +152,8 @@ final class InitCommand implements Command {
             // Just use the local path if the git repo is local
             return Paths.get(repoPath);
         } else {
-            return SMITHY_INIT_CACHE_DIR.resolve(getCacheDirFromURL(repoPath));
+            return CliCache.getTemplateCache().get().resolve(getCacheDirFromURL(repoPath));
         }
-
     }
 
     // Remove any trailing .git

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
@@ -278,7 +278,7 @@ final class InitCommand implements Command {
         }
         exec(ListUtils.of("git", "checkout"), stagingPath);
 
-        if (!Files.exists(temp.resolve(templatePath))) {
+        if (!Files.exists(stagingPath.resolve(templatePath))) {
             throw new CliError(String.format("Template path `%s` for template \"%s\" is invalid.",
                     templatePath, template));
         }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
@@ -112,12 +112,11 @@ final class InitCommand implements Command {
         if (!isLocalRepo) {
             // update remote
             exec(ListUtils.of("git", "fetch", "--depth", "1"), templateRepoDirPath);
-            String response = exec(ListUtils.of("git", "status", "-s"), templateRepoDirPath);
-
+            String response = exec(ListUtils.of("git", "rev-list", "origin..HEAD"), templateRepoDirPath);
             // If a change was detected, force the template repo to update
             if (!StringUtils.isEmpty(response)) {
                 try (ProgressTracker t = new ProgressTracker(env,
-                        ProgressStyle.dots("updating template repo", "template repo updated"),
+                        ProgressStyle.dots("updating template cache", "template repo updated"),
                         standardOptions.quiet()
                 )) {
                     exec(ListUtils.of("git", "reset", "--hard", "origin/main"), templateRepoDirPath);

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/IoUtils.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/IoUtils.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.utils;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -334,6 +335,9 @@ public final class IoUtils {
             Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    // Workaround for Windows systems that set some git packfiles to readonly
+                    file.toFile().setWritable(true);
+
                     Files.delete(file);
                     return FileVisitResult.CONTINUE;
                 }

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/IoUtils.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/IoUtils.java
@@ -335,8 +335,6 @@ public final class IoUtils {
             Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                    File fileFile = new File(file.toUri());
-                    fileFile.setWritable(true);
                     Files.delete(file);
                     return FileVisitResult.CONTINUE;
                 }

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/IoUtils.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/IoUtils.java
@@ -17,7 +17,6 @@ package software.amazon.smithy.utils;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/IoUtils.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/IoUtils.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.utils;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -334,6 +335,8 @@ public final class IoUtils {
             Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    File fileFile = new File(file.toUri());
+                    fileFile.setWritable(true);
                     Files.delete(file);
                     return FileVisitResult.CONTINUE;
                 }


### PR DESCRIPTION
*Description of changes:*
Caches a copy of the smithy init template directory in the default system temp directory. This greatly speeds up subsequent executions of both the list and create template subcommands of the `smithy init`. 
Previously, creating a template could take up to 6 seconds. With this change that time is down to ~0.3sec after the initial caching of the template repo.

---

*Example Executions*
Create a Template
![cli](https://github.com/smithy-lang/smithy/assets/124718352/aacf4a1a-1de9-4d1c-bf4c-37d6dbf98ce4)

List Templates 
![list](https://github.com/smithy-lang/smithy/assets/124718352/e29bee59-e6df-42cd-a4ac-e92e50fd1a5c)

Note: the gif recorder used here adds additional lag so these do not accurately represent the time these commands take to execute.
___

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
