### PR TITLE
Update rules engine authSchemes validation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,7 +16,7 @@ html1:
 html2:
 	@$(SPHINXBUILD) -M html "source-2.0" "build/2.0" $(SPHINXOPTS) -W --keep-going -n $(O)
 
-html: html1 html2 merge-versions
+html: html2 html1 merge-versions
 
 merge-versions:
 	mkdir -p build/html

--- a/docs/source-2.0/additional-specs/rules-engine/specification.rst
+++ b/docs/source-2.0/additional-specs/rules-engine/specification.rst
@@ -290,7 +290,7 @@ of rule conditions to that point.
 An endpoint MAY return a set of endpoint properties using the ``properties``
 field. This can be used to provide a grab-bag set of metadata associated with
 an endpoint that an endpoint resolver implementation MAY use. For example, the
-``authSchemes`` property is used to specify the priority listed order of
+``authSchemes`` property is used to specify the priority ordered list of
 authentication schemes and their configuration supported by the endpoint.
 Properties MAY contain arbitrary nested maps and arrays of strings and
 booleans.
@@ -298,6 +298,40 @@ booleans.
 .. note::
     To prevent ambiguity, the endpoint properties map MUST NOT contain
     reference or function objects. Properties MAY contain :ref:`template string <rules-engine-endpoint-rule-set-template-string>`
+
+.. _rules-engine-endpoint-rule-set-endpoint-authschemes:
+
+Endpoint ``authSchemes`` list property
+--------------------------------------
+
+The ``authSchemes`` property of an endpoint is used to specify the priority
+ordered list of authentication schemes and their configuration supported by the
+endpoint. The property is a list of configuration objects that MUST contain at
+least a ``name`` property and MAY contain additional properties. Each
+configuration object MUST have a unique value for its ``name`` property within
+the list of configuration objects within a given ``authSchemes`` property.
+
+If an ``authSchemes`` property is present on an `Endpoint object`_, clients
+MUST resolve an authentication scheme to use via the following process:
+
+#. Iterate through configuration objects in the ``authSchemes`` property.
+#. If the ``name`` property in a configuration object contains a supported
+   authentication scheme, resolve this scheme.
+#. If the ``name`` is unknown or unsupported, ignore it and continue iterating.
+#. If the list has been fully iterated and no scheme has been resolved, clients
+   MUST return an error.
+
+.. _rules-engine-standard-library-adding-authscheme-validators:
+
+Adding ``authSchemes`` configuration validators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Extensions to the rules engine can provide additional validators for
+``authSchemes`` configuration objects. No validators are provided by default.
+
+The rules engine is highly extensible through
+``software.amazon.smithy.rulesengine.language.EndpointRuleSetExtension``
+`service providers`_. See the `Javadocs`_ for more information.
 
 
 .. _rules-engine-endpoint-rule-set-error-rule:
@@ -686,3 +720,6 @@ The following two expressions are equivalent:
             "{partResult#name}"
         ]
     }
+
+.. _Javadocs: https://smithy.io/javadoc/__smithy_version__/software/amazon/smithy/rulesengine/language/EndpointRuleSetExtension.html
+.. _service providers: https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html

