### PR TITLE
Fix PartitionsTest broken by missing implicitGlobalRegion

### DIFF
--- a/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/language/functions/partition/PartitionsTest.java
+++ b/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/language/functions/partition/PartitionsTest.java
@@ -37,6 +37,7 @@ public class PartitionsTest {
                                 .dualStackDnsSuffix("api.amazonwebservices.com.cn")
                                 .supportsFips(true)
                                 .supportsDualStack(true)
+                                .implicitGlobalRegion("cn-northwest-1")
                                 .build())
                         .build())
                 .build();

--- a/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/language/functions/partition/complete-partitions.json
+++ b/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/language/functions/partition/complete-partitions.json
@@ -27,7 +27,8 @@
         "dnsSuffix": "amazonaws.com.cn",
         "dualStackDnsSuffix": "api.amazonwebservices.com.cn",
         "supportsFIPS": true,
-        "supportsDualStack": true
+        "supportsDualStack": true,
+        "implicitGlobalRegion": "cn-northwest-1"
       }
     }
   ]


### PR DESCRIPTION
*Description of changes:*
Fix NPE in test: https://github.com/smithy-lang/smithy/actions/runs/5896733530/job/15995141660#step:5:576

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
