### PR TITLE
Update getAuthSchemes javadoc

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/ServiceIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/ServiceIndex.java
@@ -105,6 +105,8 @@ public final class ServiceIndex implements KnowledgeIndex {
      * <p>An <em>auth defining trait</em> is a trait that is marked with
      * the {@code smithy.api#authDefinition} trait.
      *
+     * <p>The returned map is ordered alphabetically by absolute shape ID.
+     *
      * <p>An empty map is returned if {@code id} cannot be found in the
      * model or is not a service shape.
      *
@@ -127,7 +129,7 @@ public final class ServiceIndex implements KnowledgeIndex {
      *
      * <p>The returned map is provided in the same order as the values in the
      * {@code auth} trait if an auth trait is present, otherwise the result
-     * returned is ordered alphabetically by absolute shape id.
+     * returned is ordered alphabetically by absolute shape ID.
      *
      * <p>An empty map is returned if {@code service} cannot be found in the
      * model or is not a service shape.
@@ -167,7 +169,7 @@ public final class ServiceIndex implements KnowledgeIndex {
      *
      * <p>The returned map is provided in the same order as the values in the
      * {@code auth} trait if an auth trait is present, otherwise the result
-     * returned is ordered alphabetically by absolute shape id.
+     * returned is ordered alphabetically by absolute shape ID.
      *
      * <p>An empty map is returned if {@code service} shape cannot be found
      * in the model or is not a service shape. An empty map is returned if


### PR DESCRIPTION
Updates javadoc for ServiceIndex::getAuthSchemes to say the returned order is alphabetical. Tests were updated in [#1915](https://github.com/smithy-lang/smithy/pull/1915)to assert this ordering for ServiceIndex::getEffectiveAuthSchemes, but it also made the same update for the ServiceIndex::getAuthSchemes test. The PR didn't include a javadoc update, so the purpose of this PR is to fix that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
