### PR TITLE
Set source locations on smithy-diff events

### DIFF
--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedRequiredMember.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedRequiredMember.java
@@ -52,7 +52,7 @@ public class AddedRequiredMember extends AbstractDiffEvaluator {
     private ValidationEvent emit(MemberShape memberShape) {
         return ValidationEvent.builder()
                 .id(getEventId())
-                .shapeId(memberShape.getId())
+                .shape(memberShape)
                 .message("Adding a new member with the `required` trait "
                         + "but not the `default` trait is backwards-incompatible.")
                 .severity(Severity.ERROR)

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ModifiedTrait.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ModifiedTrait.java
@@ -273,6 +273,7 @@ public final class ModifiedTrait extends AbstractDiffEvaluator {
                                                          .id(getValidationEventId(this, trait))
                                                          .severity(severity)
                                                          .shape(shape)
+                                                         .sourceLocation(left.getSourceLocation())
                                                          .message(message)
                                                          .build());
             }

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedTraitDefinition.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedTraitDefinition.java
@@ -34,6 +34,7 @@ public final class RemovedTraitDefinition extends AbstractDiffEvaluator {
                         .id(getEventId())
                         .severity(Severity.ERROR)
                         .shape(shape)
+                        .sourceLocation(shape.expectTrait(TraitDefinition.class).getSourceLocation())
                         .message(String.format("Trait definition `%s` was removed", shape.getId()))
                         .build())
                 .collect(Collectors.toList());

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedOperationErrorTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedOperationErrorTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.diff.ModelDiff;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
@@ -31,13 +32,17 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 public class AddedOperationErrorTest {
     @Test
     public void detectsAddedErrors() {
+        SourceLocation s1 = new SourceLocation("main.smithy", 1, 2);
+        SourceLocation s2 = new SourceLocation("main.smithy", 3, 4);
         Shape e1 = StructureShape.builder()
                 .id("foo.baz#E1")
                 .addTrait(new ErrorTrait("client"))
+                .source(s1)
                 .build();
         Shape e2 = StructureShape.builder()
                 .id("foo.baz#E2")
                 .addTrait(new ErrorTrait("client"))
+                .source(s2)
                 .build();
         OperationShape operation1 = OperationShape.builder().id("foo.baz#Operation").build();
         Shape operation2 = operation1.toBuilder().addError(e1.getId()).addError(e2.getId()).build();
@@ -47,6 +52,8 @@ public class AddedOperationErrorTest {
 
         assertThat(TestHelper.findEvents(events, "AddedOperationError").size(), equalTo(2));
         assertThat(TestHelper.findEvents(events, "AddedOperationError.E1").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "AddedOperationError.E1").stream().findFirst().get().getSourceLocation(), equalTo(s1));
         assertThat(TestHelper.findEvents(events, "AddedOperationError.E2").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "AddedOperationError.E2").stream().findFirst().get().getSourceLocation(), equalTo(s2));
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedTraitDefinitionTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedTraitDefinitionTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.diff.ModelDiff;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.TraitDefinition;
@@ -30,9 +31,11 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 public class AddedTraitDefinitionTest {
     @Test
     public void detectsAddedTraitDefinition() {
+        SourceLocation source = new SourceLocation("main.smithy", 1, 2);
         Shape definition = StringShape.builder()
                 .id("foo.baz#bam")
                 .addTrait(TraitDefinition.builder().build())
+                .source(source)
                 .build();
 
         Model modelA = Model.assembler().assemble().unwrap();
@@ -40,5 +43,6 @@ public class AddedTraitDefinitionTest {
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "AddedTraitDefinition").size(), equalTo(1));
+        assertThat(events.get(0).getSourceLocation(), equalTo(source));
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedEnumTraitTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedEnumTraitTest.java
@@ -16,16 +16,15 @@
 package software.amazon.smithy.diff.evaluators;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 
 import java.util.List;
 
-import org.hamcrest.core.Every;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.diff.ModelDiff;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.EnumShape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.EnumDefinition;
@@ -36,6 +35,7 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 public class ChangedEnumTraitTest {
     @Test
     public void detectsAppendedEnums() {
+        SourceLocation source = new SourceLocation("main.smithy", 1, 2);
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
@@ -47,6 +47,7 @@ public class ChangedEnumTraitTest {
                 .addTrait(EnumTrait.builder()
                         .addEnum(EnumDefinition.builder().value("foo").build())
                         .addEnum(EnumDefinition.builder().value("baz").build())
+                        .sourceLocation(source)
                         .build())
                 .build();
         Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
@@ -55,10 +56,12 @@ public class ChangedEnumTraitTest {
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").get(0).getSeverity(), equalTo(Severity.NOTE));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").get(0).getSourceLocation(), equalTo(source));
     }
 
     @Test
     public void detectsAppendedEnumsEnumTraitNoNameToEnumShape() {
+        SourceLocation source = new SourceLocation("main.smithy", 1, 2);
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
@@ -71,6 +74,7 @@ public class ChangedEnumTraitTest {
                 .id("foo.baz#Baz")
                 .addMember("foo", "foo")
                 .addMember("baz", "baz")
+                .source(source)
                 .build();
         Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
         Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
@@ -80,12 +84,17 @@ public class ChangedEnumTraitTest {
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.0").size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.0").get(0).getSeverity(),
                 equalTo(Severity.ERROR));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.0").get(0).getSourceLocation(),
+                equalTo(source));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").get(1).getSeverity(),
                 equalTo(Severity.NOTE));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").get(1).getSourceLocation(),
+                equalTo(source));
     }
 
     @Test
     public void detectsAppendedEnumsEnumTraitWithNameToEnumShape() {
+        SourceLocation source = new SourceLocation("main.smithy", 1, 2);
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
@@ -93,30 +102,36 @@ public class ChangedEnumTraitTest {
                                 .name("foo")
                                 .value("foo")
                                 .build())
+                        .sourceLocation(source)
                         .build())
                 .build();
         EnumShape s2 = EnumShape.builder()
                 .id("foo.baz#Baz")
                 .addMember("foo", "foo")
                 .addMember("baz", "baz")
+                .source(source)
                 .build();
         Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
         Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").get(0).getSourceLocation(),
+                equalTo(source));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").stream()
                 .allMatch(e -> e.getSeverity() == Severity.NOTE), equalTo(true));
     }
 
     @Test
     public void detectsRemovedEnums() {
+        SourceLocation source = new SourceLocation("main.smithy", 1, 2);
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
                         .addEnum(EnumDefinition.builder().value("foo").build())
                         .addEnum(EnumDefinition.builder().value("baz").build())
                         .addEnum(EnumDefinition.builder().value("bat").build())
+                        .sourceLocation(source)
                         .build())
                 .build();
         StringShape s2 = StringShape.builder()
