### PR TITLE
Improve rename usage code example

### DIFF
--- a/docs/source-2.0/spec/service-types.rst
+++ b/docs/source-2.0/spec/service-types.rst
@@ -221,7 +221,7 @@ the conflicting shapes.
     @output
     structure GetSomethingOutput {
         widget1: Widget
-        fooWidget: foo.example#Widget
+        widget2: FooWidget
     }
 
     structure Widget {}


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
This change improves the example code block demonstrating the usage of rename property within the service types specification page.

In the original example, the disambiguated shape name is not actually used in the example code. It makes the example ambiguous as it is no longer clear that the newly assigned name can be used identically as the local shape names.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
