### PR TITLE
Http-Date Trait Value Validation Bug Fix

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampFormatPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampFormatPlugin.java
@@ -40,10 +40,6 @@ final class TimestampFormatPlugin implements NodeValidatorPlugin {
     public void apply(Shape shape, Node value, Context context, Emitter emitter) {
         if (shape instanceof TimestampShape) {
             validate(shape, shape.getTrait(TimestampFormatTrait.class).orElse(null), value, emitter);
-        } else if (shape instanceof MemberShape && shape.getTrait(TimestampFormatTrait.class).isPresent()) {
-            // Only perform timestamp format validation on a member when it references
-            // a timestamp shape and the member has an explicit timestampFormat trait.
-            validate(shape, shape.getTrait(TimestampFormatTrait.class).get(), value, emitter);
         }
     }
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
@@ -242,6 +242,7 @@ public class NodeValidationVisitorTest {
                 {"ns.foo#HttpDate", "\"Tuesday, 29 April 2014 18:30:38 GMT\"", new String[] {"Invalid value provided for http-date formatted timestamp. Expected a string value that matches the IMF-fixdate production of RFC 7231 section-7.1.1.1. Found: Tuesday, 29 April 2014 18:30:38 GMT"}},
                 {"ns.foo#HttpDate", "\"Tue, 29 Apr 2014 18:30:38 PST\"", new String[] {"Invalid value provided for http-date formatted timestamp. Expected a string value that matches the IMF-fixdate production of RFC 7231 section-7.1.1.1. Found: Tue, 29 Apr 2014 18:30:38 PST"}},
                 {"ns.foo#HttpDate", "11", new String[] {"Invalid value provided for http-date formatted timestamp. Expected a string value that matches the IMF-fixdate production of RFC 7231 section-7.1.1.1. Found: number"}},
+                {"ns.foo#Structure4", "{\"httpDate\": \"Tue, 29 Apr 2014 18:30:38 GMT\"}", null},
 
                 // date-time
                 {"ns.foo#DateTime", "\"1985-04-12T23:20:50.52Z\"", null},
@@ -257,8 +258,7 @@ public class NodeValidationVisitorTest {
                 // timestamp member with format.
                 {"ns.foo#TimestampList", "[\"1985-04-12T23:20:50.52Z\"]", null},
                 {"ns.foo#TimestampList", "[\"1985-04-12T23:20:50.52-07:00\"]", new String[] {
-                        "0: Invalid string value, `1985-04-12T23:20:50.52-07:00`, provided for timestamp, `smithy.api#Timestamp`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")",
-                        "0: Invalid string value, `1985-04-12T23:20:50.52-07:00`, provided for timestamp, `ns.foo#TimestampList$member`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"
+                        "0: Invalid string value, `1985-04-12T23:20:50.52-07:00`, provided for timestamp, `smithy.api#Timestamp`. Expected an RFC 3339 formatted timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"
                 }},
                 {"ns.foo#TimestampList", "[123]", new String[] {"0: Expected a string value for a date-time timestamp (e.g., \"1985-04-12T23:20:50.52Z\")"}},
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/validation/node-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/validation/node-validator.json
@@ -268,6 +268,17 @@
                 }
             }
         },
+        "ns.foo#Structure4": {
+            "type": "structure",
+            "members": {
+                "httpDate": {
+                    "target": "smithy.api#Timestamp",
+                    "traits": {
+                        "smithy.api#timestampFormat": "http-date"
+                    }
+                }
+            }
+        },
         "ns.foo#Service": {
             "type": "service",
             "version": "2017-17-01",


### PR DESCRIPTION
Found an issue where if the http-date timestamp format was used in a trait, then the validation would always fail (because it was checked twice, each time with a different format).

e.g. the following would fail:

```smithy
@trait
structure myTrait {
  @timestampFormat("http-date")
  httpDate: Timestamp
}

@myTrait({ httpDate: "Sun, 06 Nov 1994 08:49:37 GMT"  }) // Invalid string value, `Sun, 06 Nov 1994 08:49:37 GMT`, provided for timestamp, `smithy.api#Timestamp`. Expected an RFC 3339 formatted timestamp (e.g., "1985-04-12T23:20:50.52Z")
string Whatever
```

A workaround at the moment is to do:

```smithy
@timestampFormat("http-date")
timestamp HttpDate

@trait
structure myTrait {
  httpDate: HttpDate
}

@myTrait({ httpDate: "Sun, 06 Nov 1994 08:49:37 GMT"  }) // no error
string Whatever
```

This PR contains a test that reproduces the issue and one way of fixing it (no problem if you all want to do it differently or suggest a different way to me).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

YES