@@ -130,12 +145,18 @@ public class ChangedEnumTraitTest {
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.Removed.1").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.Removed.1").get(0).getSourceLocation(),
+                equalTo(source));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.Removed.2").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.Removed.2").get(0).getSourceLocation(),
+                equalTo(source));
         assertThat(TestHelper.findEvents(events, Severity.ERROR).size(), equalTo(2));
     }
 
     @Test
     public void detectsRemovedEnumsEnumTraitNoNameToEnumShape() {
+        SourceLocation beforeSource = new SourceLocation("before.smithy", 1, 2);
+        SourceLocation afterSource = new SourceLocation("after.smithy", 1, 2);
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
@@ -145,24 +166,31 @@ public class ChangedEnumTraitTest {
                         .addEnum(EnumDefinition.builder()
                                 .value("baz")
                                 .build())
+                        .sourceLocation(beforeSource)
                         .build())
                 .build();
         EnumShape s2 = EnumShape.builder()
                 .id("foo.baz#Baz")
                 .addMember("foo", "foo")
+                .source(afterSource)
                 .build();
         Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
         Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.Removed.1").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.Removed.1").get(0).getSourceLocation(),
+                equalTo(beforeSource));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.0").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.0").get(0).getSourceLocation(),
+                equalTo(afterSource));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").stream()
                 .allMatch(e -> e.getSeverity() == Severity.ERROR), equalTo(true));
     }
 
     @Test
     public void detectsRemovedEnumsEnumTraitWithNameToEnumShape() {
+        SourceLocation source = new SourceLocation("main.smithy", 1, 2);
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
@@ -174,6 +202,7 @@ public class ChangedEnumTraitTest {
                                 .name("baz")
                                 .value("baz")
                                 .build())
+                        .sourceLocation(source)
                         .build())
                 .build();
         EnumShape s2 = EnumShape.builder()
