### PR TITLE
generate resource shape 'properties' with Smithy IDL serialization

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -647,7 +647,11 @@ public final class SmithyIdlModelSerializer {
             codeWriter.writeOptionalIdList("operations", shape.getIntroducedOperations());
             codeWriter.writeOptionalIdList("collectionOperations", shape.getCollectionOperations());
             codeWriter.writeOptionalIdList("resources", shape.getIntroducedResources());
-
+            if (shape.hasProperties()) {
+              codeWriter.openBlock("properties: {");
+              shape.getProperties().forEach((name, shapeId) -> codeWriter.write("$L: $I", name, shapeId));
+              codeWriter.closeBlock("}");
+            }
             codeWriter.closeBlock("}");
             codeWriter.write("");
             return null;


### PR DESCRIPTION
Adds support for outputting `properties` for resources in the Smithy IDL model serializer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
