### PR TITLE
Replace rubrics with linkable titles

### DIFF
--- a/docs/source-2.0/additional-specs/waiters.rst
+++ b/docs/source-2.0/additional-specs/waiters.rst
@@ -513,7 +513,8 @@ conversion table:
     * - union
       - object [#funion]_
 
-.. rubric:: Footnotes
+Footnotes
+~~~~~~~~~
 
 .. [#fnumbers] ``long``, ``bigInteger``, ``bigDecimal`` are exposed as
    numbers to JMESPath. If a value for one of these types truly exceeds

--- a/docs/source-2.0/guides/building-codegen/mapping-shapes-to-languages.rst
+++ b/docs/source-2.0/guides/building-codegen/mapping-shapes-to-languages.rst
@@ -253,7 +253,8 @@ The *list* type represents an ordered homogeneous collection of values.
 A list type should be code generated using the list or array type
 provided in the standard library of the target environment.
 
-.. rubric:: Value presence
+Value presence
+~~~~~~~~~~~~~~
 
 *  List values are always present (non-nullable) unless the list is marked
    with the ``@sparse`` trait.
@@ -284,7 +285,8 @@ The :ref:`map` type represents a map data structure that maps
 maintain insertion order. Implementations should use the idiomatic
 map data structure of the target environment when possible.
 
-.. rubric:: Key and value presence
+Key and value presence
+~~~~~~~~~~~~~~~~~~~~~~
 
 * Map keys are always present and never nullable.
 * Map values are always present (non-nullable) unless the map is

--- a/docs/source-2.0/guides/converting-to-openapi.rst
+++ b/docs/source-2.0/guides/converting-to-openapi.rst
@@ -1284,7 +1284,8 @@ This results in an ``x-meta`` property being added to the respective objects in 
         }
     }
 
-.. rubric:: Supported trait locations:
+Supported trait locations
+-------------------------
 
 Only a subset of OpenAPI locations are supported in the conversion:
 

--- a/docs/source-2.0/index.rst
+++ b/docs/source-2.0/index.rst
@@ -62,7 +62,8 @@ Features
 FAQ
 ===
 
-.. rubric:: Why did you develop Smithy?
+Why did you develop Smithy?
+---------------------------
 
 Smithy is based on an interface definition language that has been widely used
 within Amazon and AWS for over a decade. We decided to release Smithy publicly
@@ -71,19 +72,22 @@ years of experience with building tens of thousands of services. By releasing
 the Smithy specification and tooling, we also hope to make it easier for
 developers to maintain open source AWS SDKs.
 
-.. rubric:: Does Smithy only work with AWS?
+Does Smithy only work with AWS?
+-------------------------------
 
 No. Smithy can be used with any kind of service. All AWS-specific metadata in
 Smithy is implemented as decoupled packages.
 
-.. rubric:: Why not just use an existing IDL?
+Why not just use an existing IDL?
+---------------------------------
 
 At AWS, we rely heavily on metadata, code generation, service frameworks,
 client libraries, and automated policy enforcement. Existing IDLs available
 outside of AWS were not extensible enough to meet our needs and not
 compatible with our existing services.
 
-.. rubric:: How is Smithy different than other IDLs and frameworks?
+How is Smithy different than other IDLs and frameworks?
+-------------------------------------------------------
 
 * Smithy is built for code generation and tools. Smithy models were designed
   for the purpose of generating code for multiple programming languages. For
@@ -108,7 +112,8 @@ compatible with our existing services.
   like maintaining an internal and external version of a model and providing
   beta models to customers as part of a private beta.
 
-.. rubric:: What does protocol-agnostic mean?
+What does protocol-agnostic mean?
+---------------------------------
 
 Protocol-agnostic means that the model is an abstraction that specifies the
 rules and semantics of how a client and server communicate. The transport and
@@ -118,14 +123,16 @@ evolve their serialization format (e.g., move from text to binary), their
 connection type (e.g., move from HTTP/1 to HTTP/2), or launch entirely new
 capabilities.
 
-.. rubric:: What is the main difference between Smithy and OpenAPI?
+What is the main difference between Smithy and OpenAPI?
+-------------------------------------------------------
 
 The primary difference between Smithy and OpenAPI is that Smithy is
 protocol-agnostic, allowing Smithy to describe a broader range of services,
 metadata, and capabilities. Smithy can be used alongside OpenAPI by
 :ref:`converting Smithy models to OpenAPI <smithy-to-openapi>`.
 
