### PR TITLE
Support enum map keys on OpenAPI 3.1.0

### DIFF
--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiVersion.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiVersion.java
@@ -15,25 +15,32 @@
 
 package software.amazon.smithy.openapi;
 
+import java.util.Set;
 import software.amazon.smithy.jsonschema.JsonSchemaVersion;
+import software.amazon.smithy.utils.SetUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * OpenAPI versions supported by the converter.
  */
 public enum OpenApiVersion {
-
-    VERSION_3_0_2("3.0.2", false, JsonSchemaVersion.DRAFT07),
-    VERSION_3_1_0("3.1.0", true, JsonSchemaVersion.DRAFT2020_12);
+    VERSION_3_0_2("3.0.2", false, JsonSchemaVersion.DRAFT07,
+            SetUtils.of("propertyNames", "contentMediaType")),
+    VERSION_3_1_0("3.1.0", true, JsonSchemaVersion.DRAFT2020_12,
+            SetUtils.of("contentMediaType"));
 
     private final String version;
     private final boolean supportsContentEncodingKeyword;
     private final JsonSchemaVersion jsonSchemaVersion;
+    // See https://swagger.io/docs/specification/data-models/keywords/ for 3.0.2.
+    private final Set<String> unsupportedKeywords;
 
-    OpenApiVersion(String version, boolean supportsContentEncodingKeyword, JsonSchemaVersion jsonSchemaVersion) {
+    OpenApiVersion(String version, boolean supportsContentEncodingKeyword, JsonSchemaVersion jsonSchemaVersion,
+                   Set<String> unsupportedKeywords) {
         this.version = version;
         this.supportsContentEncodingKeyword = supportsContentEncodingKeyword;
         this.jsonSchemaVersion = jsonSchemaVersion;
+        this.unsupportedKeywords = unsupportedKeywords;
     }
 
     @Override
@@ -44,6 +51,11 @@ public enum OpenApiVersion {
     @SmithyInternalApi
     public boolean supportsContentEncodingKeyword() {
         return supportsContentEncodingKeyword;
+    }
+
+    @SmithyInternalApi
+    public Set<String> getUnsupportedKeywords() {
+        return unsupportedKeywords;
     }
 
     JsonSchemaVersion getJsonSchemaVersion() {

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapper.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapper.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import software.amazon.smithy.jsonschema.JsonSchemaConfig;
 import software.amazon.smithy.jsonschema.JsonSchemaMapper;
 import software.amazon.smithy.jsonschema.Schema;
@@ -35,7 +34,6 @@ import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.openapi.OpenApiConfig;
 import software.amazon.smithy.openapi.model.ExternalDocumentation;
 import software.amazon.smithy.utils.MapUtils;
-import software.amazon.smithy.utils.SetUtils;
 
 /**
  * Applies OpenAPI extensions to a {@link Schema} using configuration settings
@@ -45,11 +43,6 @@ import software.amazon.smithy.utils.SetUtils;
  * {@link OpenApiConfig#setDisableFeatures}.
  */
 public final class OpenApiJsonSchemaMapper implements JsonSchemaMapper {
-
-    /** See https://swagger.io/docs/specification/data-models/keywords/. */
-    private static final Set<String> UNSUPPORTED_KEYWORD_DIRECTIVES = SetUtils.of(
-            "propertyNames",
-            "contentMediaType");
 
     @Override
     public Schema.Builder updateSchema(Shape shape, Schema.Builder builder, JsonSchemaConfig config) {
@@ -93,7 +86,10 @@ public final class OpenApiJsonSchemaMapper implements JsonSchemaMapper {
         }
 
         // Remove unsupported JSON Schema keywords.
-        UNSUPPORTED_KEYWORD_DIRECTIVES.forEach(builder::disableProperty);
+        if (config instanceof OpenApiConfig) {
+            OpenApiConfig openApiConfig = (OpenApiConfig) config;
+            openApiConfig.getVersion().getUnsupportedKeywords().forEach(builder::disableProperty);
+        }
 
         return builder;
     }

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverterTest.java
@@ -603,6 +603,7 @@ public class OpenApiConverterTest {
 
         Node.assertEquals(result, expectedNode);
     }
+
     @Test
     public void convertsToOpenAPI3_1_0() {
         Model model = Model.assembler()

--- a/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapperTest.java
+++ b/smithy-openapi/src/test/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapperTest.java
@@ -42,7 +42,6 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.ShortShape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
-import software.amazon.smithy.model.traits.BoxTrait;
 import software.amazon.smithy.model.traits.DeprecatedTrait;
 import software.amazon.smithy.model.traits.ExternalDocumentationTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
@@ -65,23 +64,6 @@ public class OpenApiJsonSchemaMapperTest {
                 .convert();
 
         assertTrue(document.toNode().expectObjectNode().getMember("components").isPresent());
-    }
-
-    @Test
-    public void stripsUnsupportedKeywords() {
-        StringShape string = StringShape.builder().id("smithy.api#String").build();
-        MemberShape key = MemberShape.builder().id("smithy.example#Map$key").target("smithy.api#String").build();
-        MemberShape value = MemberShape.builder().id("smithy.example#Map$value").target("smithy.api#String").build();
-        MapShape shape = MapShape.builder().id("smithy.example#Map").key(key).value(value).build();
-        Model model = Model.builder().addShapes(string, shape, key, value).build();
-        SchemaDocument document = JsonSchemaConverter.builder()
-                .addMapper(new OpenApiJsonSchemaMapper())
-                .model(model)
-                .build()
-                .convertShape(shape);
-        Schema schema = document.getRootSchema();
-
-        assertFalse(schema.getPropertyNames().isPresent());
     }
 
     @Test

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/nullability-and-format.smithy
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/nullability-and-format.smithy
@@ -26,7 +26,8 @@ blob FilePayload
 
 @output
 structure FooBarOutput {
-    bar: BoxedInteger
+    bar: BoxedInteger,
+    baz: MyMap
 }
 
 @error("client")
@@ -36,3 +37,18 @@ structure FooBarError {
 
 @box
 integer BoxedInteger
+
+map MyMap {
+    key: MyEnum,
+    value: String
+}
+
+@enum([
+    {
+        value: "FOO"
+    },
+    {
+        value: "BAR"
+    }
+])
+string MyEnum

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/openapi-3-0-2.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/openapi-3-0-2.openapi.json
@@ -69,7 +69,16 @@
         "properties": {
           "bar": {
             "type": "number"
+          },
+          "baz": {
+            "$ref": "#/components/schemas/MyMap"
           }
+        }
+      },
+      "MyMap": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
         }
       }
     }

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/openapi-3-1-0.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/openapi-3-1-0.openapi.json
@@ -69,7 +69,26 @@
         "properties": {
           "bar": {
             "type": "number"
+          },
+          "baz": {
+            "$ref": "#/components/schemas/MyMap"
           }
+        }
+      },
+      "MyEnum": {
+        "type": "string",
+        "enum": [
+          "FOO",
+          "BAR"
+        ]
+      },
+      "MyMap": {
+        "type": "object",
+        "propertyNames": {
+          "$ref": "#/components/schemas/MyEnum"
+        },
+        "additionalProperties": {
+          "type": "string"
         }
       }
     }


### PR DESCRIPTION
Closes: https://github.com/smithy-lang/smithy/issues/1664

This PR updates OpenAPI configuration to allow `propertyNames` to be set when using version `3.1.0`.

Previously, `propertyNames` was stripped from outputs as an unsupported keyword, since OpenAPI 3.0 did not support it.

By allowing `propertyNames`, enums can be used as map keys, without discarding all of the enum information.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
