### PR TITLE
Add ServiceIndex method to account for smithy.api#noAuth

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/synthetic/NoAuthTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/synthetic/NoAuthTrait.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.model.traits.synthetic;
+
+import software.amazon.smithy.model.knowledge.ServiceIndex;
+import software.amazon.smithy.model.knowledge.ServiceIndex.AuthSchemeMode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AnnotationTrait;
+
+/**
+ * An auth scheme trait for {@code smithy.api#noAuth} which indicates no authentication. This is not a real trait
+ * in the semantic model, but a valid auth scheme for use in {@link ServiceIndex#getEffectiveAuthSchemes} with
+ * {@link AuthSchemeMode#NO_AUTH_AWARE}.
+ */
+public final class NoAuthTrait extends AnnotationTrait {
+
+    public static final ShapeId ID = ShapeId.from("smithy.api#noAuth");
+
+    public NoAuthTrait() {
+        super(ID, Node.objectNode());
+    }
+
+    @Override
+    public boolean isSynthetic() {
+        return true;
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/knowledge/service-index-finds-auth-schemes.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/knowledge/service-index-finds-auth-schemes.smithy
@@ -2,30 +2,77 @@ $version: "2"
 
 namespace smithy.example
 
+@customAuth
 @httpBasicAuth
 @httpDigestAuth
 @httpBearerAuth
-service ServiceWithNoAuthTrait {
-    version: "2020-01-29",
+service ServiceWithoutAuthTrait {
+    version: "2020-01-29"
     operations: [
-        OperationWithNoAuthTrait,
+        OperationWithoutAuthTrait
         OperationWithAuthTrait
+        OperationWithEmptyAuthTrait
+        OperationWithOptionalAuthTrait
     ]
 }
 
+@customAuth
 @httpBasicAuth
 @httpDigestAuth
 @httpBearerAuth
 @auth([httpBasicAuth, httpDigestAuth])
 service ServiceWithAuthTrait {
-    version: "2020-01-29",
+    version: "2020-01-29"
     operations: [
-        OperationWithNoAuthTrait,
+        OperationWithoutAuthTrait
         OperationWithAuthTrait
+        OperationWithEmptyAuthTrait
+        OperationWithOptionalAuthTrait
     ]
 }
 
-operation OperationWithNoAuthTrait {}
+@customAuth
+@httpBasicAuth
+@httpDigestAuth
+@httpBearerAuth
+@auth([])
+service ServiceWithEmptyAuthTrait {
+    version: "2020-01-29"
+    operations: [
+        OperationWithoutAuthTrait
+        OperationWithAuthTrait
+        OperationWithEmptyAuthTrait
+        OperationWithOptionalAuthTrait
+    ]
+}
+
+service ServiceWithoutAuthDefinitionTraits {
+    version: "2020-01-29"
+    operations: [
+        OperationWithoutAuthTrait
+        OperationWithEmptyAuthTrait
+        OperationWithOptionalAuthTrait
+    ]
+}
+
+operation OperationWithoutAuthTrait {}
 
 @auth([httpDigestAuth])
 operation OperationWithAuthTrait {}
+
+@auth([])
+operation OperationWithEmptyAuthTrait {}
+
+@optionalAuth
+operation OperationWithOptionalAuthTrait {}
+
+// Defining a custom trait, to assert that alphabetical sorting of traits takes namespace into account, as well as
+// smithy.api#noAuth is added to the end, and not included in sorting.
+@trait(
+    selector: "service"
+    breakingChanges: [
+        {change: "remove"}
+    ]
+)
+@authDefinition
+structure customAuth {}


### PR DESCRIPTION
Add a new `getNoAuthAwareEffectiveAuthSchemes` method to ServiceIndex that wraps `getEffectiveAuthSchemes` to account for `smithy.api#noAuth` scheme.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
