### PR TITLE
Update reference branch for homebrew tap

### DIFF
--- a/.github/workflows/update-brew.yml
+++ b/.github/workflows/update-brew.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           repository: 'smithy-lang/homebrew-tap'
           path: 'homebrew-tap'
-          ref: 'master'
+          ref: 'main'
       - name: Update version
         run: |
           version="${GITHUB_REF##*/}"


### PR DESCRIPTION
*Description of changes:*
The updated homebrew tap does not have a `master` branch. This PR updates the update brew workflow to use the `main` branch as the new reference branch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
