### PR TITLE
Add --show to select command

### DIFF
--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/SelectTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/SelectTest.java
@@ -31,7 +31,7 @@ public class SelectTest {
 
     @Test
     public void selectsVariables() {
-        List<String> args = Arrays.asList("select", "--show-vars", "--selector", "list $list(*) > member > string");
+        List<String> args = Arrays.asList("select", "--show", "vars", "--selector", "list $list(*) > member > string");
         IntegUtils.run("simple-config-sources", args, result -> {
             assertThat(result.getExitCode(), equalTo(0));
             String content = result.getOutput().trim();
@@ -77,6 +77,82 @@ public class SelectTest {
         List<String> args = Arrays.asList("select", "--show-traits", "documentation,", "--selector", "service");
         IntegUtils.run("simple-config-sources", args, result -> {
             assertThat(result.getExitCode(), not(equalTo(0)));
+        });
+    }
+
+    @Test
+    public void showCannotBeEmpty() {
+        List<String> args = Arrays.asList("select", "--show", "", "--selector", "string");
+        IntegUtils.run("simple-config-sources", args, result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+        });
+    }
+
+    @Test
+    public void showCannotContainInvalidValues() {
+        List<String> args = Arrays.asList("select", "--show", "foo", "--selector", "string");
+        IntegUtils.run("simple-config-sources", args, result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+        });
+    }
+
+    @Test
+    public void showCannotContainInvalidValuesInCsv() {
+        List<String> args = Arrays.asList("select", "--show", "vars,foo", "--selector", "string");
+        IntegUtils.run("simple-config-sources", args, result -> {
+            assertThat(result.getExitCode(), equalTo(1));
+        });
+    }
+
+    @Test
+    public void includesType() {
+        List<String> args = Arrays.asList("select", "--show", "type", "--selector", "string");
+        IntegUtils.run("simple-config-sources", args, result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            String content = result.getOutput().trim();
+            // Ensure it's valid JSON
+            Node.parse(content);
+            assertThat(content, containsString("\"type\": \"string\""));
+        });
+    }
+
+    @Test
+    public void includesFile() {
+        List<String> args = Arrays.asList("select", "--show", "file", "--selector", "string");
+        IntegUtils.run("simple-config-sources", args, result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            String content = result.getOutput().trim();
+            // Ensure it's valid JSON
+            Node.parse(content);
+            assertThat(content, containsString("\"file\": "));
+        });
+    }
+
+    @Test
+    public void includesFileAndType() {
+        List<String> args = Arrays.asList("select", "--show", "file, type", "--selector", "string");
+        IntegUtils.run("simple-config-sources", args, result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            String content = result.getOutput().trim();
+            // Ensure it's valid JSON
+            Node.parse(content);
+            assertThat(content, containsString("\"type\": \"string\""));
+            assertThat(content, containsString("\"file\": "));
+        });
+    }
+
+    @Test
+    public void includesFileAndTypeAndVars() {
+        List<String> args = Arrays.asList("select", "--show", "file, type,vars", "--selector", "string $hi(*)");
+        IntegUtils.run("simple-config-sources", args, result -> {
+            assertThat(result.getExitCode(), equalTo(0));
+            String content = result.getOutput().trim();
+            // Ensure it's valid JSON
+            Node.parse(content);
+            assertThat(content, containsString("\"type\": \"string\""));
+            assertThat(content, containsString("\"file\": "));
+            assertThat(content, containsString("\"vars\": "));
+            assertThat(content, containsString("\"hi\": "));
         });
     }
 }

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/SelectCommandTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/commands/SelectCommandTest.java
@@ -57,7 +57,7 @@ public class SelectCommandTest {
     public void printsJsonVarsToStdout() throws Exception {
         String model = Paths.get(getClass().getResource("valid-model.smithy").toURI()).toString();
         CliUtils.Result result = CliUtils.runSmithy("select", "--selector", "string $referenceMe(<)",
-                                                    "--show-vars", model);
+                                                    "--show", "vars", model);
 
         assertThat(result.code(), equalTo(0));
         validateSelectorOutput(result.stdout());
@@ -81,7 +81,7 @@ public class SelectCommandTest {
         try {
             // Send the selector through input stream.
             System.setIn(new ByteArrayInputStream("string $referenceMe(<)".getBytes()));
-            CliUtils.Result result = CliUtils.runSmithy("select", "--show-vars", model);
+            CliUtils.Result result = CliUtils.runSmithy("select", "--show", "vars", model);
 
             assertThat(result.code(), equalTo(0));
             validateSelectorOutput(result.stdout());


### PR DESCRIPTION
--show is used to include additional data in select command output, including the shape type, file where the shape is defined, and/or variables captured when the shape was matched.

For example:

```
smithy select --selector 'structure $neighbors(>)' --show-traits documentation --show type,file,vars --aut s3.json
```

Outputs:

```
[
    {
        "shape": "com.amazonaws.s3#CSVInput",
        "type": "structure",
        "file": "/path/to/s3.json:16224:34",
        "vars": {
            "neighbors": [
                "com.amazonaws.s3#CSVInput$AllowQuotedRecordDelimiter",
                "com.amazonaws.s3#CSVInput$Comments",
                "com.amazonaws.s3#CSVInput$FieldDelimiter",
                "com.amazonaws.s3#CSVInput$FileHeaderInfo",
                "com.amazonaws.s3#CSVInput$QuoteCharacter",
                "com.amazonaws.s3#CSVInput$QuoteEscapeCharacter",
                "com.amazonaws.s3#CSVInput$RecordDelimiter"
            ]
        },
        "traits": {
            "smithy.api#documentation": "<p>Describes how an uncompressed comma-separated values (CSV)-formatted input object is formatted.</p>"
        }
    }
]
```

This now deprecates the `--show-vars` option, as `--show vars` should be used instead.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
