### PR TITLE
Update appearance of smithy init list output

### DIFF
--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
@@ -121,15 +121,17 @@ public class InitCommandTest {
                         .append("Invalid template `blabla`. `Smithy-Examples` provides the following templates:")
                         .append(System.lineSeparator())
                         .append(System.lineSeparator())
-                        .append("NAME                    DOCUMENTATION")
+                        .append("─────────────────────  ─────────────────────────────────────────────────────────────────────────────")
                         .append(System.lineSeparator())
-                        .append("---------------------   -----------------------------------------------------")
+                        .append("NAME                   DOCUMENTATION")
                         .append(System.lineSeparator())
-                        .append("included-file-json      Smithy Quickstart example with json file included.   ")
+                        .append("─────────────────────  ─────────────────────────────────────────────────────────────────────────────")
                         .append(System.lineSeparator())
-                        .append("included-files-gradle   Smithy Quickstart example with gradle files included.")
+                        .append("included-file-json     Smithy Quickstart example with json file included.")
                         .append(System.lineSeparator())
-                        .append("quickstart-cli          Smithy Quickstart example weather service.           ")
+                        .append("included-files-gradle  Smithy Quickstart example with gradle files included.")
+                        .append(System.lineSeparator())
+                        .append("quickstart-cli         Smithy Quickstart example weather service.")
                         .append(System.lineSeparator())
                         .toString();
 
@@ -191,17 +193,19 @@ public class InitCommandTest {
                     "init", "--list", "--url", templatesDir.toString()));
 
                 String expectedOutput = new StringBuilder()