-.. rubric:: What can Smithy do today?
+What can Smithy do today?
+-------------------------
 
 See https://github.com/smithy-lang/awesome-smithy.
 

--- a/docs/source-2.0/spec/aggregate-types.rst
+++ b/docs/source-2.0/spec/aggregate-types.rst
@@ -76,13 +76,15 @@ The following example defines a map of strings to integers:
 Map member optionality
 ----------------------
 
-.. rubric:: Map keys are never optional
+Map keys are never optional
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Map keys are not permitted to be ``null``. Not all protocol serialization
 formats have a way to define ``null`` map keys, and map implementations
 across programming languages often do not allow ``null`` keys in maps.
 
-.. rubric:: Map values are always present by default
+Map values are always present by default
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Maps values are considered *dense* by default, meaning they cannot contain
 ``null`` values. A map MAY be made *sparse* by applying the
@@ -258,7 +260,8 @@ Requirements change; what is required today might not be required tomorrow.
 Smithy provides several ways to make it so that required members no longer
 need to be provided without breaking previously generated code.
 
-.. rubric:: Migrating ``@required`` to ``@default``
+Migrating ``@required`` to ``@default``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If a ``required`` member no longer needs to be be required, the ``required``
 trait MAY be removed and replaced with the :ref:`default-trait`. Alternatively,
@@ -283,7 +286,8 @@ added to a previously published member. Some tooling does not treat the
 ``required`` trait as non-nullable but does treat the ``default`` trait as
 non-nullable.
 
-.. rubric:: Requiring members to be optional
+Requiring members to be optional
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :ref:`clientOptional-trait` is used to indicate that a member that is
 currently required by authoritative model consumers like servers MAY become
@@ -315,7 +319,8 @@ trait is *not* a backward compatible change because model consumers would
 transition from assuming the value is optional to assuming that it is always
 present due to a default value.
 
-.. rubric:: Model evolution and the ``@input`` trait
+Model evolution and the ``@input`` trait
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :ref:`input-trait` specializes a structure as the input of a single
 operation. Transitioning top-level members from ``required`` to optional is

--- a/docs/source-2.0/spec/documentation-traits.rst
+++ b/docs/source-2.0/spec/documentation-traits.rst
@@ -66,7 +66,8 @@ Value type
     string MyString
 
 
-.. rubric:: Effective documentation
+Effective documentation
+-----------------------
 
 The *effective documentation trait* of a shape is resolved using the following
 process:

--- a/docs/source-2.0/spec/http-bindings.rst
+++ b/docs/source-2.0/spec/http-bindings.rst
@@ -497,7 +497,8 @@ The following example defines an error with an HTTP status code of ``404``.
     @httpError(404)
     structure MyError {}
 
-.. rubric:: Default HTTP status codes
+Default HTTP status codes
+-------------------------
 
 The ``httpError`` trait is used to set a *custom* HTTP response status code.
 By default, error structures with no ``httpError`` trait use the default
@@ -537,7 +538,8 @@ Conflicts with
    :ref:`httpPayload-trait`,
    :ref:`httpResponseCode-trait`
 
-.. rubric:: ``httpHeader`` serialization rules:
+``httpHeader`` serialization rules:
+-----------------------------------
 
 * When a :ref:`list <list>` shape is targeted, each member of the shape is
   serialized as a separate HTTP header either by concatenating the values
@@ -550,12 +552,12 @@ Conflicts with
   :rfc:`7231#section-7.1.1.1`. The :ref:`timestampFormat-trait` MAY be used
   to use a custom serialization format.
 
-.. rubric:: Do not put too much data in HTTP headers
+.. note::
 
-While there is no limit placed on the length of an HTTP header field, many
-HTTP client and server implementations enforce limits in practice.
-Carefully consider the maximum allowed length of each member that is bound
-to an HTTP header.
+    While there is no limit placed on the length of an HTTP header field, many
+    HTTP client and server implementations enforce limits in practice.
+    Carefully consider the maximum allowed length of each member that is bound
+    to an HTTP header.
 
 
 .. _restricted-headers:
@@ -659,14 +661,16 @@ The following example defines an operation that send an HTTP label named
         foo: String
     }
 
-.. rubric:: Relationship to :ref:`http-trait`
+Relationship to :ref:`http-trait`
+---------------------------------
 
 When a structure is used as the input of an operation, any member of the
 structure with the ``httpLabel`` trait MUST have a corresponding
 :ref:`URI label <http-uri-label>` with the same name as the member.
 ``httpLabel`` traits are ignored when serializing operation output or errors.
 
-.. rubric:: Applying the ``httpLabel`` trait to members
+Applying the ``httpLabel`` trait to members
+-------------------------------------------
 
 * ``httpLabel`` can only be applied to structure members that are marked as
   :ref:`required <required-trait>`.
@@ -677,7 +681,8 @@ structure with the ``httpLabel`` trait MUST have a corresponding
 * If the corresponding URI label in the operation is greedy, then the
   ``httpLabel`` trait MUST target a member that targets a ``string`` shape.
 
-.. rubric:: ``httpLabel`` serialization rules:
+``httpLabel`` serialization rules
+---------------------------------
 
 - ``boolean`` values are serialized as ``true`` or ``false``.
 - ``timestamp`` values are serialized as an :rfc:`3339` string by default
@@ -690,7 +695,8 @@ structure with the ``httpLabel`` trait MUST have a corresponding
 - However, if the label is greedy, then "/" MUST NOT be percent-encoded
   because greedy labels are meant to span multiple path segments.
 
-.. rubric:: ``httpLabel`` is only used on input
+``httpLabel`` is only used on input
+-----------------------------------
 
 ``httpLabel`` is ignored when resolving the HTTP bindings of an operation's
 output or an error. This means that if a structure that contains members
@@ -751,7 +757,8 @@ data in a response:
 
 .. _http-protocol-document-payloads:
 
-.. rubric:: Protocol-specific document payloads
+Protocol-specific document payloads
+-----------------------------------
 
 By default, all structure members that are not bound as part of the HTTP
 message are serialized in a protocol-specific document sent in the body of
@@ -760,7 +767,8 @@ bind a single top-level operation input, output, or error structure member to
 the body of the HTTP message. Multiple members of the same structure MUST NOT
 be bound to ``httpPayload``.
 
-.. rubric:: Binding members to ``httpPayload``
+Binding members to ``httpPayload``
+----------------------------------
 
 If the ``httpPayload`` trait is present on the structure referenced by the
 input of an operation, then all other structure members MUST be bound with
@@ -772,7 +780,8 @@ output of an operation or a structure targeted by the :ref:`error-trait`,
 then all other structure members MUST be bound to a :ref:`httpHeader-trait`
 or :ref:`httpPrefixHeaders-trait`.
 
-.. rubric:: Serialization rules
+Serialization rules
+-------------------
 
 #. When a string or blob member is referenced, the raw value is serialized
    as the body of the message.
@@ -852,7 +861,8 @@ An example HTTP request would be serialized as:
     X-Foo-first: hi
     X-Foo-second: there
 
-.. rubric:: Disambiguation of ``httpPrefixHeaders``
+Disambiguation of ``httpPrefixHeaders``
+---------------------------------------
 
 In order to differentiate ``httpPrefixHeaders`` from other headers, when
 ``httpPrefixHeaders`` are used, no other :ref:`httpHeader-trait` bindings can
@@ -913,7 +923,8 @@ request:
         size: Integer
     }
 
-.. rubric:: Serialization rules
+Serialization rules
+-------------------
 
 * "&" is used to separate query string parameter key-value pairs.
 * "=" is used to separate query string parameter names from values.
@@ -946,7 +957,8 @@ request:
     HTTP requests and automatically percent-decoded when deserializing HTTP
     requests.
 
-.. rubric:: ``httpQuery`` is only used on input
+``httpQuery`` is only used on input
+-----------------------------------
 
 ``httpQuery`` is ignored when resolving the HTTP bindings of an operation's
 output or an error. This means that if a structure that contains members
@@ -955,12 +967,13 @@ of an operation, then those members are sent as part of the
 :ref:`protocol-specific document <http-protocol-document-payloads>` sent in
 the body of the response.
 