--- a/docs/source-2.0/aws/rules-engine/auth-schemes.rst
+++ b/docs/source-2.0/aws/rules-engine/auth-schemes.rst
@@ -1,0 +1,105 @@
+.. _rules-engine-aws-authscheme-validators:
+
+=================================================
+AWS rules engine authentication scheme validators
+=================================================
+
+AWS-specific rules engine library :ref:`authentication scheme validators <rules-engine-endpoint-rule-set-endpoint-authschemes>`
+make it possible to validate configurations for AWS authentication schemes like
+`AWS signature version 4`_. An additional dependency is required to access
+these validators
+
+The following example adds ``smithy-aws-endpoints`` as a Gradle dependency
+to a Smithy project:
+
+.. tab:: Gradle
+
+    .. code-block:: kotlin
+
+        dependencies {
+            ...
+            implementation("software.amazon.smithy:smithy-aws-endpoints:__smithy_version__")
+            ...
+        }
+
+.. tab:: smithy-build.json
+
+    .. code-block:: json
+
+        {
+            "maven": {
+                "dependencies": [
+                    "software.amazon.smithy:smithy-aws-endpoints:__smithy_version__"
+                ]
+            }
+        }
+
+.. _rules-engine-aws-authscheme-validator-sigv4:
+
+-----------------------------------------
+``sigv4`` authentication scheme validator
+-----------------------------------------
+
+Requirement
+    The ``name`` property is the string value ``sigv4``.
+Properties
+    .. list-table::
+        :header-rows: 1
+        :widths: 10 20 70
+
+        * - Property
+          - Type
+          - Description
+        * - ``signingName``
+          - ``option<string>``
+          - The "service" value to use when creating a signing string for this
+            endpoint.
+        * - ``signingRegion``
+          - ``option<string>``
+          - The "region" value to use when creating a signing string for this
+            endpoint.
+        * - ``disableDoubleEncoding``
+          - ``option<boolean>``
+          - Default: ``false``. When ``true``, clients MUST NOT double-escape
+            the path during signing.
+        * - ``disableNormalizePath``
+          - ``option<boolean>``
+          - Default: ``false``. When ``true``, clients MUST NOT perform any
+            path normalization during signing.
+
+
+.. _rules-engine-aws-authscheme-validator-sigv4a:
+
+------------------------------------------
+``sigv4a`` authentication scheme validator
+------------------------------------------
+
+Requirement
+    The ``name`` property is the string value ``sigv4a``.
+Properties
+    .. list-table::
+        :header-rows: 1
+        :widths: 10 20 70
+
+        * - Property
+          - Type
+          - Description
+        * - ``signingName``
+          - ``option<string>``
+          - The "service" value to use when creating a signing string for this
+            endpoint.
+        * - ``signingRegionSet``
+          - ``array<string>``
+          - The set of signing regions to use when creating a signing string
+            for this endpoint.
+        * - ``disableDoubleEncoding``
+          - ``option<boolean>``
+          - Default: ``false``. When ``true``, clients MUST NOT double-escape
+            the path during signing.
+        * - ``disableNormalizePath``
+          - ``option<boolean>``
+          - Default: ``false``. When ``true``, clients MUST NOT perform any
+            path normalization during signing.
+
+
+.. _AWS signature version 4: https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html

--- a/docs/source-2.0/aws/rules-engine/index.rst
+++ b/docs/source-2.0/aws/rules-engine/index.rst
@@ -14,3 +14,4 @@ configuration options.
 
     built-ins
     library-functions
+    auth-schemes

--- a/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/language/functions/errorfiles/invalid/signing-optional-properties-mistyped.errors
+++ b/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/language/functions/errorfiles/invalid/signing-optional-properties-mistyped.errors
@@ -1,0 +1,10 @@
+[WARNING] example#FizzBuzz: This shape applies a trait that is unstable: smithy.rules#endpointRuleSet | UnstableTrait
+[ERROR] example#FizzBuzz: Unexpected type for auth property `signingName`, found `1` but expected a string value | RuleSetAuthSchemes
+[ERROR] example#FizzBuzz: Unexpected type for auth property `signingRegion`, found `1` but expected a string value | RuleSetAuthSchemes
+[ERROR] example#FizzBuzz: Unexpected type for auth property `disableDoubleEncoding`, found `1` but expected a boolean value | RuleSetAuthSchemes
+[ERROR] example#FizzBuzz: Unexpected type for auth property `disableNormalizePath`, found `1` but expected a boolean value | RuleSetAuthSchemes
+[ERROR] example#FizzBuzz: Unexpected type for auth property `signingName`, found `1` but expected a string value | RuleSetAuthSchemes
+[ERROR] example#FizzBuzz: Unexpected type for auth property `signingRegionSet`, found `1` but expected an array<string> value | RuleSetAuthSchemes
+[ERROR] example#FizzBuzz: Unexpected type for auth property `disableDoubleEncoding`, found `1` but expected a boolean value | RuleSetAuthSchemes
+[ERROR] example#FizzBuzz: Unexpected type for auth property `disableNormalizePath`, found `1` but expected a boolean value | RuleSetAuthSchemes
+[ERROR] example#FizzBuzz: The `signingRegionSet` property must not be an empty list. | RuleSetAuthSchemes

