### PR TITLE
Relax Content-Length in unset union payloads

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
@@ -308,9 +308,6 @@ apply HttpPayloadWithUnion @httpRequestTests([
         method: "PUT",
         uri: "/HttpPayloadWithUnion",
         body: "",
-        headers: {
-            "Content-Length": "0"
-        },
         params: {}
     }
 ])

--- a/smithy-aws-protocol-tests/model/restXml/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-payload.smithy
@@ -573,7 +573,6 @@ apply HttpPayloadWithUnion @httpRequestTests([
         body: "",
         headers: {
             "Content-Type": "application/xml",
-            "Content-Length": "0"
         },
         params: {}
     }


### PR DESCRIPTION
Some HTTP clients will automatically set this value to 0, but others will explicitly not set the header. The length has no effect on service behavior, so it is relaxed by removing the assertion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