-.. rubric:: Do not put too much data in the query string
+.. note::
 
-While there is no limit placed on the length of an
-:rfc:`HTTP request line <7230#section-3.1.1>`, many HTTP client and server
-implementations enforce limits in practice. Carefully consider the maximum
-allowed length of each member that is bound to an HTTP query string or path.
+    While there is no limit placed on the length of an
+    :rfc:`HTTP request line <7230#section-3.1.1>`, many HTTP client and server
+    implementations enforce limits in practice. Carefully consider the maximum
+    allowed length of each member that is bound to an HTTP query string or
+    path.
 
 
 .. smithy-trait:: smithy.api#httpQueryParams
@@ -1013,16 +1026,8 @@ target input map as query string parameters in an HTTP request:
         value: String
     }
 
-.. rubric:: ``httpQueryParams`` is only used on input
-
-``httpQueryParams`` is ignored when resolving the HTTP bindings of an operation's
-output or an error. This means that if a structure that contains members
-marked with the ``httpQueryParams`` trait is used as the top-level output structure
-of an operation, then those members are sent as part of the
-:ref:`protocol-specific document <http-protocol-document-payloads>` sent in
-the body of the response.
-
-.. rubric:: Serialization rules
+Serialization rules
+-------------------
 
 See the :ref:`httpQuery-trait` serialization rules that define how the keys and values of the
 target map will be serialized in the request query string. Key-value pairs in the target map
@@ -1122,6 +1127,16 @@ A server should deserialize the following input structure:
         }
     }
 
+``httpQueryParams`` is only used on input
+-----------------------------------------
+
+``httpQueryParams`` is ignored when resolving the HTTP bindings of an operation's
+output or an error. This means that if a structure that contains members
+marked with the ``httpQueryParams`` trait is used as the top-level output structure
+of an operation, then those members are sent as part of the
+:ref:`protocol-specific document <http-protocol-document-payloads>` sent in
+the body of the response.
+
 .. smithy-trait:: smithy.api#httpResponseCode
 .. _httpResponseCode-trait:
 
@@ -1147,14 +1162,16 @@ Conflicts with
    :ref:`httpPrefixHeaders-trait`, :ref:`httpPayload-trait`,
    :ref:`httpQuery-trait`, :ref:`httpQueryParams-trait`,
 
-.. rubric:: ``httpResponseCode`` use cases
+``httpResponseCode`` use cases
+------------------------------
 
 Marking an output ``structure`` member with this trait can be used to provide
 different response codes for an operation, like a 200 or 201 for a PUT
 operation. If this member isn't provided, server implementations MUST default
 to the `code` set by the :ref:`http-trait`.
 
-.. rubric:: ``httpResponseCode`` is only used on output
+``httpResponseCode`` is only used on output
+-------------------------------------------
 
 ``httpResponseCode`` is ignored when resolving the HTTP bindings of any
 structure except an operation's output structure. This means that if a

--- a/docs/source-2.0/spec/index.rst
+++ b/docs/source-2.0/spec/index.rst
@@ -8,7 +8,8 @@ This is the specification of Smithy |release|, an interface definition language
 and set of tools used to build clients, servers, and other kinds of artifacts
 through model transformations.
 
-.. rubric:: Conventions used in this document
+Conventions used in this document
+=================================
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
@@ -21,14 +22,16 @@ Please report technical errors and ambiguities in this specification to the
 Smithy GitHub repository at https://github.com/smithy-lang/smithy.
 This specification is open source; contributions are welcome.
 
-.. rubric:: Examples
+Examples
+========
 
 Unless declared otherwise, example Smithy models given in this specification
 are written using the :ref:`Smithy interface definition language (IDL) <idl>`
 syntax. Complementary :ref:`JSON AST <json-ast>` examples are provided
 alongside Smithy IDL examples where appropriate.
 
-.. rubric:: Table of contents
+Table of contents
+=================
 
 .. toctree::
     :numbered:

--- a/docs/source-2.0/spec/model.rst
+++ b/docs/source-2.0/spec/model.rst
@@ -160,7 +160,8 @@ a model validator:
 
 .. _merging-metadata:
 