--- a/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/language/functions/errorfiles/invalid/signing-optional-properties-mistyped.smithy
+++ b/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/language/functions/errorfiles/invalid/signing-optional-properties-mistyped.smithy
@@ -1,0 +1,125 @@
+$version: "2.0"
+
+namespace example
+
+use smithy.rules#endpointRuleSet
+use smithy.rules#endpointTests
+
+@endpointRuleSet({
+    "parameters": {
+        "Region": {
+            "type": "string",
+            "builtIn": "AWS::Region",
+            "documentation": "The region to dispatch this request, eg. `us-east-1`."
+        }
+    },
+    "rules": [
+        {
+            "documentation": "Show failing type validation for optional fields",
+            "conditions": [
+                {
+                    "fn": "isSet",
+                    "argv": [
+                        {
+                            "ref": "Region"
+                        }
+                    ]
+                },
+                {
+                    "fn": "stringEquals",
+                    "argv": [
+                        {
+                            "ref": "Region"
+                        },
+                        "a"
+                    ]
+                }
+            ],
+            "endpoint": {
+                "url": "https://{Region}.amazonaws.com",
+                "properties": {
+                    "authSchemes": [
+                        {
+                            "name": "sigv4",
+                            "signingName": 1,
+                            "signingRegion": 1,
+                            "disableDoubleEncoding": 1,
+                            "disableNormalizePath": 1
+                        }
+                    ]
+                }
+            },
+            "type": "endpoint"
+        },
+        {
+            "documentation": "Show failing type validation for optional fields",
+            "conditions": [
+                {
+                    "fn": "isSet",
+                    "argv": [
+                        {
+                            "ref": "Region"
+                        }
+                    ]
+                },
+                {
+                    "fn": "stringEquals",
+                    "argv": [
+                        {
+                            "ref": "Region"
+                        },
+                        "b"
+                    ]
+                }
+            ],
+            "endpoint": {
+                "url": "https://{Region}.amazonaws.com",
+                "properties": {
+                    "authSchemes": [
+                        {
+                            "name": "sigv4a",
+                            "signingName": 1,
+                            "signingRegionSet": 1,
+                            "disableDoubleEncoding": 1,
+                            "disableNormalizePath": 1
+                        }
+                    ]
+                }
+            },
+            "type": "endpoint"
+        },
+        {
+            "documentation": "Show non-empty requirement of signingRegionSet",
+            "conditions": [
+                {
+                    "fn": "isSet",
+                    "argv": [
+                        {
+                            "ref": "Region"
+                        }
+                    ]
+                },
+            ],
+            "endpoint": {
+                "url": "https://{Region}.amazonaws.com",
+                "properties": {
+                    "authSchemes": [
+                        {
+                            "name": "sigv4a",
+                            "signingRegionSet": []
+                        }
+                    ]
+                }
+            },
+            "type": "endpoint"
+        },
+        {
+            "documentation": "fallback when region is unset",
+            "conditions": [],
+            "error": "Region must be set to resolve a valid endpoint",
+            "type": "error"
+        }
+    ],
+    "version": "1.3"
+})
+service FizzBuzz {}

--- a/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/language/functions/errorfiles/valid/signing-optional-properties.errors
+++ b/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/language/functions/errorfiles/valid/signing-optional-properties.errors
@@ -1,0 +1,1 @@
+[WARNING] example#FizzBuzz: This shape applies a trait that is unstable: smithy.rules#endpointRuleSet | UnstableTrait

--- a/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/language/functions/errorfiles/valid/signing-optional-properties.smithy
+++ b/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/language/functions/errorfiles/valid/signing-optional-properties.smithy
@@ -1,0 +1,84 @@
+$version: "2.0"
+
+namespace example
+
+use smithy.rules#endpointRuleSet
+use smithy.rules#endpointTests
+
+@endpointRuleSet({
+    "parameters": {
+        "Region": {
+            "type": "string",
+            "builtIn": "AWS::Region",
+            "documentation": "The region to dispatch this request, eg. `us-east-1`."
+        }
+    },
+    "rules": [
+        {
+            "documentation": "Template the region into the URI when region is set",
+            "conditions": [
+                {
+                    "fn": "isSet",
+                    "argv": [
+                        {
+                            "ref": "Region"
+                        }
+                    ]
+                },
+                {
+                    "fn": "stringEquals",
+                    "argv": [
+                        {
+                            "ref": "Region"
+                        },
+                        "a"
+                    ]
+                }
+            ],
+            "endpoint": {
+                "url": "https://{Region}.amazonaws.com",
+                "properties": {
+                    "authSchemes": [
+                        {
+                            "name": "sigv4",
+                        }
+                    ]
+                }
+            },
+            "type": "endpoint"
+        },
+        {
+            "documentation": "Template the region into the URI when region is set",
+            "conditions": [
+                {
+                    "fn": "isSet",
+                    "argv": [
+                        {
+                            "ref": "Region"
+                        }
+                    ]
+                },
+            ],
+            "endpoint": {
+                "url": "https://{Region}.amazonaws.com",
+                "properties": {
+                    "authSchemes": [
+                        {
+                            "name": "sigv4a",
+                            "signingRegionSet": ["*"]
+                        }
+                    ]
+                }
+            },
+            "type": "endpoint"
+        },
+        {
+            "documentation": "fallback when region is unset",
+            "conditions": [],
+            "error": "Region must be set to resolve a valid endpoint",
+            "type": "error"
+        }
+    ],
+    "version": "1.3"
+})
+service FizzBuzz {}

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/validators/AuthSchemeValidator.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/validators/AuthSchemeValidator.java
@@ -10,14 +10,15 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import software.amazon.smithy.model.FromSourceLocation;
-import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.rulesengine.language.syntax.Identifier;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.literal.Literal;
+import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
  * Validates an authentication scheme after passing a predicate check.
  */
