### PR TITLE
Add exceptions for invalid paths in template definition

### DIFF
--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
@@ -127,6 +127,10 @@ public class InitCommandTest {
                         .append(System.lineSeparator())
                         .append("─────────────────────  ─────────────────────────────────────────────────────────────────────────────")
                         .append(System.lineSeparator())
+                        .append("bad-include-path       Template with incorrect include path. Should throw error.")
+                        .append(System.lineSeparator())
+                        .append("bad-template-path      Template with incorrect path. Should throw error.")
+                        .append(System.lineSeparator())
                         .append("included-file-json     Smithy Quickstart example with json file included.")
                         .append(System.lineSeparator())
                         .append("included-files-gradle  Smithy Quickstart example with gradle files included.")
@@ -199,6 +203,10 @@ public class InitCommandTest {
                         .append(System.lineSeparator())
                         .append("─────────────────────  ─────────────────────────────────────────────────────────────────────────────")
                         .append(System.lineSeparator())
+                        .append("bad-include-path       Template with incorrect include path. Should throw error.")
+                        .append(System.lineSeparator())
+                        .append("bad-template-path      Template with incorrect path. Should throw error.")
+                        .append(System.lineSeparator())
                         .append("included-file-json     Smithy Quickstart example with json file included.")
                         .append(System.lineSeparator())
                         .append("included-files-gradle  Smithy Quickstart example with gradle files included.")
@@ -249,6 +257,43 @@ public class InitCommandTest {
                 assertThat(result.getOutput().trim(), emptyString());
                 assertThat(result.getExitCode(), is(0));
                 assertThat(Files.exists(Paths.get(dir.toString(), "quickstart-cli")), is(true));
+            });
+        });
+    }
+
+    @Test
+    public void badTemplatePathFailureExpected() {
+        IntegUtils.withProject(PROJECT_NAME, templatesDir -> {
+            setupTemplatesDirectory(templatesDir);
+
+            IntegUtils.withTempDir("badTemplatePath", dir -> {
+                RunResult result = IntegUtils.run(
+                        dir, ListUtils.of("init", "-t", "bad-template-path", "-u", templatesDir.toString()));
+                System.out.println(result.getOutput());
+                assertThat(Files.exists(Paths.get(dir.toString(), "bad-template-path")), is(false));
+                assertThat(result.getExitCode(), is(1));
+                assertThat(result.getOutput(),
+                        containsString("Template path `getting-started-example/does-not-exist` specified in"
+                                + " template bad-template-path is invalid."));
+
+            });
+        });
+    }
+
+    @Test
+    public void badIncludePathFailureExpected() {
+        IntegUtils.withProject(PROJECT_NAME, templatesDir -> {
+            setupTemplatesDirectory(templatesDir);
+
+            IntegUtils.withTempDir("badIncludePath", dir -> {
+                RunResult result = IntegUtils.run(
+                        dir, ListUtils.of("init", "-t", "bad-include-path", "-u", templatesDir.toString()));
+                System.out.println(result.getOutput());
+                assertThat(Files.exists(Paths.get(dir.toString(), " bad-include-path")), is(false));
+                assertThat(result.getExitCode(), is(1));
+                assertThat(result.getOutput(),
+                        containsString("File or directory getting-started-example/does-not-exist is marked"
+                                + " for inclusion in template bad-include-path but was not found"));
             });
         });
     }

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
@@ -269,13 +269,11 @@ public class InitCommandTest {
             IntegUtils.withTempDir("badTemplatePath", dir -> {
                 RunResult result = IntegUtils.run(
                         dir, ListUtils.of("init", "-t", "bad-template-path", "-u", templatesDir.toString()));
-                System.out.println(result.getOutput());
                 assertThat(Files.exists(Paths.get(dir.toString(), "bad-template-path")), is(false));
                 assertThat(result.getExitCode(), is(1));
                 assertThat(result.getOutput(),
-                        containsString("Template path `getting-started-example/does-not-exist` specified in"
-                                + " template bad-template-path is invalid."));
-
+                        containsString("Template path `getting-started-example/does-not-exist` for template"
+                                +" \"bad-template-path\" is invalid."));
             });
         });
     }