-.. rubric:: Metadata conflicts
+Metadata conflicts
+==================
 
 When a conflict occurs between top-level metadata key-value pairs,
 the following conflict resolution logic is used:
@@ -250,7 +251,8 @@ The following example defines a :ref:`trait <traits>` using a node value:
     @length(min: 1, max: 10)
     string MyString
 
-.. rubric:: Node value types
+Node value types
+================
 
 Node values have the same data model as JSON; they consist of the following
 kinds of values:
@@ -619,7 +621,8 @@ immediately precede a shape. The following example applies the
 * Refer to the :ref:`JSON AST specification <json-ast>` for a
   description of how traits are applied in the JSON AST.
 
-.. rubric:: Scope of member traits
+Scope of member traits
+----------------------
 
 Traits that target :ref:`members <member>` apply only in the context of
 the member shape and do not affect the shape targeted by the member. Traits
@@ -813,10 +816,10 @@ target from traits and how their values are defined in
         one of the member names of the union shape, and the value MUST be
         compatible with the corresponding shape.
 
-.. rubric:: Constraint traits
+.. important::
 
-Trait values MUST be compatible with the :ref:`required-trait` and any
-associated :doc:`constraint traits <constraint-traits>`.
+    Trait values MUST be compatible with the :ref:`required-trait` and any
+    associated :doc:`constraint traits <constraint-traits>`.
 
 
 .. _trait-shapes:
@@ -881,13 +884,15 @@ The following example defines two custom traits: ``beta`` and
         ipsum: "lorem and ipsum are both required values.")
     string StringShape
 
-.. rubric:: Prelude traits
+Prelude traits
+--------------
 
 When using the IDL, built-in traits defined in the Smithy
 :ref:`prelude <prelude>` namespace, ``smithy.api``, are automatically
 available in every Smithy model and namespace through relative shape IDs.
 
-.. rubric:: References to traits
+References to traits
+--------------------
 
 The only valid reference to a trait is through applying a trait to a
 shape. Members and references within a model MUST NOT target shapes.
@@ -910,7 +915,8 @@ Trait selector
 Value type
     ``structure``
 
-.. rubric:: Trait properties
+Trait properties
+^^^^^^^^^^^^^^^^
 
 ``smithy.api#trait`` is a structure that supports the following members:
 
@@ -1117,7 +1123,8 @@ Is changed to:
 Then the change to the ``foo`` member from "a" to "b" is backward
 incompatible, as is the removal of the ``baz`` member.
 
-.. rubric:: Referring to list members
+Referring to list members
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The JSON pointer can path into the members of a list using a ``member``
 segment.
@@ -1161,7 +1168,8 @@ Is changed to:
 Then the change to the second value of the ``names`` member is
 backward incompatible because it changed from ``Luke`` to ``Chewy``.
 
-.. rubric:: Referring to map members
+Referring to map members
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 Members of a map shape can be referenced in a JSON pointer using
 ``key`` and ``value``.

--- a/docs/source-2.0/spec/protocol-traits.rst
+++ b/docs/source-2.0/spec/protocol-traits.rst
@@ -162,7 +162,8 @@ The following example defines a ``video/quicktime`` blob:
     @mediaType("video/quicktime")
     blob VideoData
 
-.. rubric:: Use cases
+Use cases
+---------
 
 The primary function of the ``mediaType`` trait is to send open content
 data over the wire inside of values that are isolated from the rest of
@@ -176,7 +177,8 @@ validation, special-cased helpers to serialize and deserialize media type
 contents in code, assigning a fixed Content-Type when using
 :ref:`HTTP bindings <http-traits>`, etc.
 
-.. rubric:: Comparisons to document types
+Comparisons to document types
+-----------------------------
 
 The serialization format of a shape marked with the ``@mediaType`` trait is
 an important part of its contract. In contrast, document types are
@@ -206,7 +208,8 @@ the :ref:`protocol <protocolDefinition-trait>` of a service; however, the
 serialization format can be explicitly configured in some protocols to
 override the default format using the ``timestampFormat`` trait.
 
-.. rubric:: Timestamp formats
+Timestamp formats
+-----------------
 
 Smithy defines the following built-in timestamp formats:
 
@@ -237,7 +240,8 @@ Smithy defines the following built-in timestamp formats:
         Values that are more granular than millisecond precision SHOULD be
         truncated to fit millisecond precision.
 
