### PR TITLE
Only serialize allowConstraintErrors when true

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExamplesTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExamplesTrait.java
@@ -177,15 +177,17 @@ public final class ExamplesTrait extends AbstractTrait implements ToSmithyBuilde
             ObjectNode.Builder builder = Node.objectNodeBuilder()
                     .withMember("title", Node.from(title))
                     .withOptionalMember("documentation", getDocumentation().map(Node::from))
-                    .withOptionalMember("error", getError().map(ErrorExample::toNode))
-                    .withOptionalMember("allowConstraintErrors", BooleanNode.from(allowConstraintErrors)
-                            .asBooleanNode());
+                    .withOptionalMember("error", getError().map(ErrorExample::toNode));
 
             if (!input.isEmpty()) {
                 builder.withMember("input", input);
             }
             if (this.getOutput().isPresent()) {
                 builder.withMember("output", output);
+            }
+
+            if (this.allowConstraintErrors) {
+                builder.withMember("allowConstraintErrors", BooleanNode.from(allowConstraintErrors));
             }
 
             return builder.build();


### PR DESCRIPTION
Updates the Examples trait to only serialize the `allowConstraintErrors` when true. If not set, or false, it will not be serialized.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