@@ -185,12 +214,15 @@ public class ChangedEnumTraitTest {
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.Removed.1").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.Removed.1").get(0).getSourceLocation(),
+                equalTo(source));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.Removed.1").stream()
                 .allMatch(e -> e.getSeverity() == Severity.ERROR), equalTo(true));
     }
 
     @Test
     public void detectsRenamedEnums() {
+        SourceLocation source = new SourceLocation("main.smithy", 1, 2);
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
@@ -204,18 +236,24 @@ public class ChangedEnumTraitTest {
                         .addEnum(EnumDefinition.builder().value("foo").name("NEW1").build())
                         .addEnum(EnumDefinition.builder().value("baz").name("NEW2").build())
                         .build())
+                .source(source)
                 .build();
         Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
         Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.0").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.0").get(0).getSourceLocation(),
+                equalTo(source));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.1").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.1").get(0).getSourceLocation(),
+                equalTo(source));
         assertThat(TestHelper.findEvents(events, Severity.ERROR).size(), equalTo(2));
     }
 
     @Test
     public void detectsRenamedEnumsEnumTraitNoNameToEnumShape() {
+        SourceLocation source = new SourceLocation("main.smithy", 1, 2);
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
@@ -227,18 +265,22 @@ public class ChangedEnumTraitTest {
         EnumShape s2 = EnumShape.builder()
                 .id("foo.baz#Baz")
                 .addMember("NEW", "foo")
+                .source(source)
                 .build();
         Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
         Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.0").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.0").get(0).getSourceLocation(),
+                equalTo(source));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.0").get(0).getSeverity(),
                 equalTo(Severity.ERROR));
     }
 
     @Test
     public void detectsRenamedEnumsEnumTraitWithNameToEnumShape() {
+        SourceLocation source = new SourceLocation("main.smithy", 1, 2);
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
@@ -251,22 +293,27 @@ public class ChangedEnumTraitTest {
         EnumShape s2 = EnumShape.builder()
                 .id("foo.baz#Baz")
                 .addMember("NEW", "foo")
+                .source(source)
                 .build();
         Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
         Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.0").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.0").get(0).getSourceLocation(),
+                equalTo(source));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.0").get(0).getSeverity(),
                 equalTo(Severity.ERROR));
     }
 
     @Test
     public void detectsInsertedEnums() {
+        SourceLocation source = new SourceLocation("main.smithy", 1, 2);
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
                         .addEnum(EnumDefinition.builder().value("foo").build())
+                        .sourceLocation(source)
                         .build())
                 .build();
         StringShape s2 = StringShape.builder()
@@ -282,16 +329,22 @@ public class ChangedEnumTraitTest {
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.OrderChanged.0").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.OrderChanged.0").get(0).getSourceLocation(),
+                equalTo(source));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.OrderChanged.1").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.OrderChanged.1").get(0).getSourceLocation(),
+                equalTo(source));
         assertThat(TestHelper.findEvents(events, Severity.ERROR).size(), equalTo(2));
     }
 
     @Test
     public void detectsInsertedEnumsBeforeAppendedEnums() {
+        SourceLocation source = new SourceLocation("main.smithy", 1, 2);
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
                         .addEnum(EnumDefinition.builder().value("foo").build())
+                        .sourceLocation(source)
                         .build())
                 .build();
         StringShape s2 = StringShape.builder()
