### PR TITLE
Retain previous examples operations

### DIFF
--- a/docs/source-2.0/quickstart.rst
+++ b/docs/source-2.0/quickstart.rst
@@ -194,6 +194,7 @@ perform updates on or examine the state of a resource.
         identifiers: { cityId: CityId }
         properties: { coordinates: CityCoordinates }
         read: GetCity
+        list: ListCities
         resources: [Forecast]
     }
 


### PR DESCRIPTION
*Description of changes:*

The `City` resource had the `list: ListCities` operation defined; however, the code snippet directly following removed it again, very likely by accident


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
