### PR TITLE
Add length trait to trait index

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,4 +24,7 @@ merge-versions:
 	cp -R "build/2.0/html" "build/html/2.0"
 	cp -R "root/" "build/html"
 
+openhtml:
+	open "build/html/index.html"
+
 .PHONY: Makefile clean

--- a/docs/source-1.0/spec/core/constraint-traits.rst
+++ b/docs/source-1.0/spec/core/constraint-traits.rst
@@ -315,6 +315,7 @@ Given the following model,
   ``smithy.example#MyShape``.
 
 
+.. smithy-trait:: smithy.api#length
 .. _length-trait:
 
 ----------------

--- a/docs/source-2.0/spec/constraint-traits.rst
+++ b/docs/source-2.0/spec/constraint-traits.rst
@@ -124,6 +124,7 @@ Given the following model,
   ``smithy.example#MyShape``.
 
 
+.. smithy-trait:: smithy.api#length
 .. _length-trait:
 
 ``length`` trait


### PR DESCRIPTION
Also adds back the `openhtml` make command, routing to the top-level index.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
