### PR TITLE
Add examples link to sidebar

### DIFF
--- a/docs/source-2.0/index.rst
+++ b/docs/source-2.0/index.rst
@@ -157,4 +157,5 @@ Read more
 
     Source code <https://github.com/smithy-lang/smithy>
     Awesome Smithy <https://github.com/smithy-lang/awesome-smithy>
+    Smithy Examples <https://github.com/smithy-lang/smithy-examples>
     1.0 Documentation <https://smithy.io/1.0/>


### PR DESCRIPTION
*Description of changes:*
Adds a link to the sidebar to the smithy-examples repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