-                    .append("NAME                    DOCUMENTATION")
-                    .append(System.lineSeparator())
-                    .append("---------------------   -----------------------------------------------------")
-                    .append(System.lineSeparator())
-                    .append("included-file-json      Smithy Quickstart example with json file included.   ")
-                    .append(System.lineSeparator())
-                    .append("included-files-gradle   Smithy Quickstart example with gradle files included.")
-                    .append(System.lineSeparator())
-                    .append("quickstart-cli          Smithy Quickstart example weather service.           ")
-                    .append(System.lineSeparator())
-                    .toString();
+                        .append("─────────────────────  ─────────────────────────────────────────────────────────────────────────────")
+                        .append(System.lineSeparator())
+                        .append("NAME                   DOCUMENTATION")
+                        .append(System.lineSeparator())
+                        .append("─────────────────────  ─────────────────────────────────────────────────────────────────────────────")
+                        .append(System.lineSeparator())
+                        .append("included-file-json     Smithy Quickstart example with json file included.")
+                        .append(System.lineSeparator())
+                        .append("included-files-gradle  Smithy Quickstart example with gradle files included.")
+                        .append(System.lineSeparator())
+                        .append("quickstart-cli         Smithy Quickstart example weather service.")
+                        .append(System.lineSeparator())
+                        .toString();
 
                 assertThat(result.getOutput(), containsString(expectedOutput));
                 assertThat(result.getExitCode(), is(0));

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/ColorTheme.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/ColorTheme.java
@@ -49,5 +49,8 @@ public final class ColorTheme {
 
     public static final Style HINT_TITLE = Style.of(Style.BRIGHT_GREEN);
 
+    public static final Style TEMPLATE_TITLE = Style.of(Style.BOLD, Style.BRIGHT_WHITE);
+    public static final Style TEMPLATE_LIST_BORDER = Style.of(Style.BRIGHT_WHITE);
+
     private ColorTheme() {}
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.TreeMap;
 import java.util.function.Consumer;
 import software.amazon.smithy.cli.ArgumentReceiver;
 import software.amazon.smithy.cli.Arguments;
@@ -41,8 +40,11 @@ import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.StringUtils;
 
 final class InitCommand implements Command {
+    private static final int LINE_LENGTH = 100;
+    private static final String COLUMN_SEPARATOR = "  ";
     private static final String SMITHY_TEMPLATE_JSON = "smithy-templates.json";
     private static final String DEFAULT_REPOSITORY_URL = "https://github.com/smithy-lang/smithy-examples.git";
     private static final String DEFAULT_TEMPLATE_NAME = "quickstart-cli";
@@ -114,46 +116,51 @@ final class InitCommand implements Command {
 
     private String getTemplateList(ObjectNode smithyTemplatesNode, Env env) {
         int maxTemplateLength = 0;
-        int maxDocumentationLength = 0;
-        Map<String, String> templates = new TreeMap<>();
+        ObjectNode templatesNode = getTemplatesNode(smithyTemplatesNode);
+        for (String template : templatesNode.getStringMap().keySet()) {
+            maxTemplateLength = Math.max(maxTemplateLength, template.length());
+        }
+        int maxDocLength = LINE_LENGTH - maxTemplateLength - COLUMN_SEPARATOR.length();
 
-        for (Map.Entry<StringNode, Node> entry : getTemplatesNode(smithyTemplatesNode).getMembers().entrySet()) {
+        ColorBuffer builder = ColorBuffer.of(env.colors(), new StringBuilder());
+
+        writeTemplateBorder(builder, maxTemplateLength, maxDocLength);
+        builder.print(pad(NAME.toUpperCase(Locale.US), maxTemplateLength), ColorTheme.NOTE)
+                .print(COLUMN_SEPARATOR)
+                .print(DOCUMENTATION.toUpperCase(Locale.US), ColorTheme.NOTE)
+                .println();
+        writeTemplateBorder(builder, maxTemplateLength, maxDocLength);
+
+        int offset = maxTemplateLength + COLUMN_SEPARATOR.length();
+
+        for (Map.Entry<StringNode, Node> entry : templatesNode.getMembers().entrySet()) {
             String template = entry.getKey().getValue();
             String documentation = entry.getValue()
-                .expectObjectNode()
-                .expectMember(DOCUMENTATION, String.format(
-                        "Missing expected member `%s` from `%s` object", DOCUMENTATION, template))
-                .expectStringNode()
-                .getValue();
+                    .expectObjectNode()
+                    .expectMember(DOCUMENTATION, String.format(
+                            "Missing expected member `%s` from `%s` object", DOCUMENTATION, template))
+                    .expectStringNode()
+                    .getValue();
 
-            templates.put(template, documentation);
-
-            maxTemplateLength = Math.max(maxTemplateLength, template.length());
-            maxDocumentationLength = Math.max(maxDocumentationLength, documentation.length());
-        }
-
-        final String space = "   ";
-
-        ColorBuffer builder = ColorBuffer.of(env.colors(), new StringBuilder())
-                .print(pad(NAME.toUpperCase(Locale.US), maxTemplateLength), ColorTheme.LITERAL)
-                .print(space)
-                .print(DOCUMENTATION.toUpperCase(Locale.US), ColorTheme.LITERAL)
-                .println()
-                .print(pad("", maxTemplateLength).replace(' ', '-'), ColorTheme.MUTED)
-                .print(space)
-                .print(pad("", maxDocumentationLength).replace(' ', '-'), ColorTheme.MUTED)
-                .println();
-
-        for (Map.Entry<String, String> entry : templates.entrySet()) {
-            String template = entry.getKey();
-            String doc = entry.getValue();
-            builder.print(pad(template, maxTemplateLength))
-                    .print(space)
-                    .print(pad(doc, maxDocumentationLength))
+            builder.print(pad(template, maxTemplateLength), ColorTheme.TEMPLATE_TITLE)
+                    .print(COLUMN_SEPARATOR)
+                    .print(wrapDocumentation(documentation, maxDocLength, offset),
+                            ColorTheme.MUTED)
                     .println();
         }
 
         return builder.toString();
+    }
+
+    private static void writeTemplateBorder(ColorBuffer writer, int maxNameLength, int maxDocLength) {
+        writer.print(pad("", maxNameLength).replace(' ', '─'), ColorTheme.TEMPLATE_LIST_BORDER)
+                .print(COLUMN_SEPARATOR)
+                .print(pad("", maxDocLength).replace(' ', '─'), ColorTheme.TEMPLATE_LIST_BORDER)
+                .println();
+    }
+
+    private static String wrapDocumentation(String doc, int maxLength, int offset) {
+        return StringUtils.wrap(doc, maxLength, System.lineSeparator() + pad("", offset), false);
     }
 
     private void cloneTemplate(Path temp, ObjectNode smithyTemplatesNode, Options options,

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
@@ -159,9 +159,9 @@ final class InitCommand implements Command {
     }
 
     private static void writeTemplateBorder(ColorBuffer writer, int maxNameLength, int maxDocLength) {
-        writer.print(pad("", maxNameLength).replace(' ', '─'), ColorTheme.TEMPLATE_LIST_BORDER)
+        writer.print(pad("", maxNameLength).replace(" ", "─"), ColorTheme.TEMPLATE_LIST_BORDER)
                 .print(COLUMN_SEPARATOR)
-                .print(pad("", maxDocLength).replace(' ', '─'), ColorTheme.TEMPLATE_LIST_BORDER)
+                .print(pad("", maxDocLength).replace(" ", "─"), ColorTheme.TEMPLATE_LIST_BORDER)
                 .println();
     }
 


### PR DESCRIPTION
*Description of changes:*
This PR updates the appearance of the `smithy init --list` output. It also adds wrapping on descriptions that would cause the table output to exceed a fixed size of 100 characters.

Before: 
<img width="1023" alt="image" src="https://github.com/smithy-lang/smithy/assets/124718352/935afaac-3f02-453f-b083-2793e79483f0">


After: 
<img width="937" alt="image" src="https://github.com/smithy-lang/smithy/assets/124718352/7e521dcf-8b1b-405e-8790-89487c465935">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