@@ -308,18 +361,24 @@ public class ChangedEnumTraitTest {
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.OrderChanged.0").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.OrderChanged.0").get(0)
+                .getSourceLocation(), equalTo(source));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.OrderChanged.1").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.OrderChanged.1").get(0)
+                .getSourceLocation(), equalTo(source));
         assertThat(TestHelper.findEvents(events, Severity.ERROR).size(), equalTo(2));
     }
 
     @Test
     public void detectsInsertedEnumsEnumTraitNoNameToEnumShape() {
+        SourceLocation source = new SourceLocation("main.smithy", 1, 2);
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
                         .addEnum(EnumDefinition.builder()
                                 .value("foo")
                                 .build())
+                        .sourceLocation(source)
                         .build())
                 .build();
         EnumShape s2 = EnumShape.builder()
@@ -333,12 +392,15 @@ public class ChangedEnumTraitTest {
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(2));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.OrderChanged.0").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.OrderChanged.0").get(0).getSourceLocation(),
+                equalTo(source));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").stream()
                 .allMatch(e -> e.getSeverity() == Severity.ERROR), equalTo(true));
     }
 
     @Test
     public void detectsInsertedEnumsEnumTraitWithNameToEnumShape() {
+        SourceLocation source = new SourceLocation("main.smithy", 1, 2);
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
@@ -346,6 +408,7 @@ public class ChangedEnumTraitTest {
                                 .name("foo")
                                 .value("foo")
                                 .build())
+                        .sourceLocation(source)
                         .build())
                 .build();
         EnumShape s2 = EnumShape.builder()
@@ -358,18 +421,23 @@ public class ChangedEnumTraitTest {
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.OrderChanged.0").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.OrderChanged.0").get(0).getSourceLocation(),
+                equalTo(source));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.OrderChanged.0").stream()
                 .allMatch(e -> e.getSeverity() == Severity.ERROR), equalTo(true));
     }
 
     @Test
     public void detectsAppendedEnumsAfterRemovedEnums() {
+        SourceLocation beforeSource = new SourceLocation("before.smithy", 1, 2);
+        SourceLocation afterSource   = new SourceLocation("after.smithy", 1, 2);
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
                         .addEnum(EnumDefinition.builder().value("old1").build())
                         .addEnum(EnumDefinition.builder().value("old2").build())
                         .addEnum(EnumDefinition.builder().value("old3").build())
+                        .sourceLocation(beforeSource)
                         .build())
                 .build();
         StringShape s2 = StringShape.builder()
@@ -378,6 +446,7 @@ public class ChangedEnumTraitTest {
                         .addEnum(EnumDefinition.builder().value("old1").build())
                         .addEnum(EnumDefinition.builder().value("old3").build())
                         .addEnum(EnumDefinition.builder().value("new1").build())
+                        .sourceLocation(afterSource)
                         .build())
                 .build();
         Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
