### PR TITLE
Allow constraint trait errors on error example inputs

### DIFF
--- a/docs/source-2.0/guides/building-models/build-config.rst
+++ b/docs/source-2.0/guides/building-models/build-config.rst
@@ -61,7 +61,7 @@ The configuration file accepts the following properties:
         projection. Plugins are a mapping of :ref:`plugin IDs <plugin-id>` to
         plugin-specific configuration objects.
     * - ignoreMissingPlugins
-      - ``bool``
+      - ``boolean``
       - If a plugin can't be found, Smithy will by default fail the build. This
         setting can be set to ``true`` to allow the build to progress even if
         a plugin can't be found on the classpath.

--- a/docs/source-2.0/spec/documentation-traits.rst
+++ b/docs/source-2.0/spec/documentation-traits.rst
@@ -139,22 +139,17 @@ Each ``example`` trait value is a structure with the following members:
       - :ref:`examples-ErrorExample-structure`
       - Provides an error shape ID and example error parameters for the
         operation.
-    * - lowerInputValidationSeverity
-      - ``[string]``
-      - Lowers input validation events from ERROR to WARNING for specific
-        validation types. List can include: ``BLOB_LENGTH_WARNING``,
-        ``MAP_LENGTH_WARNING``, ``PATTERN_TRAIT_WARNING``,
-        ``RANGE_TRAIT_WARNING``, ``REQUIRED_TRAIT_WARNING``,
-        ``STRING_LENGTH_WARNING``.
-
+    * - disableConstraints
+      - ``boolean``
+      - Set to true to lower input constraint trait validations to warnings.
 
 When ``input`` and ``output`` members are present, both MUST be compatible
 with the shapes and constraints of the corresponding structure. When ``input``
 and ``error`` members are present, input validation events will be emitted as
-an ``ERROR`` by default. Specific validation events for the ``input`` can be
-lowered to a ``WARNING`` by setting the appropriate
-``lowerInputValidationSeverity`` value. ``input`` and ``output`` members use
-the same semantics and format as :ref:`custom trait values <trait-node-values>`.
+an ``ERROR`` by default. Constraint trait validation events for the ``input``
+can be lowered to a ``WARNING`` by setting ``disableConstraints`` to true.
+``input`` and ``output`` members use the same semantics and format as
+:ref:`custom trait values <trait-node-values>`.
 
 A value for ``output`` or ``error`` SHOULD be provided. However, both
 MUST NOT be defined for the same example.
@@ -198,7 +193,7 @@ MUST NOT be defined for the same example.
                     message: "Invalid 'foo'. Special character not allowed."
                 }
             },
-            lowerInputValidationSeverity: ["PATTERN_TRAIT_WARNING"]
+            disableConstraints: true
         }
     ])
 

--- a/docs/source-2.0/spec/documentation-traits.rst
+++ b/docs/source-2.0/spec/documentation-traits.rst
@@ -139,7 +139,7 @@ Each ``example`` trait value is a structure with the following members:
       - :ref:`examples-ErrorExample-structure`
       - Provides an error shape ID and example error parameters for the
         operation.
-    * - disableConstraints
+    * - allowConstraintErrors
       - ``boolean``
       - Set to true to lower input constraint trait validations to warnings.
         This can only be set when ``error`` is provided.
@@ -186,7 +186,7 @@ MUST NOT be defined for the same example.
                     message: "Invalid 'foo'. Special character not allowed."
                 }
             },
-            disableConstraints: true
+            allowConstraintErrors: true
         }
     ])
 

--- a/docs/source-2.0/spec/documentation-traits.rst
+++ b/docs/source-2.0/spec/documentation-traits.rst
@@ -142,14 +142,7 @@ Each ``example`` trait value is a structure with the following members:
     * - disableConstraints
       - ``boolean``
       - Set to true to lower input constraint trait validations to warnings.
-
-When ``input`` and ``output`` members are present, both MUST be compatible
-with the shapes and constraints of the corresponding structure. When ``input``
-and ``error`` members are present, input validation events will be emitted as
-an ``ERROR`` by default. Constraint trait validation events for the ``input``
-can be lowered to a ``WARNING`` by setting ``disableConstraints`` to true.
-``input`` and ``output`` members use the same semantics and format as
-:ref:`custom trait values <trait-node-values>`.
+        This can only be set when ``error`` is provided.
 
 A value for ``output`` or ``error`` SHOULD be provided. However, both
 MUST NOT be defined for the same example.

--- a/docs/source-2.0/spec/documentation-traits.rst
+++ b/docs/source-2.0/spec/documentation-traits.rst
@@ -139,11 +139,22 @@ Each ``example`` trait value is a structure with the following members:
       - :ref:`examples-ErrorExample-structure`
       - Provides an error shape ID and example error parameters for the
         operation.
+    * - lowerInputValidationSeverity
+      - ``[string]``
+      - Lowers input validation events from ERROR to WARNING for specific
+        validation types. List can include: ``BLOB_LENGTH_WARNING``,
+        ``MAP_LENGTH_WARNING``, ``PATTERN_TRAIT_WARNING``,
+        ``RANGE_TRAIT_WARNING``, ``REQUIRED_TRAIT_WARNING``,
+        ``STRING_LENGTH_WARNING``.
 
-The values provided for the ``input`` and ``output`` members MUST be
-compatible with the shapes and constraints of the corresponding structure.
-These values use the same semantics and format as
-:ref:`custom trait values <trait-node-values>`.
+
+When ``input`` and ``output`` members are present, both MUST be compatible
+with the shapes and constraints of the corresponding structure. When ``input``
+and ``error`` members are present, input validation events will be emitted as
+an ``ERROR`` by default. Specific validation events for the ``input`` can be
+lowered to a ``WARNING`` by setting the appropriate
+``lowerInputValidationSeverity`` value. ``input`` and ``output`` members use
+the same semantics and format as :ref:`custom trait values <trait-node-values>`.
 
 A value for ``output`` or ``error`` SHOULD be provided. However, both
 MUST NOT be defined for the same example.
@@ -186,7 +197,8 @@ MUST NOT be defined for the same example.
                 content: {
                     message: "Invalid 'foo'. Special character not allowed."
                 }
-            }
+            },
+            lowerInputValidationSeverity: ["PATTERN_TRAIT_WARNING"]
         }
     ])
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExamplesTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExamplesTrait.java
@@ -119,7 +119,7 @@ public final class ExamplesTrait extends AbstractTrait implements ToSmithyBuilde
         private final ObjectNode input;
         private final ObjectNode output;
         private final ErrorExample error;
-        private final boolean disableConstraints;
+        private final boolean allowConstraintErrors;
 
         private Example(Builder builder) {
             this.title = Objects.requireNonNull(builder.title, "Example title must not be null");
@@ -127,7 +127,7 @@ public final class ExamplesTrait extends AbstractTrait implements ToSmithyBuilde
             this.input = builder.input;
             this.output = builder.output;
             this.error = builder.error;
-            this.disableConstraints = builder.disableConstraints;
+            this.allowConstraintErrors = builder.allowConstraintErrors;
         }
 
         /**
@@ -166,10 +166,10 @@ public final class ExamplesTrait extends AbstractTrait implements ToSmithyBuilde
         }
 
         /**
-         * @return Returns true if input constraints validation has been disabled.
+         * @return Returns true if input constraints errors are allowed.
          */
