### PR TITLE
Improve NumberNode

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
@@ -218,7 +218,7 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
     private List<ValidationEvent> validateNaturalNumber(Shape shape, Long min, Long max) {
         return value.asNumberNode()
                 .map(number -> {
-                    if (!number.isNaturalNumber()) {
+                    if (number.isFloatingPointNumber()) {
                         return ListUtils.of(event(String.format(
                                 "%s shapes must not have floating point values, but found `%s` provided for `%s`",
                                 shape.getType(), number.getValue(), shape.getId())));

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/NumberNodeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/NumberNodeTest.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.model.node;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -199,6 +200,11 @@ public class NumberNodeTest {
             public double doubleValue() {
                 return 0;
             }
+
+            @Override
+            public String toString() {
+                return "0.000";
+            }
         }, true);
         cases.put(new Number() {
             @Override
@@ -282,5 +288,15 @@ public class NumberNodeTest {
         Node right = Node.from((double) 1.0e+10);
 
         assertThat(left, equalTo(right));
+    }
+
+    @Test
+    public void detectsNegativeValues() {
+        assertThat(NumberNode.from(Double.NEGATIVE_INFINITY).isNegative(), is(true));
+        assertThat(NumberNode.from(Double.POSITIVE_INFINITY).isNegative(), is(false));
+        assertThat(NumberNode.from(Double.NaN).isNegative(), is(false));
+        assertThat(NumberNode.from(0).isNegative(), is(false));
+        assertThat(NumberNode.from(1).isNegative(), is(false));
+        assertThat(NumberNode.from(-1).isNegative(), is(true));
     }
 }


### PR DESCRIPTION
This change now makes the BigDecimal get created eagerly, and accounts
for NaN and Infinity. The previous implementation would have failed
in these cases. NodeValidationVisitor now uses the computed BigDecimal
rather than create a one-off each time. It also doesn't recreate the
already available BigDecimcal of the range trait.

This change deprecates isNaturalNumber since that method was poorly
named. A natural number is an integer >= 1, but we were including 0
(which is likely why some callers assumed it asserts >= 0).

This also adds an isNegative method since multiple callers need to
assert that a NumberNode contains a non-negative value.