@@ -387,18 +456,24 @@ public class ChangedEnumTraitTest {
         List<ValidationEvent> changeEvents = TestHelper.findEvents(allEvents, "ChangedEnumTrait");
         assertThat(changeEvents.size(), equalTo(2));
         assertThat(TestHelper.findEvents(changeEvents, "ChangedEnumTrait.Removed.1").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(changeEvents, "ChangedEnumTrait.Removed.1").get(0).getSourceLocation(),
+                equalTo(beforeSource));
 
         ValidationEvent removedEvent = changeEvents.get(0);
         assertThat(removedEvent.getSeverity(), equalTo(Severity.ERROR));
         assertThat(removedEvent.getMessage(), stringContainsInOrder("Enum value `old2` was removed"));
+        assertThat(removedEvent.getSourceLocation(), equalTo(beforeSource));
 
         ValidationEvent appendedEvent = changeEvents.get(1);
         assertThat(appendedEvent.getSeverity(), equalTo(Severity.NOTE));
         assertThat(appendedEvent.getMessage(), stringContainsInOrder("Enum value `new1` was appended"));
+        assertThat(appendedEvent.getSourceLocation(), equalTo(afterSource));
     }
 
     @Test
     public void detectsAppendedEnumsAfterRemovedEnumsEnumTraitNoNameToEnumShape() {
+        SourceLocation beforeSource = new SourceLocation("before.smithy", 1, 2);
+        SourceLocation afterSource = new SourceLocation("after.smithy", 1, 2);
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
@@ -411,6 +486,7 @@ public class ChangedEnumTraitTest {
                         .addEnum(EnumDefinition.builder()
                                 .value("old3")
                                 .build())
+                        .sourceLocation(beforeSource)
                         .build())
                 .build();
         EnumShape s2 = EnumShape.builder()
@@ -418,6 +494,7 @@ public class ChangedEnumTraitTest {
                 .addMember("old1", "old1")
                 .addMember("old3", "old3")
                 .addMember("new1", "new1")
+                .source(afterSource)
                 .build();
         Model modelA = Model.assembler().addShape(s1).assemble().unwrap();
         Model modelB = Model.assembler().addShape(s2).assemble().unwrap();
@@ -425,8 +502,14 @@ public class ChangedEnumTraitTest {
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(4));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.0").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.0").get(0).getSourceLocation(),
+                equalTo(afterSource));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.Removed.1").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.Removed.1").get(0).getSourceLocation(),
+                equalTo(beforeSource));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.2").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.NameChanged.2").get(0).getSourceLocation(),
+                equalTo(afterSource));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").subList(0, 3).stream()
                 .allMatch(e -> e.getSeverity() == Severity.ERROR), equalTo(true));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").subList(3, 4).stream()
