### PR TITLE
Bump action version to v6 and set to dryrun

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-      - uses: aws-actions/stale-issue-cleanup@v3
+      - uses: aws-actions/stale-issue-cleanup@v4
         with:
           # Targeted types
           issue-types: issues
@@ -22,7 +22,7 @@ jobs:
 
           # Labels
           stale-issue-label: closing-soon
-          exempt-issue-label: bug,documentation,feature-request,investigating,protocol-test
+          exempt-issue-labels: bug,documentation,feature-request,investigating,protocol-test
           response-requested-label: response-requested
 
           # Messages
@@ -41,3 +41,4 @@ jobs:
 
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           loglevel: DEBUG
+          dryrun: true

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-      - uses: aws-actions/stale-issue-cleanup@v4
+      - uses: aws-actions/stale-issue-cleanup@v6
         with:
           # Targeted types
           issue-types: issues


### PR DESCRIPTION
*Description of changes:*
Workflow wrongly tagged some of the issues due to running v3 version of the action which does not support multiple exemption labels. This change upgrades it to v4, which does have that support, and sets the workflow to dryrun to allow us to verify the run before actually turning the workflow on next time.

Closes #1937 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
