### PR TITLE
Add the metadata key to RemovedMetadata event id, eg. `RemovedMetadat…

### DIFF
--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedMetadata.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedMetadata.java
@@ -30,7 +30,7 @@ public final class RemovedMetadata extends AbstractDiffEvaluator {
     public List<ValidationEvent> evaluate(Differences differences) {
         return differences.removedMetadata()
                 .map(metadata -> ValidationEvent.builder()
-                        .id(getEventId())
+                        .id(getEventId() + "." + metadata.getLeft())
                         .severity(Severity.DANGER)
                         .sourceLocation(metadata.getRight().getSourceLocation())
                         .message(String.format(

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedMetadataTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedMetadataTest.java
@@ -32,6 +32,6 @@ public class RemovedMetadataTest {
         Model modelB = Model.assembler().assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "RemovedMetadata").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "RemovedMetadata.foo").size(), equalTo(1));
     }
 }


### PR DESCRIPTION
…a.suppressions`

*Description of changes:*
Adds the metadata key being removed as a diff event subpart: `RemovedMetadata.XXXXXXX`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
