### PR TITLE
Revert "Add sha digest to resolved artifacts (#1961)"

### DIFF
--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/MavenResolverTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/MavenResolverTest.java
@@ -154,9 +154,8 @@ public class MavenResolverTest {
             String cacheContents = result.getFile("build", "smithy", "classpath.json");
 
             ObjectNode node = Node.parse(cacheContents).expectObjectNode();
-            ObjectNode artifacts = node.expectObjectMember("artifacts");
-            String location = artifacts.expectObjectMember("software.amazon.smithy:smithy-aws-traits:"
-                                                      + TEST_VERSION).expectStringMember("path").getValue();
+            String location = node.expectStringMember("software.amazon.smithy:smithy-aws-traits:"
+                                                      + TEST_VERSION).getValue();
 
             // Set the lastModified of the JAR to the current time, which is > than the time of the config file,
             // so the cache is invalided.

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/ResolvedArtifact.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/dependencies/ResolvedArtifact.java
@@ -16,39 +16,26 @@
 package software.amazon.smithy.cli.dependencies;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Objects;
-import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.node.ObjectNode;
-import software.amazon.smithy.model.node.ToNode;
-import software.amazon.smithy.utils.IoUtils;
 
 /**
  * An artifact resolved from a repository that provides the path on disk where the artifact
  * was downloaded, and the coordinates of the artifact.
  */
-public final class ResolvedArtifact implements ToNode {
-    private static final String SHA_SUM_MEMBER_NAME = "shaSum";
-    private static final String PATH_MEMBER_NAME = "path";
-
+public final class ResolvedArtifact {
     private final Path path;
     private final String coordinates;
     private final String groupId;
     private final String artifactId;
     private final String version;
-    private final String shaSum;
 
     public ResolvedArtifact(Path path, String groupId, String artifactId, String version) {
-        this(path, groupId + ':' + artifactId + ':' + version, groupId, artifactId,
-                version, IoUtils.computeSha256(path));
+        this(path, groupId + ':' + artifactId + ':' + version, groupId, artifactId, version);
     }
 
-    private ResolvedArtifact(Path path, String coordinates, String groupId, String artifactId,
-                             String version, String shaSum
-    ) {
+    private ResolvedArtifact(Path path, String coordinates, String groupId, String artifactId, String version) {
         this.coordinates = Objects.requireNonNull(coordinates);
         this.path = Objects.requireNonNull(path);
-        this.shaSum = Objects.requireNonNull(shaSum);
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.version = version;
@@ -57,21 +44,17 @@ public final class ResolvedArtifact implements ToNode {
     /**
      * Creates a resolved artifact from a file path and Maven coordinates string.
      *
+     * @param location    Location of the artifact.
      * @param coordinates Maven coordinates (e.g., group:artifact:version).
-     * @param node Node containing the resolved artifact data.
      * @return Returns the created artifact.
      * @throws DependencyResolverException if the provided coordinates are invalid.
      */
-    public static ResolvedArtifact fromNode(String coordinates, Node node) {
+    public static ResolvedArtifact fromCoordinates(Path location, String coordinates) {
         String[] parts = coordinates.split(":");
         if (parts.length != 3) {
             throw new DependencyResolverException("Invalid Maven coordinates: " + coordinates);
         }
-        ObjectNode objectNode = node.expectObjectNode();
-        Path location = Paths.get(objectNode.expectMember(PATH_MEMBER_NAME).expectStringNode().getValue());
-        String shaSum = objectNode.expectMember(SHA_SUM_MEMBER_NAME).expectStringNode().getValue();
-
-        return new ResolvedArtifact(location, coordinates, parts[0], parts[1], parts[2], shaSum);
+        return new ResolvedArtifact(location, coordinates, parts[0], parts[1], parts[2]);
     }
 
     /**
@@ -113,28 +96,14 @@ public final class ResolvedArtifact implements ToNode {
         return version;
     }
 
-    /**
-     * @return Get the sha256 digest of the artifact.
-     */
-    public String getShaSum() {
-        return shaSum;
-    }
-
-    /**
-     * @return Get the last time the artifact was modified.
-     */
-    public long getLastModified() {
-        return path.toFile().lastModified();
-    }
-
     @Override
     public String toString() {
-        return "{path=" + path + ", coordinates='" + coordinates + ", shaSum='" + shaSum + "'}";
+        return "{path=" + path + ", coordinates='" + coordinates + "'}";
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(coordinates, path, shaSum);
+        return Objects.hash(coordinates, path);
     }
 
     @Override
@@ -145,16 +114,6 @@ public final class ResolvedArtifact implements ToNode {
             return false;
         }
         ResolvedArtifact artifact = (ResolvedArtifact) o;
-        return path.equals(artifact.path)
-                && shaSum.equals(artifact.shaSum)
-                && coordinates.equals(artifact.coordinates);
-    }
-
-    @Override
-    public Node toNode() {
-        return Node.objectNodeBuilder()
-                .withMember(PATH_MEMBER_NAME, path.toString())
-                .withMember(SHA_SUM_MEMBER_NAME, shaSum)
-                .build();
+        return path.equals(artifact.path) && coordinates.equals(artifact.coordinates);
     }
 }

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/FileCacheResolverTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/FileCacheResolverTest.java
@@ -11,7 +11,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Date;
@@ -19,7 +18,6 @@ import java.util.List;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.model.MavenRepository;
-import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.utils.IoUtils;
 import software.amazon.smithy.utils.ListUtils;
 
@@ -43,7 +41,7 @@ public class FileCacheResolverTest {
         File jar = File.createTempFile("foo", ".json");
 
         List<ResolvedArtifact> result = ListUtils.of(
-                ResolvedArtifact.fromNode("com.foo:bar:1.0.0", getNodeForPath(jar.toPath())));
+                ResolvedArtifact.fromCoordinates(jar.toPath(), "com.foo:bar:1.0.0"));
         Mock mock = new Mock(result);
         DependencyResolver resolver = new FileCacheResolver(cache, System.currentTimeMillis(), mock);
 
@@ -69,8 +67,7 @@ public class FileCacheResolverTest {
         File jar = File.createTempFile("foo", ".jar");
         Files.write(jar.toPath(), "{}".getBytes(StandardCharsets.UTF_8));
 
-        ResolvedArtifact artifact = ResolvedArtifact.fromNode("com.foo:bar:1.0.0",
-                getNodeForPath(jar.toPath()));
+        ResolvedArtifact artifact = ResolvedArtifact.fromCoordinates(jar.toPath(), "com.foo:bar:1.0.0");
         List<ResolvedArtifact> result = new ArrayList<>();
         result.add(artifact);
 
@@ -107,8 +104,7 @@ public class FileCacheResolverTest {
         File jar = File.createTempFile("foo", ".jar");
         Files.write(jar.toPath(), "{}".getBytes(StandardCharsets.UTF_8));
 
-        ResolvedArtifact artifact = ResolvedArtifact.fromNode("com.foo:bar:1.0.0",
-                getNodeForPath(jar.toPath()));
+        ResolvedArtifact artifact = ResolvedArtifact.fromCoordinates(jar.toPath(), "com.foo:bar:1.0.0");
         List<ResolvedArtifact> result = new ArrayList<>();
         result.add(artifact);
 
@@ -139,8 +135,7 @@ public class FileCacheResolverTest {
         File jar = File.createTempFile("foo", ".jar");
         Files.write(jar.toPath(), "{}".getBytes(StandardCharsets.UTF_8));
 
-        ResolvedArtifact artifact = ResolvedArtifact.fromNode("com.foo:bar:1.0.0",
-                getNodeForPath(jar.toPath()));
+        ResolvedArtifact artifact = ResolvedArtifact.fromCoordinates(jar.toPath(), "com.foo:bar:1.0.0");
         List<ResolvedArtifact> result = new ArrayList<>();
         result.add(artifact);
 
@@ -186,12 +181,5 @@ public class FileCacheResolverTest {
         public List<ResolvedArtifact> resolve() {
             return artifacts;
         }
-    }
-
-    private static Node getNodeForPath(Path path) {
-        return Node.objectNodeBuilder()
-                .withMember("path", path.toString())
-                .withMember("shaSum", IoUtils.computeSha256(path))
-                .build();
     }
 }

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/FilterCliVersionResolverTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/FilterCliVersionResolverTest.java
@@ -4,13 +4,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.model.MavenRepository;
-import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.utils.ListUtils;
 
 public class FilterCliVersionResolverTest {
@@ -52,17 +52,17 @@ public class FilterCliVersionResolverTest {
             @Override
             public List<ResolvedArtifact> resolve() {
                 return Arrays.asList(
-                    ResolvedArtifact.fromNode("software.amazon.smithy:smithy-model:1.25.0", getNodeForPath("/a")),
-                    ResolvedArtifact.fromNode("software.amazon.smithy:smithy-utils:1.25.0", getNodeForPath("/b")),
-                    ResolvedArtifact.fromNode("software.amazon.smithy:smithy-other:1.25.0", getNodeForPath("/c")),
-                    ResolvedArtifact.fromNode("software.amazon.foo:foo-other:1.0.0", getNodeForPath("/d"))
+                    ResolvedArtifact.fromCoordinates(Paths.get("/a"), "software.amazon.smithy:smithy-model:1.25.0"),
+                    ResolvedArtifact.fromCoordinates(Paths.get("/b"), "software.amazon.smithy:smithy-utils:1.25.0"),
+                    ResolvedArtifact.fromCoordinates(Paths.get("/c"), "software.amazon.smithy:smithy-other:1.25.0"),
+                    ResolvedArtifact.fromCoordinates(Paths.get("/d"), "software.amazon.foo:foo-other:1.0.0")
                 );
             }
         });
 
         assertThat(filter.resolve(), contains(
-            ResolvedArtifact.fromNode("software.amazon.smithy:smithy-other:1.25.0", getNodeForPath("/c")),
-            ResolvedArtifact.fromNode("software.amazon.foo:foo-other:1.0.0", getNodeForPath("/d"))
+            ResolvedArtifact.fromCoordinates(Paths.get("/c"), "software.amazon.smithy:smithy-other:1.25.0"),
+            ResolvedArtifact.fromCoordinates(Paths.get("/d"), "software.amazon.foo:foo-other:1.0.0")
         ));
     }
 
@@ -81,18 +81,11 @@ public class FilterCliVersionResolverTest {
 
             @Override
             public List<ResolvedArtifact> resolve() {
-                return ListUtils.of(ResolvedArtifact.fromNode("software.amazon.smithy:smithy-model:1.27.0",
-                        getNodeForPath("/a")));
+                return ListUtils.of(ResolvedArtifact.fromCoordinates(Paths.get("/a"),
+                                                                     "software.amazon.smithy:smithy-model:1.27.0"));
             }
         });
 
         Assertions.assertThrows(DependencyResolverException.class, filter::resolve);
-    }
-
-    private static Node getNodeForPath(String pathStr) {
-        return Node.objectNodeBuilder()
-                .withMember("path", pathStr)
-                .withMember("shaSum", pathStr)
-                .build();
     }
 }

--- a/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/ResolvedArtifactTest.java
+++ b/smithy-cli/src/test/java/software/amazon/smithy/cli/dependencies/ResolvedArtifactTest.java
@@ -3,34 +3,28 @@ package software.amazon.smithy.cli.dependencies;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Objects;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import software.amazon.smithy.model.node.Node;
 
 public class ResolvedArtifactTest {
     @Test
-    public void loadsFromNode() {
+    public void loadsFromCoordinates() {
+        Path path = Paths.get("/a");
         String coordinates = "com.foo:baz-bam:1.2.0";
+        ResolvedArtifact artifact = ResolvedArtifact.fromCoordinates(path, coordinates);
 
-        ResolvedArtifact artifact = ResolvedArtifact.fromNode(coordinates, getNodeForPath());
-
-        assertThat(artifact.getPath(), equalTo(Paths.get("/a")));
+        assertThat(artifact.getPath(), equalTo(path));
         assertThat(artifact.getCoordinates(), equalTo(coordinates));
         assertThat(artifact.getGroupId(), equalTo("com.foo"));
         assertThat(artifact.getArtifactId(), equalTo("baz-bam"));
         assertThat(artifact.getVersion(), equalTo("1.2.0"));
-        assertThat(artifact.getShaSum(), equalTo("sum"));
     }
 
     @Test
-    public void createsCoordinatesStringFromParts() throws URISyntaxException {
-        Path path =  Paths.get(Objects.requireNonNull(getClass().getResource("test.txt")).toURI());
-
+    public void createsCoordinatesStringFromParts() {
+        Path path = Paths.get("/a");
         ResolvedArtifact artifact = new ResolvedArtifact(path, "com.foo", "baz-bam", "1.2.0");
 
         assertThat(artifact.getPath(), equalTo(path));
@@ -42,22 +36,19 @@ public class ResolvedArtifactTest {
 
     @Test
     public void validatesCoordinatesNotTooManyParts() {
+        Path path = Paths.get("/a");
         String coordinates = "com.foo:baz-bam:1.2.0:boo";
+
         Assertions.assertThrows(DependencyResolverException.class,
-                                () -> ResolvedArtifact.fromNode(coordinates, getNodeForPath()));
+                                () -> ResolvedArtifact.fromCoordinates(path, coordinates));
     }
 
     @Test
     public void validatesCoordinatesEnoughParts() {
+        Path path = Paths.get("/a");
         String coordinates = "com.foo:baz-bam";
-        Assertions.assertThrows(DependencyResolverException.class,
-                                () -> ResolvedArtifact.fromNode(coordinates, getNodeForPath()));
-    }
 
-    private static Node getNodeForPath() {
-        return Node.objectNodeBuilder()
-                .withMember("path", "/a")
-                .withMember("shaSum", "sum")
-                .build();
+        Assertions.assertThrows(DependencyResolverException.class,
+                                () -> ResolvedArtifact.fromCoordinates(path, coordinates));
     }
 }

--- a/smithy-cli/src/test/resources/software/amazon/smithy/cli/dependencies/test.txt
+++ b/smithy-cli/src/test/resources/software/amazon/smithy/cli/dependencies/test.txt
@@ -1,1 +1,0 @@
-This is a test.

--- a/smithy-utils/src/main/java/software/amazon/smithy/utils/IoUtils.java
+++ b/smithy-utils/src/main/java/software/amazon/smithy/utils/IoUtils.java
@@ -31,9 +31,6 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.security.DigestInputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -150,40 +147,6 @@ public final class IoUtils {
     public static String readUtf8Url(URL url) {
         try (InputStream is = url.openStream()) {
             return toUtf8String(is);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-    }
-
-    /**
-     * Computes the sha256 digest of a file.
-     *
-     * @param path Path to file to compute hash for.
-     * @return sha256 digest string.
-     * @throws UncheckedIOException if the specified file could not be read.
-     */
-    public static String computeSha256(Path path) {
-        try (InputStream in = Files.newInputStream(path)) {
-            MessageDigest md = MessageDigest.getInstance("SHA-256");
-            try (DigestInputStream din = new DigestInputStream(in, md)) {
-                byte[] buf = new byte[8192];
-                int n;
-                do {
-                    n = din.read(buf);
-                } while (n > 0);
-            }
-            StringBuilder sb = new StringBuilder();
-            for (byte b : md.digest()) {
-                int decimal = (int) b & 0xff;
-                String hex = Integer.toHexString(decimal);
-                if (hex.length() == 1) {
-                    sb.append('0');
-                }
-                sb.append(hex);
-            }
-            return sb.toString();
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/smithy-utils/src/test/java/software/amazon/smithy/utils/IoUtilsTest.java
+++ b/smithy-utils/src/test/java/software/amazon/smithy/utils/IoUtilsTest.java
@@ -30,7 +30,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Objects;
 import java.util.Random;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -148,13 +147,5 @@ public class IoUtilsTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> IoUtils.rmdir(path));
 
         Files.delete(path);
-    }
-
-    @Test
-    public void computesCorrectShaHash() throws URISyntaxException {
-        // Expected sha was computed using the `sha256sum` command line utility
-        String expectedSha = "4c5a232ddc90924079fd73170b97a6c32a8132437d37ca622cc70b1024396693";
-        String shaHash = IoUtils.computeSha256(Paths.get(Objects.requireNonNull(getClass().getResource("sha-test.txt")).toURI()));
-        assertEquals(shaHash, expectedSha);
     }
 }

--- a/smithy-utils/src/test/resources/software/amazon/smithy/utils/sha-test.txt
+++ b/smithy-utils/src/test/resources/software/amazon/smithy/utils/sha-test.txt
@@ -1,1 +1,0 @@
-Tests sha digest.


### PR DESCRIPTION
### Description of changes:
This reverts commit facbdc355aeb6fe97ef993957d2205ee8f822714.

The sha-1 checksum is used within the maven resolver itself and I believe we should be able to re-use that sha rather than  re-computing a checksum for each artifact.
The changes here are being reverted so that we can avoid adding unnecessary latency to the dependency resolution within the CLI.

The sha will be re-added using the resolver in: https://github.com/smithy-lang/smithy/pull/1974


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
