### PR TITLE
Fix flaky init cache unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,10 +53,11 @@ subprojects {
     }
 
     dependencies {
-        testImplementation "org.junit.jupiter:junit-jupiter-api:5.4.0"
-        testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.4.0"
-        testImplementation "org.junit.jupiter:junit-jupiter-params:5.4.0"
+        testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"
+        testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.0"
+        testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.0"
         testImplementation "org.hamcrest:hamcrest:2.1"
+        testCompileOnly "org.apiguardian:apiguardian-api:1.1.2"
     }
 
     // Reusable license copySpec for building JARs

--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation "org.slf4j:slf4j-jdk14:1.7.36" // Route slf4j used by Maven through JUL like the rest of Smithy.
 
     testImplementation "org.mock-server:mockserver-netty:3.10.8"
+
 }
 
 // ------ Shade Maven dependency resolvers into the JAR. -------
@@ -223,7 +224,7 @@ tasks["runtime"].dependsOn("shadowJar")
 
 sourceSets {
     create("it") {
-        compileClasspath += sourceSets["main"].output + configurations["testRuntimeClasspath"]
+        compileClasspath += sourceSets["main"].output + configurations["testRuntimeClasspath"] + configurations["testCompileClasspath"]
         runtimeClasspath += output + compileClasspath + sourceSets["test"].runtimeClasspath
     }
 }
@@ -233,7 +234,11 @@ task integ(type: Test) {
     systemProperty "SMITHY_BINARY", "${smithyBinary}"
     testClassesDirs = sourceSets["it"].output.classesDirs
     classpath = sourceSets["it"].runtimeClasspath
-    maxParallelForks = Runtime.getRuntime().availableProcessors() / 2
+
+    // Configuration parameters to execute top-level classes in parallel but methods in same thread
+    systemProperties["junit.jupiter.execution.parallel.enabled"] = "true"
+    systemProperties["junit.jupiter.execution.parallel.mode.default"] = "same_thread"
+    systemProperties["junit.jupiter.execution.parallel.mode.classes.default"] = "concurrent"
 
     testLogging {
         events = ["passed", "skipped", "failed"]

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/CleanCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/CleanCommandTest.java
@@ -11,13 +11,13 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.ListUtils;
 
-
+@Isolated
 public class CleanCommandTest {
     private static final String PROJECT_NAME = "simple-config-sources";
     @Test

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/InitCommandTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.ListUtils;
 
@@ -20,6 +21,7 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 
+@Isolated
 public class InitCommandTest {
     private static final String PROJECT_NAME = "smithy-templates";
 


### PR DESCRIPTION
### Description of changes
Fixes issue where integration tests acting on the global init cache were occasionally failling. 
We correct this by ensuring that cache tests are not run in parallel with any other tests using the `@Isolated` flag. 

It is also necessary to remove the `max__ ` property and set parallelism via the JUnit test runner because gradle's forking of the test task does not respect JUnit test configurations.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
