### PR TITLE
Add short --aut for --allow-unknown-traits

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/BuildOptions.java
@@ -29,6 +29,7 @@ import software.amazon.smithy.cli.HelpPrinter;
 final class BuildOptions implements ArgumentReceiver {
 
     static final String ALLOW_UNKNOWN_TRAITS = "--allow-unknown-traits";
+    static final String ALLOW_UNKNOWN_TRAITS_SHORT = "--aut";
     static final String MODELS = "<MODELS>";
 
     private boolean allowUnknownTraits;
@@ -37,7 +38,8 @@ final class BuildOptions implements ArgumentReceiver {
 
     @Override
     public void registerHelp(HelpPrinter printer) {
-        printer.option(ALLOW_UNKNOWN_TRAITS, null, "Ignore unknown traits when validating models.");
+        printer.option(ALLOW_UNKNOWN_TRAITS, ALLOW_UNKNOWN_TRAITS_SHORT,
+                       "Ignore unknown traits when validating models.");
         printer.param("--output", null, "OUTPUT_PATH",
                       "Where to write Smithy artifacts, caches, and other files (defaults to './build/smithy').");
 
@@ -48,7 +50,7 @@ final class BuildOptions implements ArgumentReceiver {
 
     @Override
     public boolean testOption(String name) {
-        if (ALLOW_UNKNOWN_TRAITS.equals(name)) {
+        if (ALLOW_UNKNOWN_TRAITS.equals(name) || ALLOW_UNKNOWN_TRAITS_SHORT.equalsIgnoreCase(name)) {
             allowUnknownTraits = true;
             return true;
         }

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/BuildCommandTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/BuildCommandTest.java
@@ -105,6 +105,14 @@ public class BuildCommandTest {
     }
 
     @Test
+    public void projectionUnknownTraitsAreAllowedWithShortFlag() throws Exception {
+        String config = Paths.get(getClass().getResource("projection-model-import.json").toURI()).toString();
+        CliUtils.Result result = CliUtils.runSmithy("build", "--aut",  "--config", config);
+
+        assertThat(result.code(), equalTo(0));
+    }
+
+    @Test
     public void exceptionsThrownByProjectionsAreDetected() {
         // TODO: need to make a plugin throw an exception
     }


### PR DESCRIPTION
`--allow-unknown-traits` bugs me every time I use it, so I added `--aut` as a short alias.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
