### PR TITLE
Enable stale-issues workflow

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -41,4 +41,3 @@ jobs:
 
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           loglevel: DEBUG
-          dryrun: true


### PR DESCRIPTION
Enable stale-issues workflow by removing the `dryrun` flag. I verified the execution logs from latest run and checked that the new version properly skips issues tagged with at least one of the exempt labels.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