+@SmithyUnstableApi
 public interface AuthSchemeValidator extends Predicate<String> {
     /**
      * Validates that the provided {@code authScheme} matches required modeling behavior,
@@ -30,6 +31,6 @@ public interface AuthSchemeValidator extends Predicate<String> {
      */
     List<ValidationEvent> validateScheme(
             Map<Identifier, Literal> authScheme,
-            SourceLocation sourceLocation,
+            FromSourceLocation sourceLocation,
             BiFunction<FromSourceLocation, String, ValidationEvent> emitter);
 }

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-auth-name-type.errors
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-auth-name-type.errors
@@ -1,3 +1,3 @@
 [WARNING] example#FizzBuzz: This shape applies a trait that is unstable: smithy.rules#clientContextParams | UnstableTrait
 [WARNING] example#FizzBuzz: This shape applies a trait that is unstable: smithy.rules#endpointRuleSet | UnstableTrait
-[ERROR] example#FizzBuzz: Expected auth property `signingName` of a string type but didn't find one | RuleSetAuthSchemes
+[ERROR] example#FizzBuzz: Expected `authSchemes` to have a `name` key with a string value but it did not: `{name=true}` | RuleSetAuthSchemes

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-auth-name-type.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-auth-name-type.smithy
@@ -1,0 +1,67 @@
+$version: "2.0"
+
+namespace example
+
+use smithy.rules#clientContextParams
+use smithy.rules#endpointRuleSet
+use smithy.rules#endpointTests
+
+@clientContextParams(
+    bar: {type: "string", documentation: "a client string parameter"}
+)
+@endpointRuleSet({
+    version: "1.0",
+    parameters: {
+        bar: {
+            type: "string",
+            documentation: "docs"
+        }
+        endpoint: {
+            type: "string",
+            builtIn: "SDK::Endpoint",
+            required: true,
+            default: "asdf"
+            documentation: "docs"
+        },
+    },
+    rules: [
+        {
+            "documentation": "Shows invalid authScheme name type",
+            "conditions": [
+                {
+                    "fn": "isSet",
+                    "argv": [
+                        {
+                            "ref": "bar"
+                        }
+                    ]
+                }
+            ],
+            "endpoint": {
+                "url": "https://example.com/",
+                "properties": {
+                    "authSchemes": [
+                        {
+                            "name": true,
+                        }
+                    ]
+                }
+            },
+            "type": "endpoint"
+        },
+        {
+            "conditions": [],
+            "documentation": "error fallthrough",
+            "error": "endpoint error",
+            "type": "error"
+        }
+    ]
+})
+service FizzBuzz {
+    version: "2022-01-01",
+    operations: [GetThing]
+}
+
+operation GetThing {
+    input := {}
+}

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-duplicate-auth-name.errors
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-duplicate-auth-name.errors
@@ -1,0 +1,5 @@
+[WARNING] example#FizzBuzz: This shape applies a trait that is unstable: smithy.rules#clientContextParams | UnstableTrait
+[WARNING] example#FizzBuzz: This shape applies a trait that is unstable: smithy.rules#endpointRuleSet | UnstableTrait
+[WARNING] example#FizzBuzz: Did not find a validator for the `duplicate` auth scheme | RuleSetAuthSchemes
+[WARNING] example#FizzBuzz: Did not find a validator for the `duplicate` auth scheme | RuleSetAuthSchemes
+[ERROR] example#FizzBuzz: Found duplicate `name` of `duplicate` in the `authSchemes` list | RuleSetAuthSchemes

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-duplicate-auth-name.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-duplicate-auth-name.smithy
@@ -1,0 +1,70 @@
+$version: "2.0"
+
+namespace example
+
+use smithy.rules#clientContextParams
+use smithy.rules#endpointRuleSet
+use smithy.rules#endpointTests
+
+@clientContextParams(
+    bar: {type: "string", documentation: "a client string parameter"}
+)
+@endpointRuleSet({
+    version: "1.0",
+    parameters: {
+        bar: {
+            type: "string",
+            documentation: "docs"
+        }
+        endpoint: {
+            type: "string",
+            builtIn: "SDK::Endpoint",
+            required: true,
+            default: "asdf"
+            documentation: "docs"
+        },
+    },
+    rules: [
+        {
+            "documentation": "Shows invalid duplicate authScheme names",
+            "conditions": [
+                {
+                    "fn": "isSet",
+                    "argv": [
+                        {
+                            "ref": "bar"
+                        }
+                    ]
+                }
+            ],
+            "endpoint": {
+                "url": "https://example.com/",
+                "properties": {
+                    "authSchemes": [
+                        {
+                            "name": "duplicate",
+                        },
+                        {
+                            "name": "duplicate",
+                        }
+                    ]
+                }
+            },
+            "type": "endpoint"
+        },
+        {
+            "conditions": [],
+            "documentation": "error fallthrough",
+            "error": "endpoint error",
+            "type": "error"
+        }
+    ]
+})
+service FizzBuzz {
+    version: "2022-01-01",
+    operations: [GetThing]
+}
+
+operation GetThing {
+    input := {}
+}

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-missing-auth-name.errors
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-missing-auth-name.errors
@@ -1,3 +1,3 @@
 [WARNING] example#FizzBuzz: This shape applies a trait that is unstable: smithy.rules#clientContextParams | UnstableTrait
 [WARNING] example#FizzBuzz: This shape applies a trait that is unstable: smithy.rules#endpointRuleSet | UnstableTrait