-.. rubric:: Resolving timestamp formats
+Resolving timestamp formats
+---------------------------
 
 The following steps are taken to determine the serialization format of a
 :ref:`member <member>` that targets a timestamp:

--- a/docs/source-2.0/spec/resource-traits.rst
+++ b/docs/source-2.0/spec/resource-traits.rst
@@ -220,7 +220,8 @@ Trait selector
 Value type
     ``list`` of ``Reference`` structures
 
-.. rubric:: ``Reference`` structure
+``Reference`` structure
+-----------------------
 
 The ``references`` trait is a list of ``Reference`` structures that contain
 the following members:
@@ -264,7 +265,8 @@ the following members:
         contain a link relation as defined in :rfc:`5988#section-4` (i.e.,
         this value SHOULD contain either a `standard link relation`_ or URI).
 
-.. rubric:: Runtime resolution of references
+Runtime resolution of references
+--------------------------------
 
 References MAY NOT be resolvable at runtime in the following circumstances:
 
@@ -273,7 +275,8 @@ References MAY NOT be resolvable at runtime in the following circumstances:
 #. The targeted resource and/or service shape is not part of the model
 #. The reference is bound to a specific service that is unknown to the tool
 
-.. rubric:: Implicit identifier mappings example
+Implicit identifier mappings example
+------------------------------------
 
 The following example creates a reference to a ``HistoricalForecast`` resource
 (a resource that requires the "forecastId" and "historicalId" identifiers):
@@ -301,7 +304,8 @@ explicitly mapped to structure members. This is because the targeted structure
 contains members with names that match the names of the identifiers of the
 ``HistoricalForecast`` resource.
 
-.. rubric:: Explicit identifier mappings example
+Explicit identifier mappings example
+------------------------------------
 
 Explicit mappings between identifier names and structure member names can be
 defined if needed. For example:
@@ -325,7 +329,8 @@ defined if needed. For example:
         customHistoricalId: String
     }
 
-.. rubric:: Additional examples
+Additional examples
+-------------------
 
 The following example defines several references:
 
@@ -359,7 +364,8 @@ The following example defines several references:
         objectKey: ObjectKey
     }
 
-.. rubric:: References on string shapes
+References on string shapes
+---------------------------
 
 A reference can be formed on a string shape for resources that have one
 identifier. References applied to a string shape MUST omit the "ids"

--- a/docs/source-2.0/spec/selectors.rst
+++ b/docs/source-2.0/spec/selectors.rst
@@ -1499,7 +1499,8 @@ hierarchy of a qualified service or resource shape. This function essentially
 allows shapes to be matched by inheriting from the resource or service they
 are bound to.
 
-.. rubric:: Selector arguments
+Selector arguments
+~~~~~~~~~~~~~~~~~~
 
 Exactly one or two selectors MUST be provided to the ``:topdown`` selector:
 
@@ -1515,7 +1516,8 @@ Exactly one or two selectors MUST be provided to the ``:topdown`` selector:
    shape because resource and operation shapes bound to the current shape
    could yield matching results.
 
-.. rubric:: Examples
+Examples
+~~~~~~~~
 
 The following selector finds all service, resource, and operation shapes that
 are marked with the ``aws.api#dataPlane`` trait or that are bound within the

--- a/docs/source-2.0/spec/service-types.rst
+++ b/docs/source-2.0/spec/service-types.rst
@@ -170,7 +170,27 @@ case-insensitively because many model transformations (like code generation)
 change the casing and inflection of shape names to make artifacts more
 idiomatic.
 
-.. rubric:: Shape types allowed to conflict in a closure
+.. important::
+
+    Resources and operations can only be bound once. An operation or resource
+    MUST NOT be bound to multiple shapes within the closure of a service. This
+    constraint allows services to discern between operations and resources
+    using only their shape name rather than a fully-qualified path from the
+    service to the shape.
+
+.. note::
+
+    Undeclared operation inputs and outputs are not a part of the service
+    closure. :ref:`smithy.api#Unit <unit-type>` is the shape that is implicitly
+    targeted by operation inputs and outputs when they are not explicitly
+    declared. This does not, however, add ``smithy.api#Unit`` to the service's
+    closure, and does not require renaming to avoid conflicts with other shapes
+    named ``Unit``. Unions in the service closure with members targeting
+    ``smithy.api#Unit``, however, will cause ``smithy.api#Unit`` to be a part
+    of the service closure.
+
+Shape types allowed to conflict in a closure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :ref:`Simple types <simple-types>` and :ref:`lists <list>` of compatible simple
 types are allowed to conflict because a conflict for these type would rarely
