### PR TITLE
Force operation errors on multiple lines

### DIFF
--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/errors-always-multiple-lines.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/errors-always-multiple-lines.smithy
@@ -1,0 +1,22 @@
+$version: "2.0"
+
+namespace smithy.example
+
+operation DeleteFoo1 {
+    errors: [
+        BadRequest
+    ]
+}
+
+operation DeleteFoo2 {
+    errors: [
+        BadRequest
+        WorseRequest
+    ]
+}
+
+@error("client")
+structure BadRequest {}
+
+@error("client")
+structure WorseRequest {}


### PR DESCRIPTION
Rather than keep operation errors on a single line if it fits, this PR forces errors to appear on multiple lines.

Further PRs will be added to make the same treatment to service and resource "resources" and "operations" properties (though that's more involved).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