-[ERROR] example#FizzBuzz: Expected auth property `signingName` of a string type but didn't find one | RuleSetAuthSchemes
+[ERROR] example#FizzBuzz: Expected `authSchemes` to have a `name` key with a string value but it did not: `{}` | RuleSetAuthSchemes

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-missing-auth-name.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-missing-auth-name.smithy
@@ -1,0 +1,65 @@
+$version: "2.0"
+
+namespace example
+
+use smithy.rules#clientContextParams
+use smithy.rules#endpointRuleSet
+use smithy.rules#endpointTests
+
+@clientContextParams(
+    bar: {type: "string", documentation: "a client string parameter"}
+)
+@endpointRuleSet({
+    version: "1.0",
+    parameters: {
+        bar: {
+            type: "string",
+            documentation: "docs"
+        }
+        endpoint: {
+            type: "string",
+            builtIn: "SDK::Endpoint",
+            required: true,
+            default: "asdf"
+            documentation: "docs"
+        },
+    },
+    rules: [
+        {
+            "documentation": "Shows invalid auth without a signing name",
+            "conditions": [
+                {
+                    "fn": "isSet",
+                    "argv": [
+                        {
+                            "ref": "bar"
+                        }
+                    ]
+                }
+            ],
+            "endpoint": {
+                "url": "https://example.com/",
+                "properties": {
+                    "authSchemes": [
+                        {}
+                    ]
+                }
+            },
+            "type": "endpoint"
+        },
+        {
+            "conditions": [],
+            "documentation": "error fallthrough",
+            "error": "endpoint error",
+            "type": "error"
+        }
+    ]
+})
+service FizzBuzz {
+    version: "2022-01-01",
+    operations: [GetThing]
+}
+
+operation GetThing {
+    input := {}
+}


### PR DESCRIPTION
This commit fixes several issues with validating authSchemes properties in defined endpoints within an endpoints rule set. It now properly enforces the typing and uniqueness of names of schemes defined within an authSchemes property.

It also fixes several issues validating the presence and typing of properties configuring the sigv4, sigv4a, and "beta" schemes.

A specification has been added to clearly detail how clients should choose schemes, detail what properties of the above schemes will be validated, and explain how to add new validators.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