@@ -179,7 +199,8 @@ allowed if both conflicting shapes are the same type and have the exact same
 traits. In the case of a list, a conflict is only allowed if the members
 of the conflicting shapes target compatible shapes.
 
-.. rubric:: Disambiguating shapes with ``rename``
+Disambiguating shapes with ``rename``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``rename`` property of a service is used to disambiguate conflicting
 shape names found in the closure of a service. The ``rename`` property is
@@ -225,23 +246,6 @@ the conflicting shapes.
     }
 
     structure Widget {}
-
-.. rubric:: Resources and operations can be bound once
-
-An operation or resource MUST NOT be bound to multiple shapes within the
-closure of a service. This constraint allows services to discern between
-operations and resources using only their shape name rather than a
-fully-qualified path from the service to the shape.
-
-.. rubric:: Undeclared operation inputs and outputs are not a
-            part of the service closure
-
-:ref:`smithy.api#Unit <unit-type>` is the shape that is implicitly targeted by
-operation inputs and outputs when they are not explicitly declared. This does
-not, however, add ``smithy.api#Unit`` to the service's closure, and does not
-require renaming to avoid conflicts with other shapes named ``Unit``. Unions in
-the service closure with members targeting ``smithy.api#Unit``, however, will
-cause ``smithy.api#Unit`` to be a part of the service closure.
 
 
 ..  _operation:
@@ -519,7 +523,8 @@ Binding identifiers to operations
 *Identifier bindings* indicate which top-level members of the input or output
 structure of an operation provide values for the identifiers of a resource.
 
-.. rubric:: Identifier binding validation
+Identifier binding validation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Child resources MUST provide identifier bindings for all of its parent's
   identifiers.
@@ -774,7 +779,8 @@ members, use the :ref:`nested-properties-trait` on a member to designate its
 target structure shape as the root to form property bindings. No adjacent
 members can form property bindings when this trait is applied.
 
-.. rubric:: Resource property binding validation
+Resource property binding validation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - All top-level input or output members must bind to a resource property unless
   marked with :ref:`notProperty-trait` or another trait with it applied, or one
@@ -852,7 +858,8 @@ The following example defines the ``PutForecast`` operation.
         chanceOfRain: Float
     }
 
-.. rubric:: Put semantics
+Put semantics
+^^^^^^^^^^^^^
 
 The semantics of a ``put`` lifecycle operation are similar to the semantics
 of a HTTP PUT method as described in :rfc:`section 4.3.4 of [RFC7231] <7231#section-4.3.4>`:

--- a/docs/source-2.0/spec/type-refinement-traits.rst
+++ b/docs/source-2.0/spec/type-refinement-traits.rst
@@ -420,7 +420,8 @@ The following example defines an ``@input`` structure:
         name: String
     }
 
-.. rubric:: ``@input`` structure constraints
+``@input`` structure constraints
+--------------------------------
 
 Structure shapes marked with the ``@input`` trait MUST adhere to the
 following constraints:
@@ -435,7 +436,8 @@ following constraints:
 These constraints allow tooling to specialize operation input shapes in
 ways that would otherwise require complex model transformations.
 
-.. rubric:: Impact on backward compatibility
+Impact on backward compatibility
+--------------------------------
 
 Required members of a structure marked with the ``@input`` trait are implicitly
 considered :ref:`clientOptional <clientOptional-trait>`. It is backward
@@ -461,6 +463,9 @@ Value type
     Annotation trait.
 Conflicts with
     :ref:`input-trait`, :ref:`error-trait`
+
+``@output`` structure constraints
+---------------------------------
 
 Structure shapes marked with the ``@output`` trait MUST adhere to the
 following constraints:


### PR DESCRIPTION
Resolves #1381 

Includes minor reordering of some sections. A few rubrics were changed to note/important as they're informative content.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