@@ -288,12 +286,11 @@ public class InitCommandTest {
             IntegUtils.withTempDir("badIncludePath", dir -> {
                 RunResult result = IntegUtils.run(
                         dir, ListUtils.of("init", "-t", "bad-include-path", "-u", templatesDir.toString()));
-                System.out.println(result.getOutput());
                 assertThat(Files.exists(Paths.get(dir.toString(), " bad-include-path")), is(false));
                 assertThat(result.getExitCode(), is(1));
                 assertThat(result.getOutput(),
-                        containsString("File or directory getting-started-example/does-not-exist is marked"
-                                + " for inclusion in template bad-include-path but was not found"));
+                        containsString("File or directory `getting-started-example/does-not-exist` is marked"
+                                + " for inclusion in template \"bad-include-path\", but was not found"));
             });
         });
     }

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/smithy-templates/smithy-templates.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/smithy-templates/smithy-templates.json
@@ -18,6 +18,17 @@
                 "getting-started-example/common-gradle-configs/gradlew",
                 "getting-started-example/common-gradle-configs/gradle.properties"
             ]
+        },
+        "bad-template-path": {
+            "documentation": "Template with incorrect path. Should throw error.",
+            "path": "getting-started-example/does-not-exist"
+        },
+        "bad-include-path": {
+            "documentation": "Template with incorrect include path. Should throw error.",
+            "path": "getting-started-example/included-files-gradle",
+            "include": [
+                "getting-started-example/does-not-exist"
+            ]
         }
     }
 }

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
@@ -214,8 +214,8 @@ final class InitCommand implements Command {
             exec(ListUtils.of("git", "checkout"), temp);
         }
 
-        if (!Files.exists(temp.resolve(directory))) {
-            throw new CliError(String.format("Template path `%s` specified in template %s is invalid.",
+        if (!Files.exists(temp.resolve(templatePath))) {
+            throw new CliError(String.format("Template path `%s` for template \"%s\" is invalid.",
                     templatePath, template));
         }
 
@@ -276,7 +276,7 @@ final class InitCommand implements Command {
             Path includedPath = Paths.get(temp, included);
             if (!Files.exists(includedPath)) {
                 throw new CliError(String.format(
-                        "File or directory %s is marked for inclusion in template %s but was not found",
+                        "File or directory `%s` is marked for inclusion in template \"%s\", but was not found",
                         included, templateName));
             }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
@@ -201,7 +201,7 @@ final class InitCommand implements Command {
         final String templatePath = getTemplatePath(templateNode, template);
         List<String> includedFiles = getIncludedFiles(templateNode);
 
-        try (ProgressTracker t = new ProgressTracker(env,
+        try (ProgressTracker ignored = new ProgressTracker(env,
                 ProgressStyle.dots("cloning template", "template cloned"),
                 standardOptions.quiet()
         )) {
@@ -214,8 +214,13 @@ final class InitCommand implements Command {
             exec(ListUtils.of("git", "checkout"), temp);
         }
 
+        if (!Files.exists(temp.resolve(directory))) {
+            throw new CliError(String.format("Template path `%s` specified in template %s is invalid.",
+                    templatePath, template));
+        }
+
         IoUtils.copyDir(Paths.get(temp.toString(), templatePath), dest);
-        copyIncludedFiles(temp.toString(), dest.toString(), includedFiles, template, env);
+        copyIncludedFiles(temp.toString(), dest.toString(), includedFiles, template);
 
         if (!standardOptions.quiet()) {
             try (ColorBuffer buffer = ColorBuffer.of(env.colors(), env.stdout())) {
@@ -266,15 +271,13 @@ final class InitCommand implements Command {
     }
 
     private static void copyIncludedFiles(String temp, String dest, List<String> includedFiles,
-                                          String templateName, Env env) throws IOException {
+                                          String templateName) throws IOException {
         for (String included : includedFiles) {
             Path includedPath = Paths.get(temp, included);
             if (!Files.exists(includedPath)) {
-                try (ColorBuffer buffer = ColorBuffer.of(env.colors(), env.stderr())) {
-                    buffer.println(String.format(
-                            "File or directory %s is marked for inclusion in template %s but was not found",
-                            included, templateName), ColorTheme.WARNING);
-                }
+                throw new CliError(String.format(
+                        "File or directory %s is marked for inclusion in template %s but was not found",
+                        included, templateName));
             }
 
             Path target = Paths.get(dest, Objects.requireNonNull(includedPath.getFileName()).toString());


### PR DESCRIPTION
*Description of changes:*
Throws an error if the `include` files or the root template path specified in the `smithy-templates.json` are invalid.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
