### PR TITLE
Fix NPE on trait with implicit null

### DIFF
--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FormatVisitor.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FormatVisitor.java
@@ -328,24 +328,29 @@ final class FormatVisitor {
                             .detectHardLines(cursor)
                             .write();
                 } else {
-                    // Check the inner trait node for hard line breaks rather than the wrapper.
-                    TreeCursor traitNode = cursor
-                            .getFirstChild(TreeType.TRAIT_NODE)
-                            .getFirstChild(TreeType.NODE_VALUE)
-                            .getFirstChild(); // The actual node value.
-                    return new BracketFormatter()
-                            .open(Formatter.LPAREN)
-                            .close(Formatter.RPAREN)
-                            .extractChildren(cursor, BracketFormatter.extractor(this::visit, child -> {
-                                if (child.getTree().getType() == TreeType.TRAIT_NODE) {
-                                    // Split WS and NODE_VALUE so that they appear on different lines.
-                                    return child.getChildrenByType(TreeType.NODE_VALUE, TreeType.WS).stream();
-                                } else {
-                                    return Stream.empty();
-                                }
-                            }))
-                            .detectHardLines(traitNode)
-                            .write();
+                    if (cursor.getFirstChild(TreeType.TRAIT_NODE) != null) {
+                        // Check the inner trait node for hard line breaks rather than the wrapper.
+                        TreeCursor traitNode = cursor
+                                .getFirstChild(TreeType.TRAIT_NODE)
+                                .getFirstChild(TreeType.NODE_VALUE)
+                                .getFirstChild(); // The actual node value.
+                        return new BracketFormatter()
+                                .open(Formatter.LPAREN)
+                                .close(Formatter.RPAREN)
+                                .extractChildren(cursor, BracketFormatter.extractor(this::visit, child -> {
+                                    if (child.getTree().getType() == TreeType.TRAIT_NODE) {
+                                        // Split WS and NODE_VALUE so that they appear on different lines.
+                                        return child.getChildrenByType(TreeType.NODE_VALUE, TreeType.WS).stream();
+                                    } else {
+                                        return Stream.empty();
+                                    }
+                                }))
+                                .detectHardLines(traitNode)
+                                .write();
+                    } else {
+                        // If the trait node is empty, remove the empty parentheses.
+                        return Doc.text("");
+                    }
                 }
             }
 

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/null-trait-body.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/null-trait-body.formatted.smithy
@@ -1,0 +1,17 @@
+$version: "2.0"
+
+namespace smithy.example
+
+structure Struct {
+    @default
+    a: String
+
+    @default
+    b: String
+
+    @default
+    c: String
+
+    @default(null)
+    d: String
+}

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/null-trait-body.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/null-trait-body.smithy
@@ -1,0 +1,17 @@
+$version: "2.0"
+
+namespace smithy.example
+
+structure Struct {
+    @default
+    a: String
+
+    @default()
+    b: String
+
+    @default( )
+    c: String
+
+    @default(null)
+    d: String
+}


### PR DESCRIPTION
This PR fixes smithy-syntax throwing a NullPointerException when encountering a trait with an implicit null.

Following this fix, if a trait is encountered with an empty body, the parentheses will be omitted.

This:
```
structure Struct {
    @default()
    a: String

    @default( )
    b: String

    @default(null)
    c: String
}
```

Will now be formatted to this:
```
structure Struct {
    @default
    a: String

    @default
    b: String

    @default(null)
    c: String
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