@@ -435,6 +518,7 @@ public class ChangedEnumTraitTest {
 
     @Test
     public void detectsAppendedEnumsAfterRemovedEnumsEnumTraitWithNameToEnumShape() {
+        SourceLocation source = new SourceLocation("main.smithy", 1, 2);
         StringShape s1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder()
@@ -450,6 +534,7 @@ public class ChangedEnumTraitTest {
                                 .name("old3")
                                 .value("old3")
                                 .build())
+                        .sourceLocation(source)
                         .build())
                 .build();
         EnumShape s2 = EnumShape.builder()
@@ -464,6 +549,8 @@ public class ChangedEnumTraitTest {
 
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").size(), equalTo(2));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.Removed.1").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.Removed.1").get(0).getSourceLocation(),
+                equalTo(source));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait.Removed.1").stream()
                 .allMatch(e -> e.getSeverity() == Severity.ERROR), equalTo(true));
         assertThat(TestHelper.findEvents(events, "ChangedEnumTrait").subList(1, 2).stream()

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ModifiedTraitTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ModifiedTraitTest.java
@@ -153,7 +153,11 @@ public class ModifiedTraitTest {
 
         assertThat(events, hasSize(3));
         assertThat(events.stream().filter(e -> e.getSeverity() == Severity.WARNING).count(), equalTo(1L));
+        assertThat(events.stream().filter(e -> e.getSourceLocation().getFilename().endsWith("a.smithy")).count(),
+                equalTo(1L));
         assertThat(events.stream().filter(e -> e.getSeverity() == Severity.NOTE).count(), equalTo(2L));
+        assertThat(events.stream().filter(e -> e.getSourceLocation().getFilename().endsWith("b.smithy")).count(),
+                equalTo(2L));
 
         assertThat(messages, containsInAnyOrder(
                 "Changed trait `smithy.example#b` from \"hello\" to \"hello!\"",
@@ -178,6 +182,8 @@ public class ModifiedTraitTest {
         assertThat(events, hasSize(2));
         assertThat(events.stream().filter(e -> e.getSeverity() == Severity.ERROR).count(), equalTo(1L));
         assertThat(events.stream().filter(e -> e.getSeverity() == Severity.WARNING).count(), equalTo(1L));
+        assertThat(events.stream().filter(e -> e.getSourceLocation().getFilename().endsWith("b.smithy")).count(),
+                equalTo(2L));
 
         assertThat(messages, containsInAnyOrder(
                 "Added trait contents to `smithy.example#aTrait` at path `/bar` with value \"no\"",
@@ -199,6 +205,10 @@ public class ModifiedTraitTest {
         List<String> messages = events.stream().map(ValidationEvent::getMessage).collect(Collectors.toList());
 
         assertThat(events, hasSize(4));
+        assertThat(events.stream().filter(e -> e.getMessage().contains("Removed"))
+                .filter(e -> e.getSourceLocation().getFilename().endsWith("a.smithy")).count(), equalTo(2L));
+        assertThat(events.stream().filter(e -> !e.getMessage().contains("Removed"))
+                .filter(e -> e.getSourceLocation().getFilename().endsWith("b.smithy")).count(), equalTo(2L));
         assertThat(messages, containsInAnyOrder(
                 "Changed trait contents of `smithy.example#aTrait` at path `/foo/1` from \"b\" to \"B\"",
                 "Added trait contents to `smithy.example#aTrait` at path `/foo/3` with value \"4\"",
@@ -222,6 +232,10 @@ public class ModifiedTraitTest {
         List<String> messages = events.stream().map(ValidationEvent::getMessage).collect(Collectors.toList());
 
         assertThat(events, hasSize(4));
+        assertThat(events.stream().filter(e -> e.getMessage().contains("Removed"))
+                .filter(e -> e.getSourceLocation().getFilename().endsWith("a.smithy")).count(), equalTo(2L));
+        assertThat(events.stream().filter(e -> !e.getMessage().contains("Removed"))
+                .filter(e -> e.getSourceLocation().getFilename().endsWith("b.smithy")).count(), equalTo(2L));
         assertThat(messages, containsInAnyOrder(
                 "Changed trait contents of `smithy.example#aTrait` at path `/foo/1` from \"b\" to \"B\"",
                 "Added trait contents to `smithy.example#aTrait` at path `/foo/3` with value \"4\"",
@@ -244,6 +258,10 @@ public class ModifiedTraitTest {
         List<String> messages = events.stream().map(ValidationEvent::getMessage).collect(Collectors.toList());
 
         assertThat(events, hasSize(4));
+        assertThat(events.stream().filter(e -> e.getMessage().contains("Removed"))
+                .filter(e -> e.getSourceLocation().getFilename().endsWith("a.smithy")).count(), equalTo(2L));
+        assertThat(events.stream().filter(e -> !e.getMessage().contains("Removed"))
+                .filter(e -> e.getSourceLocation().getFilename().endsWith("b.smithy")).count(), equalTo(2L));
         assertThat(messages, containsInAnyOrder(
                 "Changed trait contents of `smithy.example#aTrait` at path `/foo/bam` from \"b\" to \"B\"",
                 "Removed trait contents from `smithy.example#aTrait` at path `/foo`. Removed value: {\n    \"baz\": \"1\",\n    \"bam\": \"2\",\n    \"boo\": \"3\"\n}",
@@ -266,6 +284,8 @@ public class ModifiedTraitTest {
         List<String> messages = events.stream().map(ValidationEvent::getMessage).collect(Collectors.toList());
 
         assertThat(events, hasSize(2));
+        assertThat(events.stream().filter(e -> e.getSourceLocation().getFilename().endsWith("b.smithy")).count(),
+                equalTo(2L));
         assertThat(messages, containsInAnyOrder(
                 "Changed trait contents of `smithy.example#aTrait` at path `/baz/foo` from \"a\" to \"b\"",
                 "Changed trait contents of `smithy.example#aTrait` at path `/baz/baz` from \"a\" to \"b\""
@@ -286,6 +306,10 @@ public class ModifiedTraitTest {
         List<String> messages = events.stream().map(ValidationEvent::getMessage).collect(Collectors.toList());
 
         assertThat(events, hasSize(12));
+        assertThat(events.stream().filter(e -> e.getMessage().contains("Removed"))
+                .filter(e -> e.getSourceLocation().getFilename().endsWith("a.smithy")).count(), equalTo(3L));
+        assertThat(events.stream().filter(e -> e.getMessage().contains("Changed") || e.getMessage().contains("Added"))
+                .filter(e -> e.getSourceLocation().getFilename().endsWith("b.smithy")).count(), equalTo(9L));
         assertThat(messages, containsInAnyOrder(
                 "Added trait contents to `smithy.example#aTrait` at path `/a` with value \"a\"",
                 "Removed trait contents from `smithy.example#aTrait` at path `/b`. Removed value: \"a\"",

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.diff.ModelDiff;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
@@ -30,11 +31,13 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 public class RemovedEntityBindingTest {
     @Test
     public void detectsRemovedOperationFromService() {
+        SourceLocation source = new SourceLocation("foo.smithy");
         OperationShape o = OperationShape.builder().id("foo.baz#Operation").build();
         ServiceShape service1 = ServiceShape.builder()
                 .version("1")
                 .id("foo.baz#Service")
                 .addOperation(o.getId())
+                .source(source)
                 .build();
         ServiceShape service2 = service1.toBuilder().clearOperations().build();
         Model modelA = Model.assembler().addShapes(service1, o).assemble().unwrap();
@@ -42,27 +45,32 @@ public class RemovedEntityBindingTest {
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "RemovedOperationBinding.FromService.Operation").size(), equalTo(1));
+        assertThat(events.get(0).getSourceLocation(), equalTo(source));
     }
 
     @Test
     public void detectsRemovedOperationFromResource() {
+        SourceLocation source = new SourceLocation("foo.smithy");
         OperationShape o = OperationShape.builder().id("foo.baz#Operation").build();
-        ResourceShape r1 = ResourceShape.builder().id("foo.baz#Resource").addOperation(o.getId()).build();
+        ResourceShape r1 = ResourceShape.builder().id("foo.baz#Resource").addOperation(o.getId()).source(source).build();
         ResourceShape r2 = r1.toBuilder().clearOperations().build();
         Model modelA = Model.assembler().addShapes(r1, o).assemble().unwrap();
         Model modelB = Model.assembler().addShapes(r2, o).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "RemovedOperationBinding.FromResource.Operation").size(), equalTo(1));
+        assertThat(events.get(0).getSourceLocation(), equalTo(source));
     }
 
     @Test
     public void detectsRemovedResourceFromService() {
+        SourceLocation source = new SourceLocation("foo.smithy");
         ResourceShape r = ResourceShape.builder().id("foo.baz#Resource").build();
         ServiceShape service1 = ServiceShape.builder()
                 .id("foo.baz#Service")
                 .version("1")
                 .addResource(r.getId())
+                .source(source)
                 .build();
         ServiceShape service2 = service1.toBuilder().clearResources().build();
         Model modelA = Model.assembler().addShapes(service1, r).assemble().unwrap();
@@ -70,17 +78,20 @@ public class RemovedEntityBindingTest {
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "RemovedResourceBinding.FromService.Resource").size(), equalTo(1));
+        assertThat(events.get(0).getSourceLocation(), equalTo(source));
     }
 
     @Test
     public void detectsRemovedResourceFromResource() {
+        SourceLocation source = new SourceLocation("foo.smithy");
         ResourceShape child = ResourceShape.builder().id("foo.baz#C").build();
-        ResourceShape p1 = ResourceShape.builder().id("foo.baz#P").addResource(child.getId()).build();
+        ResourceShape p1 = ResourceShape.builder().id("foo.baz#P").addResource(child.getId()).source(source).build();
         ResourceShape p2 = p1.toBuilder().clearResources().build();
         Model modelA = Model.assembler().addShapes(p1, child).assemble().unwrap();
         Model modelB = Model.assembler().addShapes(p2, child).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "RemovedResourceBinding.FromResource.C").size(), equalTo(1));
+        assertThat(events.get(0).getSourceLocation(), equalTo(source));
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedTraitDefinitionTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedTraitDefinitionTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.diff.ModelDiff;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.traits.TraitDefinition;
@@ -30,9 +31,10 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 public class RemovedTraitDefinitionTest {
     @Test
     public void detectsRemovedTraitDefinition() {
+        SourceLocation source = new SourceLocation("bar.smithy");
         Shape definition = StringShape.builder()
                 .id("foo.baz#bam")
-                .addTrait(TraitDefinition.builder().build())
+                .addTrait(TraitDefinition.builder().sourceLocation(source).build())
                 .build();
 
         Model modelA = Model.assembler().addShape(definition).assemble().unwrap();
@@ -40,5 +42,7 @@ public class RemovedTraitDefinitionTest {
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "RemovedTraitDefinition").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, "RemovedTraitDefinition").get(0).getSourceLocation(),
+                equalTo(source));
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ServiceRenameTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ServiceRenameTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.diff.ModelDiff;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.validation.Severity;
@@ -48,6 +49,7 @@ public class ServiceRenameTest {
 
     @Test
     public void detectsRenameRemoved() {
+        SourceLocation source = new SourceLocation("foo.smithy");
         ServiceShape service1 = service.toBuilder()
                 .putRename(operation.getId(), "O1")
                 .build();
@@ -57,6 +59,7 @@ public class ServiceRenameTest {
 
         ServiceShape service2 = service.toBuilder()
                 .clearRename()
+                .source(source)
                 .build();
         Model modelB = modelA.toBuilder().addShape(service2).build();
 
@@ -64,10 +67,12 @@ public class ServiceRenameTest {
         assertThat(TestHelper.findEvents(events, "ServiceRename").size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, service2.getId()).size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, Severity.ERROR).size(), equalTo(1));
+        assertThat(events.get(0).getSourceLocation(), equalTo(source));
     }
 
     @Test
     public void detectsRenameChange() {
+        SourceLocation source = new SourceLocation("foo.smithy");
         ServiceShape service1 = service.toBuilder()
                 .putRename(operation.getId(), "O1")
                 .build();
@@ -77,6 +82,7 @@ public class ServiceRenameTest {
 
         ServiceShape service2 = service.toBuilder()
                 .putRename(operation.getId(), "O2")
+                .source(source)
                 .build();
         Model modelB = modelA.toBuilder().addShape(service2).build();
 
@@ -84,16 +90,19 @@ public class ServiceRenameTest {
         assertThat(TestHelper.findEvents(events, "ServiceRename").size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, service2.getId()).size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, Severity.ERROR).size(), equalTo(1));
+        assertThat(events.get(0).getSourceLocation(), equalTo(source));
     }
 
     @Test
     public void detectsRenameAdded() {
+        SourceLocation source = new SourceLocation("foo.smithy");
         Model modelA = Model.builder()
                 .addShapes(operation, service)
                 .build();
 
         ServiceShape service2 = service.toBuilder()
                 .putRename(operation.getId(), "O2")
+                .source(source)
                 .build();
         Model modelB = modelA.toBuilder().addShape(service2).build();
 
@@ -102,6 +111,7 @@ public class ServiceRenameTest {
         assertThat(TestHelper.findEvents(events, "ServiceRename").size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, service2.getId()).size(), equalTo(1));
         assertThat(TestHelper.findEvents(events, Severity.ERROR).size(), equalTo(1));
+        assertThat(events.get(0).getSourceLocation(), equalTo(source));
     }
 
     @Test

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EnumShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EnumShape.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import software.amazon.smithy.model.SourceException;
+import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.traits.DeprecatedTrait;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.EnumDefinition;
@@ -516,6 +517,11 @@ public final class EnumShape extends StringShape {
             }
             members(NamedMemberUtils.flattenMixins(members.get(), getMixins(), getId(), getSourceLocation()));
             return (Builder) super.flattenMixins();
+        }
+
+        @Override
+        public Builder source(SourceLocation source) {
+            return (Builder) super.source(source);
         }
     }
 }


### PR DESCRIPTION
This PR updates smithy-diff evaluators to set source locations on the emitted events where the source location was missing previously.

For events where something is removed from a model (member, trait definition, etc), the location from the old model is used. For events where something is added or modified within a model, the location from the new model is used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
