### PR TITLE
fix for ExampleTrait.Example equality

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExamplesTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExamplesTrait.java
@@ -194,6 +194,19 @@ public final class ExamplesTrait extends AbstractTrait implements ToSmithyBuilde
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Example example = (Example) o;
+            return allowConstraintErrors == example.allowConstraintErrors && Objects.equals(title, example.title) && Objects.equals(documentation, example.documentation) && Objects.equals(input, example.input) && Objects.equals(output, example.output) && Objects.equals(error, example.error);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(title, documentation, input, output, error, allowConstraintErrors);
+        }
+
+        @Override
         public Builder toBuilder() {
             return new Builder().documentation(documentation).title(title).input(input).output(output).error(error)
                     .allowConstraintErrors(allowConstraintErrors);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExamplesTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExamplesTrait.java
@@ -195,10 +195,16 @@ public final class ExamplesTrait extends AbstractTrait implements ToSmithyBuilde
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
             Example example = (Example) o;
-            return allowConstraintErrors == example.allowConstraintErrors && Objects.equals(title, example.title) && Objects.equals(documentation, example.documentation) && Objects.equals(input, example.input) && Objects.equals(output, example.output) && Objects.equals(error, example.error);
+            return allowConstraintErrors == example.allowConstraintErrors && Objects.equals(title, example.title) &&
+                    Objects.equals(documentation, example.documentation) && Objects.equals(input, example.input) &&
+                    Objects.equals(output, example.output) && Objects.equals(error, example.error);
         }
 
         @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExamplesTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExamplesTrait.java
@@ -202,9 +202,9 @@ public final class ExamplesTrait extends AbstractTrait implements ToSmithyBuilde
                 return false;
             }
             Example example = (Example) o;
-            return allowConstraintErrors == example.allowConstraintErrors && Objects.equals(title, example.title) &&
-                    Objects.equals(documentation, example.documentation) && Objects.equals(input, example.input) &&
-                    Objects.equals(output, example.output) && Objects.equals(error, example.error);
+            return allowConstraintErrors == example.allowConstraintErrors && Objects.equals(title, example.title)
+                    && Objects.equals(documentation, example.documentation) && Objects.equals(input, example.input)
+                    && Objects.equals(output, example.output) && Objects.equals(error, example.error);
         }
 
         @Override

--- a/smithy-model/src/test/java/software/amazon/smithy/model/ModelTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/ModelTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -38,13 +39,10 @@ import software.amazon.smithy.model.knowledge.KnowledgeIndex;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.node.ExpectationNotMetException;
 import software.amazon.smithy.model.node.Node;
-import software.amazon.smithy.model.shapes.EnumShape;
-import software.amazon.smithy.model.shapes.IntegerShape;
-import software.amazon.smithy.model.shapes.ListShape;
-import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.shapes.StringShape;
-import software.amazon.smithy.model.shapes.TimestampShape;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.shapes.*;
+import software.amazon.smithy.model.traits.ExamplesTrait;
 import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.model.traits.synthetic.OriginalShapeIdTrait;
 
@@ -77,6 +75,26 @@ public class ModelTest {
         assertThat(modelA, equalTo(modelA));
         assertThat(modelA, not(equalTo(modelB)));
         assertThat(modelA, not(equalTo(null)));
+    }
+
+    @Test
+    public void modelEqualityExamples() {
+        StructureShape opInput = StructureShape.builder().id(ShapeId.fromParts("foo", "FooInput")).addMember("test", ShapeId.from("smithy.api#String")).build();
+        Supplier<OperationShape> op = () -> {
+            ExamplesTrait.Example example = ExamplesTrait.Example.builder().title("anything").input(ObjectNode.builder().withMember("test", StringNode.from("something")).build()).build();
+            ExamplesTrait examples = ExamplesTrait.builder().addExample(example).build();
+            return OperationShape.builder().id(ShapeId.fromParts("foo", "Foo")).input(opInput).addTrait(examples).build();
+        };
+
+        Model modelA = Model.builder()
+                .addShape(op.get())
+                .build();
+        Model modelB = Model.builder()
+                .addShape(op.get())
+                .build();
+
+        assertThat(modelA, equalTo(modelA));
+        assertThat(modelA, equalTo(modelB));
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*

Found this issue through:

```scala
val modelString =
  """|$version: "2"
     |
     |namespace foo
     |
     |@examples([
     |  {
     |    title: "Test This"
     |    input: {
     |      test: "something"
     |    }
     |  }
     |])
     |operation Foo {
     |  input := {
     |    test: String
     |  }
     |}
     |""".stripMargin

val one = Model
  .assembler()
  .addUnparsedModel("foo.smithy", modelString)
  .assemble()
  .unwrap()
val two = Model
  .assembler()
  .addUnparsedModel("foo.smithy", modelString)
  .assemble()
  .unwrap()

one == two // false
```

I've allowed edits from maintainers, feel free to change as you see fit or tell me what to change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

YES