-        public boolean getDisableConstraints() {
-            return disableConstraints;
+        public boolean getAllowConstraintErrors() {
+            return allowConstraintErrors;
         }
 
         @Override
@@ -178,7 +178,8 @@ public final class ExamplesTrait extends AbstractTrait implements ToSmithyBuilde
                     .withMember("title", Node.from(title))
                     .withOptionalMember("documentation", getDocumentation().map(Node::from))
                     .withOptionalMember("error", getError().map(ErrorExample::toNode))
-                    .withOptionalMember("disableConstraints", BooleanNode.from(disableConstraints).asBooleanNode());
+                    .withOptionalMember("allowConstraintErrors", BooleanNode.from(allowConstraintErrors)
+                            .asBooleanNode());
 
             if (!input.isEmpty()) {
                 builder.withMember("input", input);
@@ -193,7 +194,7 @@ public final class ExamplesTrait extends AbstractTrait implements ToSmithyBuilde
         @Override
         public Builder toBuilder() {
             return new Builder().documentation(documentation).title(title).input(input).output(output).error(error)
-                    .disableConstraints(disableConstraints);
+                    .allowConstraintErrors(allowConstraintErrors);
         }
 
         public static Builder builder() {
@@ -209,7 +210,7 @@ public final class ExamplesTrait extends AbstractTrait implements ToSmithyBuilde
             private ObjectNode input = Node.objectNode();
             private ObjectNode output;
             private ErrorExample error;
-            private boolean disableConstraints;
+            private boolean allowConstraintErrors;
 
             @Override
             public Example build() {
@@ -241,8 +242,8 @@ public final class ExamplesTrait extends AbstractTrait implements ToSmithyBuilde
                 return this;
             }
 
-            public Builder disableConstraints(Boolean disableConstraints) {
-                this.disableConstraints = disableConstraints;
+            public Builder allowConstraintErrors(Boolean allowConstraintErrors) {
+                this.allowConstraintErrors = allowConstraintErrors;
                 return this;
             }
         }
@@ -339,7 +340,7 @@ public final class ExamplesTrait extends AbstractTrait implements ToSmithyBuilde
                     .getObjectMember("input", builder::input)
                     .getObjectMember("output", builder::output)
                     .getMember("error", ErrorExample::fromNode, builder::error)
-                    .getBooleanMember("disableConstraints", builder::disableConstraints);
+                    .getBooleanMember("allowConstraintErrors", builder::allowConstraintErrors);
             return builder.build();
         }
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExamplesTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExamplesTrait.java
@@ -170,8 +170,8 @@ public final class ExamplesTrait extends AbstractTrait implements ToSmithyBuilde
         /**
          * @return Gets the list of lowered input validation severities.
          */
-        public Optional<List<NodeValidationVisitor.Feature>> getLowerInputValidationSeverity() {
-            return Optional.ofNullable(lowerInputValidationSeverity);
+        public List<NodeValidationVisitor.Feature> getLowerInputValidationSeverity() {
+            return lowerInputValidationSeverity;
         }
 
         @Override
@@ -179,19 +179,17 @@ public final class ExamplesTrait extends AbstractTrait implements ToSmithyBuilde
             ObjectNode.Builder builder = Node.objectNodeBuilder()
                     .withMember("title", Node.from(title))
                     .withOptionalMember("documentation", getDocumentation().map(Node::from))
-                    .withOptionalMember("error", getError().map(ErrorExample::toNode));
+                    .withOptionalMember("error", getError().map(ErrorExample::toNode))
+                    .withMember("lowerInputValidationSeverity", ArrayNode.fromNodes(lowerInputValidationSeverity
+                                    .stream()
+                                    .map(NodeValidationVisitor.Feature::toNode)
+                                    .collect(Collectors.toList())));
 
             if (!input.isEmpty()) {
                 builder.withMember("input", input);
             }
             if (this.getOutput().isPresent()) {
                 builder.withMember("output", output);
-            }
-            if (this.getLowerInputValidationSeverity().isPresent()) {
-                builder.withMember("lowerInputValidationSeverity", ArrayNode.fromNodes(lowerInputValidationSeverity
-                        .stream()
-                        .map(NodeValidationVisitor.Feature::toNode)
-                        .collect(Collectors.toList())));
             }
 
             return builder.build();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
@@ -110,7 +110,7 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
         RANGE_TRAIT_ZERO_VALUE_WARNING,
 
         // Lowers severity of constraint trait validations to WARNING.
-        DISABLE_CONSTRAINTS;
+        ALLOW_CONSTRAINT_ERRORS;
 
         public static Feature fromNode(Node node) {
             return Feature.valueOf(node.expectStringNode().getValue());
@@ -328,7 +328,7 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
 
                     for (MemberShape member : members.values()) {
                         if (member.isRequired() && !object.getMember(member.getMemberName()).isPresent()) {
-                            Severity severity = this.validationContext.hasFeature(Feature.DISABLE_CONSTRAINTS)
+                            Severity severity = this.validationContext.hasFeature(Feature.ALLOW_CONSTRAINT_ERRORS)
                                     ? Severity.WARNING : Severity.ERROR;
                             events.add(event(String.format(
                                     "Missing required structure member `%s` for `%s`",

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
@@ -109,23 +109,8 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
          */
         RANGE_TRAIT_ZERO_VALUE_WARNING,
 
-        // Lowers severity of Length Trait validations on blobs to a WARNING.
-        BLOB_LENGTH_WARNING,
-
-        // Lowers severity of Length Trait validations on maps to a WARNING.
-        MAP_LENGTH_WARNING,
-
-        // Lowers severity of Pattern Trait validations to a WARNING.
-        PATTERN_TRAIT_WARNING,
-
-        // Lowers severity of Range Trait validations to a WARNING.
-        RANGE_TRAIT_WARNING,
-
-        // Lowers severity of Required Trait validations to a WARNING.
-        REQUIRED_TRAIT_WARNING,
-
-        // Lowers severity of Length Trait validations on strings to a WARNING.
-        STRING_LENGTH_WARNING,;
+        // Lowers severity of constraint trait validations to WARNING.
+        DISABLE_CONSTRAINTS;
 
         public static Feature fromNode(Node node) {
             return Feature.valueOf(node.expectStringNode().getValue());
@@ -343,7 +328,7 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
 
                     for (MemberShape member : members.values()) {
                         if (member.isRequired() && !object.getMember(member.getMemberName()).isPresent()) {
-                            Severity severity = this.validationContext.hasFeature(Feature.REQUIRED_TRAIT_WARNING)
+                            Severity severity = this.validationContext.hasFeature(Feature.DISABLE_CONSTRAINTS)
                                     ? Severity.WARNING : Severity.ERROR;
                             events.add(event(String.format(
                                     "Missing required structure member `%s` for `%s`",

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
@@ -104,10 +104,36 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
          * Emit a warning when a range trait is incompatible with a default value of 0.
          *
          * <p>This was a common pattern in Smithy 1.0 and earlier. It implies that the value is effectively
-         * required. However, chaning the type of the value by un-boxing it or adjusting the range trait would
-         * be a lossy tranformation when migrating a model from 1.0 to 2.0.
+         * required. However, changing the type of the value by un-boxing it or adjusting the range trait would
+         * be a lossy transformation when migrating a model from 1.0 to 2.0.
          */
-        RANGE_TRAIT_ZERO_VALUE_WARNING
+        RANGE_TRAIT_ZERO_VALUE_WARNING,
+
+        // Lowers severity of Length Trait validations on blobs to a WARNING.
+        BLOB_LENGTH_WARNING,
+
+        // Lowers severity of Length Trait validations on maps to a WARNING.
+        MAP_LENGTH_WARNING,
+
+        // Lowers severity of Pattern Trait validations to a WARNING.
+        PATTERN_TRAIT_WARNING,
+
+        // Lowers severity of Range Trait validations to a WARNING.
+        RANGE_TRAIT_WARNING,
+
+        // Lowers severity of Required Trait validations to a WARNING.
+        REQUIRED_TRAIT_WARNING,
+
+        // Lowers severity of Length Trait validations on strings to a WARNING.
+        STRING_LENGTH_WARNING,;
+
+        public static Feature fromNode(Node node) {
+            return Feature.valueOf(node.expectStringNode().getValue());
+        }
+
+        public static Node toNode(Feature feature) {
+            return StringNode.from(feature.toString());
+        }
     }
 
     public static Builder builder() {
@@ -317,9 +343,11 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
 
                     for (MemberShape member : members.values()) {
                         if (member.isRequired() && !object.getMember(member.getMemberName()).isPresent()) {
+                            Severity severity = this.validationContext.hasFeature(Feature.REQUIRED_TRAIT_WARNING)
+                                    ? Severity.WARNING : Severity.ERROR;
                             events.add(event(String.format(
                                     "Missing required structure member `%s` for `%s`",
-                                    member.getMemberName(), shape.getId())));
+                                    member.getMemberName(), shape.getId()), severity));
                         }
                     }
                     return events;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/BlobLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/BlobLengthPlugin.java
@@ -57,7 +57,7 @@ final class BlobLengthPlugin extends MemberAndShapeTraitPlugin<BlobShape, String
     }
 
     private Severity getSeverity(Context context) {
-        return context.hasFeature(NodeValidationVisitor.Feature.BLOB_LENGTH_WARNING)
+        return context.hasFeature(NodeValidationVisitor.Feature.DISABLE_CONSTRAINTS)
                 ? Severity.WARNING : Severity.ERROR;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/BlobLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/BlobLengthPlugin.java
@@ -20,6 +20,8 @@ import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.BlobShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.LengthTrait;
+import software.amazon.smithy.model.validation.NodeValidationVisitor;
+import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -39,16 +41,23 @@ final class BlobLengthPlugin extends MemberAndShapeTraitPlugin<BlobShape, String
 
         trait.getMin().ifPresent(min -> {
             if (size < min) {
-                emitter.accept(node, "Value provided for `" + shape.getId() + "` must have at least "
-                                     + min + " bytes, but the provided value only has " + size + " bytes");
+                emitter.accept(node, getSeverity(context), "Value provided for `" + shape.getId()
+                            + "` must have at least " + min + " bytes, but the provided value only has " + size
+                            + " bytes");
             }
         });
 
         trait.getMax().ifPresent(max -> {
             if (value.getBytes(StandardCharsets.UTF_8).length > max) {
-                emitter.accept(node, "Value provided for `" + shape.getId() + "` must have no more than "
-                                     + max + " bytes, but the provided value has " + size + " bytes");
+                emitter.accept(node, getSeverity(context), "Value provided for `" + shape.getId()
+                            + "` must have no more than " + max + " bytes, but the provided value has " + size
+                            + " bytes");
             }
         });
+    }
+
+    private Severity getSeverity(Context context) {
+        return context.hasFeature(NodeValidationVisitor.Feature.BLOB_LENGTH_WARNING)
+                ? Severity.WARNING : Severity.ERROR;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/BlobLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/BlobLengthPlugin.java
@@ -57,7 +57,7 @@ final class BlobLengthPlugin extends MemberAndShapeTraitPlugin<BlobShape, String
     }
 
     private Severity getSeverity(Context context) {
-        return context.hasFeature(NodeValidationVisitor.Feature.DISABLE_CONSTRAINTS)
+        return context.hasFeature(NodeValidationVisitor.Feature.ALLOW_CONSTRAINT_ERRORS)
                 ? Severity.WARNING : Severity.ERROR;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/MapLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/MapLengthPlugin.java
@@ -19,6 +19,8 @@ import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.LengthTrait;
+import software.amazon.smithy.model.validation.NodeValidationVisitor;
+import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -35,7 +37,7 @@ final class MapLengthPlugin extends MemberAndShapeTraitPlugin<MapShape, ObjectNo
     protected void check(Shape shape, LengthTrait trait, ObjectNode node, Context context, Emitter emitter) {
         trait.getMin().ifPresent(min -> {
             if (node.size() < min) {
-                emitter.accept(node, String.format(
+                emitter.accept(node, getSeverity(context), String.format(
                         "Value provided for `%s` must have at least %d entries, but the provided value only "
                         + "has %d entries", shape.getId(), min, node.size()));
             }
@@ -43,10 +45,15 @@ final class MapLengthPlugin extends MemberAndShapeTraitPlugin<MapShape, ObjectNo
 
         trait.getMax().ifPresent(max -> {
             if (node.size() > max) {
-                emitter.accept(node, String.format(
+                emitter.accept(node, getSeverity(context), String.format(
                         "Value provided for `%s` must have no more than %d entries, but the provided value "
                         + "has %d entries", shape.getId(), max, node.size()));
             }
         });
+    }
+
+    private Severity getSeverity(Context context) {
+        return context.hasFeature(NodeValidationVisitor.Feature.MAP_LENGTH_WARNING)
+                ? Severity.WARNING : Severity.ERROR;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/MapLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/MapLengthPlugin.java
@@ -53,7 +53,7 @@ final class MapLengthPlugin extends MemberAndShapeTraitPlugin<MapShape, ObjectNo
     }
 
     private Severity getSeverity(Context context) {
-        return context.hasFeature(NodeValidationVisitor.Feature.MAP_LENGTH_WARNING)
+        return context.hasFeature(NodeValidationVisitor.Feature.DISABLE_CONSTRAINTS)
                 ? Severity.WARNING : Severity.ERROR;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/MapLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/MapLengthPlugin.java
@@ -53,7 +53,7 @@ final class MapLengthPlugin extends MemberAndShapeTraitPlugin<MapShape, ObjectNo
     }
 
     private Severity getSeverity(Context context) {
-        return context.hasFeature(NodeValidationVisitor.Feature.DISABLE_CONSTRAINTS)
+        return context.hasFeature(NodeValidationVisitor.Feature.ALLOW_CONSTRAINT_ERRORS)
                 ? Severity.WARNING : Severity.ERROR;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/PatternTraitPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/PatternTraitPlugin.java
@@ -42,7 +42,7 @@ final class PatternTraitPlugin extends MemberAndShapeTraitPlugin<StringShape, St
 
 
     private Severity getSeverity(Context context) {
-        return context.hasFeature(NodeValidationVisitor.Feature.DISABLE_CONSTRAINTS)
+        return context.hasFeature(NodeValidationVisitor.Feature.ALLOW_CONSTRAINT_ERRORS)
                 ? Severity.WARNING : Severity.ERROR;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/PatternTraitPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/PatternTraitPlugin.java
@@ -19,6 +19,8 @@ import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.PatternTrait;
+import software.amazon.smithy.model.validation.NodeValidationVisitor;
+import software.amazon.smithy.model.validation.Severity;
 
 /**
  * Validates the pattern trait on string shapes or members that target them.
@@ -32,9 +34,15 @@ final class PatternTraitPlugin extends MemberAndShapeTraitPlugin<StringShape, St
     @Override
     protected void check(Shape shape, PatternTrait trait, StringNode node, Context context, Emitter emitter) {
         if (!trait.getPattern().matcher(node.getValue()).find()) {
-            emitter.accept(node, String.format(
+            emitter.accept(node, getSeverity(context), String.format(
                     "String value provided for `%s` must match regular expression: %s",
                     shape.getId(), trait.getPattern().pattern()));
         }
+    }
+
+
+    private Severity getSeverity(Context context) {
+        return context.hasFeature(NodeValidationVisitor.Feature.PATTERN_TRAIT_WARNING)
+                ? Severity.WARNING : Severity.ERROR;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/PatternTraitPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/PatternTraitPlugin.java
@@ -42,7 +42,7 @@ final class PatternTraitPlugin extends MemberAndShapeTraitPlugin<StringShape, St
 
 
     private Severity getSeverity(Context context) {
-        return context.hasFeature(NodeValidationVisitor.Feature.PATTERN_TRAIT_WARNING)
+        return context.hasFeature(NodeValidationVisitor.Feature.DISABLE_CONSTRAINTS)
                 ? Severity.WARNING : Severity.ERROR;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/RangeTraitPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/RangeTraitPlugin.java
@@ -36,33 +36,32 @@ class RangeTraitPlugin implements NodeValidatorPlugin {
     public final void apply(Shape shape, Node value, Context context, Emitter emitter) {
         if (shape.hasTrait(RangeTrait.class)) {
             if (value.isNumberNode()) {
-                boolean zeroValueWarning = context
-                        .hasFeature(NodeValidationVisitor.Feature.RANGE_TRAIT_ZERO_VALUE_WARNING);
-                check(shape, zeroValueWarning, shape.expectTrait(RangeTrait.class), value.expectNumberNode(), emitter);
+                check(shape, context, shape.expectTrait(RangeTrait.class), value.expectNumberNode(), emitter);
             } else if (value.isStringNode()) {
-                checkNonNumeric(shape, shape.expectTrait(RangeTrait.class), value.expectStringNode(), emitter);
+                checkNonNumeric(shape, shape.expectTrait(RangeTrait.class), value.expectStringNode(), emitter,
+                        context);
             }
         }
     }
 
-    private void checkNonNumeric(Shape shape, RangeTrait trait, StringNode node, Emitter emitter) {
+    private void checkNonNumeric(Shape shape, RangeTrait trait, StringNode node, Emitter emitter, Context context) {
         NonNumericFloat.fromStringRepresentation(node.getValue()).ifPresent(value -> {
             if (value.equals(NonNumericFloat.NAN)) {
-                emitter.accept(node, Severity.ERROR, String.format(
+                emitter.accept(node, getSeverity(context), String.format(
                         "Value provided for `%s` must be a number because the `smithy.api#range` trait is applied, "
                                 + "but found \"%s\"",
                         shape.getId(), node.getValue()));
             }
 
             if (trait.getMin().isPresent() && value.equals(NonNumericFloat.NEGATIVE_INFINITY)) {
-                emitter.accept(node, Severity.ERROR, String.format(
+                emitter.accept(node, getSeverity(context), String.format(
                         "Value provided for `%s` must be greater than or equal to %s, but found \"%s\"",
                         shape.getId(), trait.getMin().get(), node.getValue()),
                         shape.isMemberShape() ? MEMBER : TARGET);
             }
 
             if (trait.getMax().isPresent() && value.equals(NonNumericFloat.POSITIVE_INFINITY)) {
-                emitter.accept(node, Severity.ERROR, String.format(
+                emitter.accept(node, getSeverity(context), String.format(
                         "Value provided for `%s` must be less than or equal to %s, but found \"%s\"",
                         shape.getId(), trait.getMax().get(), node.getValue()),
                         shape.isMemberShape() ? MEMBER : TARGET);
@@ -70,7 +69,7 @@ class RangeTraitPlugin implements NodeValidatorPlugin {
         });
     }
 
-    protected void check(Shape shape, boolean zeroValueWarning, RangeTrait trait, NumberNode node, Emitter emitter) {
+    protected void check(Shape shape, Context context, RangeTrait trait, NumberNode node, Emitter emitter) {
         Number number = node.getValue();
         BigDecimal decimal = number instanceof BigDecimal
                 ? (BigDecimal) number
@@ -78,7 +77,7 @@ class RangeTraitPlugin implements NodeValidatorPlugin {
 
         trait.getMin().ifPresent(min -> {
             if (decimal.compareTo(new BigDecimal(min.toString())) < 0) {
-                emitter.accept(node, getSeverity(node, zeroValueWarning), String.format(
+                emitter.accept(node, getSeverity(node, context), String.format(
                         "Value provided for `%s` must be greater than or equal to %s, but found %s",
                         shape.getId(), min, number),
                         shape.isMemberShape() ? MEMBER : TARGET);
@@ -87,7 +86,7 @@ class RangeTraitPlugin implements NodeValidatorPlugin {
 
         trait.getMax().ifPresent(max -> {
             if (decimal.compareTo(new BigDecimal(max.toString())) > 0) {
-                emitter.accept(node, getSeverity(node, zeroValueWarning), String.format(
+                emitter.accept(node, getSeverity(node, context), String.format(
                         "Value provided for `%s` must be less than or equal to %s, but found %s",
                         shape.getId(), max, number),
                         shape.isMemberShape() ? MEMBER : TARGET);
@@ -95,7 +94,15 @@ class RangeTraitPlugin implements NodeValidatorPlugin {
         });
     }
 
-    private Severity getSeverity(NumberNode node, boolean zeroValueWarning) {
-        return zeroValueWarning && node.isZero() ? Severity.WARNING : Severity.ERROR;
+    private Severity getSeverity(NumberNode node, Context context) {
+        boolean zeroValueWarning = context
+                .hasFeature(NodeValidationVisitor.Feature.RANGE_TRAIT_ZERO_VALUE_WARNING);
+        boolean rangeTraitWarning = context.hasFeature(NodeValidationVisitor.Feature.RANGE_TRAIT_WARNING);
+        return (zeroValueWarning && node.isZero()) || rangeTraitWarning ? Severity.WARNING : Severity.ERROR;
+    }
+
+    private Severity getSeverity(Context context) {
+        return context.hasFeature(NodeValidationVisitor.Feature.RANGE_TRAIT_WARNING)
+                ? Severity.WARNING : Severity.ERROR;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/RangeTraitPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/RangeTraitPlugin.java
@@ -97,12 +97,12 @@ class RangeTraitPlugin implements NodeValidatorPlugin {
     private Severity getSeverity(NumberNode node, Context context) {
         boolean zeroValueWarning = context
                 .hasFeature(NodeValidationVisitor.Feature.RANGE_TRAIT_ZERO_VALUE_WARNING);
-        boolean rangeTraitWarning = context.hasFeature(NodeValidationVisitor.Feature.RANGE_TRAIT_WARNING);
+        boolean rangeTraitWarning = context.hasFeature(NodeValidationVisitor.Feature.DISABLE_CONSTRAINTS);
         return (zeroValueWarning && node.isZero()) || rangeTraitWarning ? Severity.WARNING : Severity.ERROR;
     }
 
     private Severity getSeverity(Context context) {
-        return context.hasFeature(NodeValidationVisitor.Feature.RANGE_TRAIT_WARNING)
+        return context.hasFeature(NodeValidationVisitor.Feature.DISABLE_CONSTRAINTS)
                 ? Severity.WARNING : Severity.ERROR;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/RangeTraitPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/RangeTraitPlugin.java
@@ -97,12 +97,12 @@ class RangeTraitPlugin implements NodeValidatorPlugin {
     private Severity getSeverity(NumberNode node, Context context) {
         boolean zeroValueWarning = context
                 .hasFeature(NodeValidationVisitor.Feature.RANGE_TRAIT_ZERO_VALUE_WARNING);
-        boolean rangeTraitWarning = context.hasFeature(NodeValidationVisitor.Feature.DISABLE_CONSTRAINTS);
+        boolean rangeTraitWarning = context.hasFeature(NodeValidationVisitor.Feature.ALLOW_CONSTRAINT_ERRORS);
         return (zeroValueWarning && node.isZero()) || rangeTraitWarning ? Severity.WARNING : Severity.ERROR;
     }
 
     private Severity getSeverity(Context context) {
-        return context.hasFeature(NodeValidationVisitor.Feature.DISABLE_CONSTRAINTS)
+        return context.hasFeature(NodeValidationVisitor.Feature.ALLOW_CONSTRAINT_ERRORS)
                 ? Severity.WARNING : Severity.ERROR;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/StringLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/StringLengthPlugin.java
@@ -51,7 +51,7 @@ final class StringLengthPlugin extends MemberAndShapeTraitPlugin<StringShape, St
     }
 
     private Severity getSeverity(Context context) {
-        return context.hasFeature(NodeValidationVisitor.Feature.STRING_LENGTH_WARNING)
+        return context.hasFeature(NodeValidationVisitor.Feature.DISABLE_CONSTRAINTS)
                 ? Severity.WARNING : Severity.ERROR;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/StringLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/StringLengthPlugin.java
@@ -19,6 +19,8 @@ import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.LengthTrait;
+import software.amazon.smithy.model.validation.NodeValidationVisitor;
+import software.amazon.smithy.model.validation.Severity;
 
 /**
  * Validates the length trait on string shapes or members that target them.
@@ -33,7 +35,7 @@ final class StringLengthPlugin extends MemberAndShapeTraitPlugin<StringShape, St
     protected void check(Shape shape, LengthTrait trait, StringNode node, Context context, Emitter emitter) {
         trait.getMin().ifPresent(min -> {
             if (node.getValue().length() < min) {
-                emitter.accept(node, String.format(
+                emitter.accept(node, getSeverity(context), String.format(
                         "String value provided for `%s` must be >= %d characters, but the provided value is "
                         + "only %d characters.", shape.getId(), min, node.getValue().length()));
             }
@@ -41,10 +43,15 @@ final class StringLengthPlugin extends MemberAndShapeTraitPlugin<StringShape, St
 
         trait.getMax().ifPresent(max -> {
             if (node.getValue().length() > max) {
-                emitter.accept(node, String.format(
+                emitter.accept(node, getSeverity(context), String.format(
                         "String value provided for `%s` must be <= %d characters, but the provided value is "
                         + "%d characters.", shape.getId(), max, node.getValue().length()));
             }
         });
+    }
+
+    private Severity getSeverity(Context context) {
+        return context.hasFeature(NodeValidationVisitor.Feature.STRING_LENGTH_WARNING)
+                ? Severity.WARNING : Severity.ERROR;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/StringLengthPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/StringLengthPlugin.java
@@ -51,7 +51,7 @@ final class StringLengthPlugin extends MemberAndShapeTraitPlugin<StringShape, St
     }
 
     private Severity getSeverity(Context context) {
-        return context.hasFeature(NodeValidationVisitor.Feature.DISABLE_CONSTRAINTS)
+        return context.hasFeature(NodeValidationVisitor.Feature.ALLOW_CONSTRAINT_ERRORS)
                 ? Severity.WARNING : Severity.ERROR;
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ExamplesTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ExamplesTraitValidator.java
@@ -15,18 +15,9 @@
 
 package software.amazon.smithy.model.validation.validators;
 
-import static software.amazon.smithy.model.validation.NodeValidationVisitor.Feature.BLOB_LENGTH_WARNING;
-import static software.amazon.smithy.model.validation.NodeValidationVisitor.Feature.MAP_LENGTH_WARNING;
-import static software.amazon.smithy.model.validation.NodeValidationVisitor.Feature.PATTERN_TRAIT_WARNING;
-import static software.amazon.smithy.model.validation.NodeValidationVisitor.Feature.RANGE_TRAIT_WARNING;
-import static software.amazon.smithy.model.validation.NodeValidationVisitor.Feature.REQUIRED_TRAIT_WARNING;
-import static software.amazon.smithy.model.validation.NodeValidationVisitor.Feature.STRING_LENGTH_WARNING;
-
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -40,14 +31,6 @@ import software.amazon.smithy.model.validation.ValidationEvent;
  * Validates that examples traits are valid for their operations.
  */
 public final class ExamplesTraitValidator extends AbstractValidator {
-
-    private static final Set<NodeValidationVisitor.Feature> ALLOWED_FEATURES = EnumSet.of(
-            BLOB_LENGTH_WARNING,
-            MAP_LENGTH_WARNING,
-            PATTERN_TRAIT_WARNING,
-            RANGE_TRAIT_WARNING,
-            REQUIRED_TRAIT_WARNING,
-            STRING_LENGTH_WARNING);
 
     @Override
     public List<ValidationEvent> validate(Model model) {
@@ -69,16 +52,12 @@ public final class ExamplesTraitValidator extends AbstractValidator {
 
             model.getShape(shape.getInputShape()).ifPresent(input -> {
                 NodeValidationVisitor validator;
-                if (!example.getLowerInputValidationSeverity().isEmpty()) {
-                    if (!isErrorDefined) {
-                        events.add(error(shape, trait, String.format(
-                            "Example: `%s` has lowerInputValidationSeverity defined, so error must also be defined.",
+                if (example.getDisableConstraints() && !isErrorDefined) {
+                    events.add(error(shape, trait, String.format(
+                            "Example: `%s` has disableConstraints enabled, so error must be defined.",
                             example.getTitle())));
-                    }
-                    validator = createVisitor("input", example.getInput(), model, shape, example, true);
-                } else {
-                    validator = createVisitor("input", example.getInput(), model, shape, example, false);
                 }
+                validator = createVisitor("input", example.getInput(), model, shape, example);
                 List<ValidationEvent> inputValidationEvents = input.accept(validator);
                 events.addAll(inputValidationEvents);
             });
@@ -90,7 +69,7 @@ public final class ExamplesTraitValidator extends AbstractValidator {
             } else if (isOutputDefined) {
                 model.getShape(shape.getOutputShape()).ifPresent(output -> {
                     NodeValidationVisitor validator = createVisitor(
-                            "output", example.getOutput().get(), model, shape, example, false);
+                            "output", example.getOutput().get(), model, shape, example);
                     events.addAll(output.accept(validator));
                 });
             } else if (isErrorDefined) {
@@ -98,7 +77,7 @@ public final class ExamplesTraitValidator extends AbstractValidator {
                 Optional<Shape> errorShape = model.getShape(errorExample.getShapeId());
                 if (errorShape.isPresent() && shape.getErrors().contains(errorExample.getShapeId())) {
                     NodeValidationVisitor validator = createVisitor(
-                            "error", errorExample.getContent(), model, shape, example, false);
+                            "error", errorExample.getContent(), model, shape, example);
                     events.addAll(errorShape.get().accept(validator));
                 } else {
                     events.add(error(shape, trait, String.format(
@@ -116,8 +95,7 @@ public final class ExamplesTraitValidator extends AbstractValidator {
             ObjectNode value,
             Model model,
             Shape shape,
-            ExamplesTrait.Example example,
-            boolean enableFeatures
+            ExamplesTrait.Example example
     ) {
         NodeValidationVisitor.Builder builder = NodeValidationVisitor.builder()
                 .model(model)
@@ -125,10 +103,8 @@ public final class ExamplesTraitValidator extends AbstractValidator {
                 .value(value)
                 .startingContext("Example " + name + " of `" + example.getTitle() + "`")
                 .eventId(getName());
-        if (enableFeatures) {
-            example.getLowerInputValidationSeverity().stream()
-                    .filter(ALLOWED_FEATURES::contains)
-                    .forEach(builder::addFeature);
+        if (example.getDisableConstraints()) {
+            builder.addFeature(NodeValidationVisitor.Feature.DISABLE_CONSTRAINTS);
         }
         return builder.build();
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ExamplesTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ExamplesTraitValidator.java
@@ -69,8 +69,7 @@ public final class ExamplesTraitValidator extends AbstractValidator {
 
             model.getShape(shape.getInputShape()).ifPresent(input -> {
                 NodeValidationVisitor validator;
-                if (example.getLowerInputValidationSeverity().isPresent()
-                        && !example.getLowerInputValidationSeverity().get().isEmpty()) {
+                if (!example.getLowerInputValidationSeverity().isEmpty()) {
                     if (!isErrorDefined) {
                         events.add(error(shape, trait, String.format(
                             "Example: `%s` has lowerInputValidationSeverity defined, so error must also be defined.",
@@ -127,9 +126,9 @@ public final class ExamplesTraitValidator extends AbstractValidator {
                 .startingContext("Example " + name + " of `" + example.getTitle() + "`")
                 .eventId(getName());
         if (enableFeatures) {
-            example.getLowerInputValidationSeverity().ifPresent(features -> features.stream()
+            example.getLowerInputValidationSeverity().stream()
                     .filter(ALLOWED_FEATURES::contains)
-                    .forEach(builder::addFeature));
+                    .forEach(builder::addFeature);
         }
         return builder.build();
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ExamplesTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ExamplesTraitValidator.java
@@ -52,9 +52,9 @@ public final class ExamplesTraitValidator extends AbstractValidator {
 
             model.getShape(shape.getInputShape()).ifPresent(input -> {
                 NodeValidationVisitor validator;
-                if (example.getDisableConstraints() && !isErrorDefined) {
+                if (example.getAllowConstraintErrors() && !isErrorDefined) {
                     events.add(error(shape, trait, String.format(
-                            "Example: `%s` has disableConstraints enabled, so error must be defined.",
+                            "Example: `%s` has allowConstraintErrors enabled, so error must be defined.",
                             example.getTitle())));
                 }
                 validator = createVisitor("input", example.getInput(), model, shape, example);
@@ -103,8 +103,8 @@ public final class ExamplesTraitValidator extends AbstractValidator {
                 .value(value)
                 .startingContext("Example " + name + " of `" + example.getTitle() + "`")
                 .eventId(getName());
-        if (example.getDisableConstraints()) {
-            builder.addFeature(NodeValidationVisitor.Feature.DISABLE_CONSTRAINTS);
+        if (example.getAllowConstraintErrors()) {
+            builder.addFeature(NodeValidationVisitor.Feature.ALLOW_CONSTRAINT_ERRORS);
         }
         return builder.build();
     }

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -364,7 +364,7 @@ structure Example {
 
     error: ExampleError
 
-    disableConstraints: Boolean
+    allowConstraintErrors: Boolean
 }
 
 @private

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -364,7 +364,7 @@ structure Example {
 
     error: ExampleError
 
-    lowerInputValidationSeverity: NonEmptyStringList
+    disableConstraints: Boolean
 }
 
 @private

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -363,6 +363,8 @@ structure Example {
     output: Document
 
     error: ExampleError
+
+    lowerInputValidationSeverity: NonEmptyStringList
 }
 
 @private

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/ExamplesTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/ExamplesTraitTest.java
@@ -25,11 +25,14 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.validation.NodeValidationVisitor;
 
 public class ExamplesTraitTest {
     @Test
     public void loadsTrait() {
         TraitFactory provider = TraitFactory.createServiceFactory();
+        ArrayNode lowerInputValidationSeverity = Node.fromStrings(
+                NodeValidationVisitor.Feature.REQUIRED_TRAIT_WARNING.name() );
         ArrayNode node = Node.arrayNode(
                 Node.objectNode()
                         .withMember("title", Node.from("foo")),
@@ -40,7 +43,8 @@ public class ExamplesTraitTest {
                         .withMember("output", Node.objectNode().withMember("c", Node.from("d")))
                         .withMember("error", Node.objectNode()
                                 .withMember(Node.from("shapeId"), Node.from("smithy.example#FooError"))
-                                .withMember(Node.from("content"), Node.objectNode().withMember("e", Node.from("f")))));
+                                .withMember(Node.from("content"), Node.objectNode().withMember("e", Node.from("f"))))
+                        .withMember("lowerInputValidationSeverity", lowerInputValidationSeverity));
 
         Optional<Trait> trait = provider.createTrait(
                 ShapeId.from("smithy.api#examples"), ShapeId.from("ns.qux#foo"), node);

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/ExamplesTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/ExamplesTraitTest.java
@@ -41,7 +41,7 @@ public class ExamplesTraitTest {
                         .withMember("error", Node.objectNode()
                                 .withMember(Node.from("shapeId"), Node.from("smithy.example#FooError"))
                                 .withMember(Node.from("content"), Node.objectNode().withMember("e", Node.from("f"))))
-                        .withMember("disableConstraints", Node.from(true)));
+                        .withMember("allowConstraintErrors", Node.from(true)));
 
         Optional<Trait> trait = provider.createTrait(
                 ShapeId.from("smithy.api#examples"), ShapeId.from("ns.qux#foo"), node);

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/ExamplesTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/ExamplesTraitTest.java
@@ -25,14 +25,11 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.validation.NodeValidationVisitor;
 
 public class ExamplesTraitTest {
     @Test
     public void loadsTrait() {
         TraitFactory provider = TraitFactory.createServiceFactory();
-        ArrayNode lowerInputValidationSeverity = Node.fromStrings(
-                NodeValidationVisitor.Feature.REQUIRED_TRAIT_WARNING.name() );
         ArrayNode node = Node.arrayNode(
                 Node.objectNode()
                         .withMember("title", Node.from("foo")),
@@ -44,7 +41,7 @@ public class ExamplesTraitTest {
                         .withMember("error", Node.objectNode()
                                 .withMember(Node.from("shapeId"), Node.from("smithy.example#FooError"))
                                 .withMember(Node.from("content"), Node.objectNode().withMember("e", Node.from("f"))))
-                        .withMember("lowerInputValidationSeverity", lowerInputValidationSeverity));
+                        .withMember("disableConstraints", Node.from(true)));
 
         Optional<Trait> trait = provider.createTrait(
                 ShapeId.from("smithy.api#examples"), ShapeId.from("ns.qux#foo"), node);

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/ExamplesTraitValidatorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/ExamplesTraitValidatorTest.java
@@ -1,11 +1,16 @@
 package software.amazon.smithy.model.validation;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.ExamplesTrait;
 import software.amazon.smithy.model.validation.validators.ExamplesTraitValidator;
+import software.amazon.smithy.utils.ListUtils;
 
 public class ExamplesTraitValidatorTest {
     // There was an NPE previously due to the input/output values

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.errors
@@ -6,3 +6,17 @@
 [WARNING] ns.foo#Operation: Example output of `Testing 2`: Invalid structure member `additional` found for `ns.foo#OperationOutput` | ExamplesTrait
 [ERROR] ns.foo#Operation: Example output of `Testing 2`: Missing required structure member `bam` for `ns.foo#OperationOutput` | ExamplesTrait
 [WARNING] ns.foo#Operation: Example error of `Testing 1`: Invalid structure member `extra` found for `ns.foo#OperationError` | ExamplesTrait
+[ERROR] ns.foo#Operation: Example: `Testing 4` has lowerInputValidationSeverity defined, so error must also be defined. | ExamplesTrait
+[WARNING] ns.foo#Operation: Example input of `Testing 5`.blobMin: Value provided for `ns.foo#OperationInput$blobMin` must have at least 3 bytes, but the provided value only has 1 bytes | ExamplesTrait
+[WARNING] ns.foo#Operation: Example input of `Testing 5`.blobMax: Value provided for `ns.foo#OperationInput$blobMax` must have no more than 3 bytes, but the provided value has 6 bytes | ExamplesTrait
+[WARNING] ns.foo#Operation: Example input of `Testing 5`: Missing required structure member `foo` for `ns.foo#OperationInput` | ExamplesTrait
+[WARNING] ns.foo#Operation: Example input of `Testing 5`.mapMin: Value provided for `ns.foo#OperationInput$mapMin` must have at least 3 entries, but the provided value only has 1 entries | ExamplesTrait
+[WARNING] ns.foo#Operation: Example input of `Testing 5`.mapMax: Value provided for `ns.foo#OperationInput$mapMax` must have no more than 1 entries, but the provided value has 2 entries | ExamplesTrait
+[WARNING] ns.foo#Operation: Example input of `Testing 5`.pattern: String value provided for `ns.foo#OperationInput$pattern` must match regular expression: ^[a-z]$ | ExamplesTrait
+[WARNING] ns.foo#Operation: Example input of `Testing 5`.rangeMin: Value provided for `ns.foo#OperationInput$rangeMin` must be greater than or equal to 2, but found 1 | ExamplesTrait.Member
+[WARNING] ns.foo#Operation: Example input of `Testing 5`.rangeMax: Value provided for `ns.foo#OperationInput$rangeMax` must be less than or equal to 8, but found 10 | ExamplesTrait.Member
+[WARNING] ns.foo#Operation: Example input of `Testing 5`.rangeNaN: Value provided for `ns.foo#OperationInput$rangeNaN` must be a number because the `smithy.api#range` trait is applied, but found "NaN" | ExamplesTrait
+[WARNING] ns.foo#Operation: Example input of `Testing 5`.rangeNegativeInfinity: Value provided for `ns.foo#OperationInput$rangeNegativeInfinity` must be greater than or equal to 1, but found "-Infinity" | ExamplesTrait.Member
+[WARNING] ns.foo#Operation: Example input of `Testing 5`.rangePositiveInfinity: Value provided for `ns.foo#OperationInput$rangePositiveInfinity` must be less than or equal to 2, but found "Infinity" | ExamplesTrait.Member
+[WARNING] ns.foo#Operation: Example input of `Testing 5`.stringMin: String value provided for `ns.foo#OperationInput$stringMin` must be >= 3 characters, but the provided value is only 1 characters. | ExamplesTrait
+[WARNING] ns.foo#Operation: Example input of `Testing 5`.stringMax: String value provided for `ns.foo#OperationInput$stringMax` must be <= 3 characters, but the provided value is 6 characters. | ExamplesTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.errors
@@ -6,7 +6,7 @@
 [WARNING] ns.foo#Operation: Example output of `Testing 2`: Invalid structure member `additional` found for `ns.foo#OperationOutput` | ExamplesTrait
 [ERROR] ns.foo#Operation: Example output of `Testing 2`: Missing required structure member `bam` for `ns.foo#OperationOutput` | ExamplesTrait
 [WARNING] ns.foo#Operation: Example error of `Testing 1`: Invalid structure member `extra` found for `ns.foo#OperationError` | ExamplesTrait
-[ERROR] ns.foo#Operation: Example: `Testing 4` has lowerInputValidationSeverity defined, so error must also be defined. | ExamplesTrait
+[ERROR] ns.foo#Operation: Example: `Testing 4` has disableConstraints enabled, so error must be defined. | ExamplesTrait
 [WARNING] ns.foo#Operation: Example input of `Testing 5`.blobMin: Value provided for `ns.foo#OperationInput$blobMin` must have at least 3 bytes, but the provided value only has 1 bytes | ExamplesTrait
 [WARNING] ns.foo#Operation: Example input of `Testing 5`.blobMax: Value provided for `ns.foo#OperationInput$blobMax` must have no more than 3 bytes, but the provided value has 6 bytes | ExamplesTrait
 [WARNING] ns.foo#Operation: Example input of `Testing 5`: Missing required structure member `foo` for `ns.foo#OperationInput` | ExamplesTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.errors
@@ -6,7 +6,7 @@
 [WARNING] ns.foo#Operation: Example output of `Testing 2`: Invalid structure member `additional` found for `ns.foo#OperationOutput` | ExamplesTrait
 [ERROR] ns.foo#Operation: Example output of `Testing 2`: Missing required structure member `bam` for `ns.foo#OperationOutput` | ExamplesTrait
 [WARNING] ns.foo#Operation: Example error of `Testing 1`: Invalid structure member `extra` found for `ns.foo#OperationError` | ExamplesTrait
-[ERROR] ns.foo#Operation: Example: `Testing 4` has disableConstraints enabled, so error must be defined. | ExamplesTrait
+[ERROR] ns.foo#Operation: Example: `Testing 4` has allowConstraintErrors enabled, so error must be defined. | ExamplesTrait
 [WARNING] ns.foo#Operation: Example input of `Testing 5`.blobMin: Value provided for `ns.foo#OperationInput$blobMin` must have at least 3 bytes, but the provided value only has 1 bytes | ExamplesTrait
 [WARNING] ns.foo#Operation: Example input of `Testing 5`.blobMax: Value provided for `ns.foo#OperationInput$blobMax` must have no more than 3 bytes, but the provided value has 6 bytes | ExamplesTrait
 [WARNING] ns.foo#Operation: Example input of `Testing 5`: Missing required structure member `foo` for `ns.foo#OperationInput` | ExamplesTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.json
@@ -62,9 +62,7 @@
                         "output": {
                             "bam": "value3"
                         },
-                        "lowerInputValidationSeverity": [
-                            "REQUIRED_TRAIT_WARNING"
-                        ]
+                        "disableConstraints": true
                     },
                     {
                         "title": "Testing 5",
@@ -93,14 +91,7 @@
                                 "bat": "baz"
                             }
                         },
-                        "lowerInputValidationSeverity": [
-                            "BLOB_LENGTH_WARNING",
-                            "MAP_LENGTH_WARNING",
-                            "PATTERN_TRAIT_WARNING",
-                            "RANGE_TRAIT_WARNING",
-                            "REQUIRED_TRAIT_WARNING",
-                            "STRING_LENGTH_WARNING"
-                        ]
+                        "disableConstraints": true
                     }
                 ]
             }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.json
@@ -53,6 +53,54 @@
                                 "bat": "baz"
                             }
                         }
+                    },
+                    {
+                        "title": "Testing 4",
+                        "input": {
+                            "foo": "baz"
+                        },
+                        "output": {
+                            "bam": "value3"
+                        },
+                        "lowerInputValidationSeverity": [
+                            "REQUIRED_TRAIT_WARNING"
+                        ]
+                    },
+                    {
+                        "title": "Testing 5",
+                        "input": {
+                            "blobMin": "a",
+                            "blobMax": "abcdef",
+                            "mapMin": {
+                                "a": "b"
+                            },
+                            "mapMax": {
+                                "a": "b",
+                                "b": "c"
+                            },
+                            "pattern": "123",
+                            "rangeMin": 1,
+                            "rangeMax": 10,
+                            "rangeNaN": "NaN",
+                            "rangeNegativeInfinity": "-Infinity",
+                            "rangePositiveInfinity": "Infinity",
+                            "stringMin": "a",
+                            "stringMax": "abcdef"
+                        },
+                        "error": {
+                            "shapeId": "ns.foo#OperationError",
+                            "content": {
+                                "bat": "baz"
+                            }
+                        },
+                        "lowerInputValidationSeverity": [
+                            "BLOB_LENGTH_WARNING",
+                            "MAP_LENGTH_WARNING",
+                            "PATTERN_TRAIT_WARNING",
+                            "RANGE_TRAIT_WARNING",
+                            "REQUIRED_TRAIT_WARNING",
+                            "STRING_LENGTH_WARNING"
+                        ]
                     }
                 ]
             }
@@ -79,6 +127,101 @@
                 },
                 "baz": {
                     "target": "ns.foo#String"
+                },
+                "blobMin": {
+                    "target": "ns.foo#Blob",
+                    "traits": {
+                        "smithy.api#length": {
+                            "min": 3
+                        }
+                    }
+                },
+                "blobMax": {
+                    "target": "ns.foo#Blob",
+                    "traits": {
+                        "smithy.api#length": {
+                            "max": 3
+                        }
+                    }
+                },
+                "mapMin": {
+                    "target": "ns.foo#Map",
+                    "traits": {
+                        "smithy.api#length": {
+                            "min": 3
+                        }
+                    }
+                },
+                "mapMax": {
+                    "target": "ns.foo#Map",
+                    "traits": {
+                        "smithy.api#length": {
+                            "max": 1
+                        }
+                    }
+                },
+                "pattern": {
+                    "target": "ns.foo#String",
+                    "traits": {
+                        "smithy.api#pattern": "^[a-z]$"
+                    }
+                },
+                "rangeMin": {
+                    "target": "ns.foo#Integer",
+                    "traits": {
+                        "smithy.api#range": {
+                            "min": 2
+                        }
+                    }
+                },
+                "rangeMax": {
+                    "target": "ns.foo#Integer",
+                    "traits": {
+                        "smithy.api#range": {
+                            "max": 8
+                        }
+                    }
+                },
+                "rangeNaN": {
+                    "target": "ns.foo#Float",
+                    "traits": {
+                        "smithy.api#range": {
+                            "min": 1,
+                            "max": 2
+                        }
+                    }
+                },
+                "rangeNegativeInfinity": {
+                    "target": "ns.foo#Float",
+                    "traits": {
+                        "smithy.api#range": {
+                            "min": 1
+                        }
+                    }
+                },
+                "rangePositiveInfinity": {
+                    "target": "ns.foo#Float",
+                    "traits": {
+                        "smithy.api#range": {
+                            "max": 2
+                        }
+                    }
+                },
+                "stringMin": {
+                    "target": "ns.foo#String",
+                    "traits": {
+                        "smithy.api#length": {
+                            "min": 3
+                        }
+                    }
+                },
+                "stringMax": {
+                    "target": "ns.foo#String",
+                    "traits": {
+                        "smithy.api#length": {
+                            "max": 3
+                        }
+                    }
                 }
             },
             "traits": {
@@ -127,6 +270,24 @@
         },
         "ns.foo#String": {
             "type": "string"
+        },
+        "ns.foo#Blob": {
+            "type": "blob"
+        },
+        "ns.foo#Map": {
+            "type": "map",
+            "key": {
+                "target": "smithy.api#String"
+            },
+            "value": {
+                "target": "smithy.api#String"
+            }
+        },
+        "ns.foo#Integer": {
+            "type": "integer"
+        },
+        "ns.foo#Float": {
+            "type": "float"
         }
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-validator.json
@@ -62,7 +62,7 @@
                         "output": {
                             "bam": "value3"
                         },
-                        "disableConstraints": true
+                        "allowConstraintErrors": true
                     },
                     {
                         "title": "Testing 5",
@@ -91,7 +91,7 @@
                                 "bat": "baz"
                             }
                         },
-                        "disableConstraints": true
+                        "allowConstraintErrors": true
                     }
                 ]
             }


### PR DESCRIPTION
This PR adds a `disableConstraints` boolean to the @examples trait, allowing for input constraint trait validations to be lowered from `ERROR` to `WARNING`.

By lowering the severity from an `ERROR`, Smithy model authors can include examples of invalid inputs and their corresponding errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
