### PR TITLE
Fix AbbreviationAsWordInName checkstyle warning

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
@@ -154,13 +154,13 @@ final class InitCommand implements Command {
             // Just use the local path if the git repo is local
             return Paths.get(repoPath);
         } else {
-            return CliCache.getTemplateCache().get().resolve(getCacheDirFromURL(repoPath));
+            return CliCache.getTemplateCache().get().resolve(getCacheDirFromUrl(repoPath));
         }
     }
 
     // Remove any trailing .git
     // Remove "/" and ".." and ":" characters so a directory can be created with no nesting
-    private String getCacheDirFromURL(final String repositoryUrl) {
+    private String getCacheDirFromUrl(final String repositoryUrl) {
         return repositoryUrl.replace(".git", "")
                 .replace(":", "_")
                 .replace("/", "_")


### PR DESCRIPTION
Fixes this that I was seeing in the build
```
> Task :smithy-cli:checkstyleMain
[ant:checkstyle] [WARN] /Volumes/workplace/github/smithy/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java:163:20: Abbreviation in name 'getCacheDirFromURL' must contain no more than '2' consecutive capital letters. [AbbreviationAsWordInName]
Checkstyle rule violations were found. See the report at: file:///Volumes/workplace/github/smithy/smithy-cli/build/reports/checkstyle/main.html
Checkstyle files with violations: 1
Checkstyle violations by severity: [warning:1]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
