### PR TITLE
Update AWS docs to ignore __type in unions

### DIFF
--- a/docs/source-2.0/aws/protocols/aws-json.rst.template
+++ b/docs/source-2.0/aws/protocols/aws-json.rst.template
@@ -132,6 +132,7 @@ to convert each shape type:
     * - ``union``
       - JSON object. A union is serialized identically as a ``structure``
         shape, but only a single member can be set to a non-null value.
+        Deserializers MUST ignore an unrecognized ``__type`` member if present.
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source-2.0/aws/protocols/aws-restjson1-protocol.rst
+++ b/docs/source-2.0/aws/protocols/aws-restjson1-protocol.rst
@@ -287,6 +287,7 @@ JSON shape serialization
     * - ``union``
       - JSON object. A union is serialized identically as a ``structure``
         shape, but only a single member can be set to a non-null value.
+        Deserializers MUST ignore an unrecognized ``__type`` member if present.
 
 
 --------------------------

--- a/smithy-aws-protocol-tests/model/awsJson1_0/unions.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/unions.smithy
@@ -509,4 +509,31 @@ apply JsonUnions @httpResponseTests([
             }
         }
     },
+    {
+        id: "AwsJson10DeserializeIgnoreType"
+        appliesTo: "client"
+        documentation: "Ignores an unrecognized __type property"
+        protocol: awsJson1_0
+        code: 200
+        body: """
+            {
+                "contents": {
+                    "__type": "aws.protocoltests.json10#MyUnion",
+                    "structureValue": {
+                        "hi": "hello"
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: {
+            "Content-Type": "application/x-amz-json-1.0"
+        },
+        params: {
+            contents: {
+                structureValue: {
+                    hi: "hello"
+                }
+            }
+        }
+    }
 ])

--- a/smithy-aws-protocol-tests/model/awsJson1_1/unions.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/unions.smithy
@@ -440,4 +440,31 @@ apply JsonUnions @httpResponseTests([
             }
         }
     },
+    {
+        id: "AwsJson11DeserializeIgnoreType"
+        appliesTo: "client"
+        documentation: "Ignores an unrecognized __type property"
+        protocol: awsJson1_1
+        code: 200
+        body: """
+            {
+                "contents": {
+                    "__type": "aws.protocoltests.json10#MyUnion",
+                    "structureValue": {
+                        "hi": "hello"
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1"
+        }
+        params: {
+            contents: {
+                structureValue: {
+                    hi: "hello"
+                }
+            }
+        }
+    }
 ])

--- a/smithy-aws-protocol-tests/model/restJson1/unions.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/unions.smithy
@@ -442,6 +442,33 @@ apply JsonUnions @httpResponseTests([
             }
         }
     },
+    {
+        id: "RestJsonDeserializeIgnoreType"
+        appliesTo: "client"
+        documentation: "Ignores an unrecognized __type property"
+        protocol: restJson1
+        code: 200
+        body: """
+            {
+                "contents": {
+                    "__type": "aws.protocoltests.json10#MyUnion",
+                    "structureValue": {
+                        "hi": "hello"
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: {
+            "Content-Type": "application/json"
+        }
+        params: {
+            contents: {
+                structureValue: {
+                    hi: "hello"
+                }
+            }
+        }
+    }
 ])
 
 


### PR DESCRIPTION
Some older implementations of AWS JSON protocols will unnecessarily serialize a `__type` property, even for unions. This behavior can't be changed. To account for this, deserializers should be updated to ignore an unrecognized `__type` when deserializing unions for AWS restJson1, awsJson1_0, and awsJson1_1.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
