### PR TITLE
Add automatic integration configuration

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SmithyIntegration.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SmithyIntegration.java
@@ -75,9 +75,8 @@ public interface SmithyIntegration<S, W extends SymbolWriter<W, ?>, C extends Co
      * Configures the integration.
      *
      * <p>This provides access to both the parsed settings for the generator and
-     * an unparsed {@link ObjectNode} containing settings for all integrations.
-     * Integrations SHOULD put all of their settings inside a nested object so
-     * that they don't experience conflicts with other integrations.
+     * an unparsed {@link ObjectNode} containing settings for this particular
+     * integration.
      *
      * <p>The following {@code smithy-build.json} file contains an example of how
      * this configuration will be set.
@@ -102,9 +101,9 @@ public interface SmithyIntegration<S, W extends SymbolWriter<W, ?>, C extends Co
      * }
      * }</pre>
      *
-     * <p>In this example, everything under the key {@code integrations} will be
-     * provided as the {@code rawSettings} value and the {@code my-integration} key
-     * represents the settings for a particular integration.
+     * <p>In this example, an integration whose {@link #name} is {@code my-integration}
+     * Would receive the extra settings from the key of the same name within the
+     * {@code integrations} node.
      *
      * <p>Integrations SHOULD use modeled traits as much as possible to drive
      * configuration. This is intended for configuration that doesn't make sense

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SmithyIntegration.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/SmithyIntegration.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.utils.AbstractCodeWriter;
 import software.amazon.smithy.utils.CodeInterceptor;
 import software.amazon.smithy.utils.CodeSection;
@@ -71,6 +72,50 @@ public interface SmithyIntegration<S, W extends SymbolWriter<W, ?>, C extends Co
     }
 
     /**
+     * Configures the integration.
+     *
+     * <p>This provides access to both the parsed settings for the generator and
+     * an unparsed {@link ObjectNode} containing settings for all integrations.
+     * Integrations SHOULD put all of their settings inside a nested object so
+     * that they don't experience conflicts with other integrations.
+     *
+     * <p>The following {@code smithy-build.json} file contains an example of how
+     * this configuration will be set.
+     *
+     * <pre>{@code
+     * {
+     *     "version": "1.0",
+     *     "projections": {
+     *         "codegen-projection": {
+     *             "plugins": {
+     *                 "code-generator": {
+     *                     "service": "com.example#DocumentedService",
+     *                     "integrations": {
+     *                         "my-integration": {
+     *                             "example-setting": "foo"
+     *                         }
+     *                     }
+     *                 }
+     *             }
+     *         }
+     *     }
+     * }
+     * }</pre>
+     *
+     * <p>In this example, everything under the key {@code integrations} will be
+     * provided as the {@code rawSettings} value and the {@code my-integration} key
+     * represents the settings for a particular integration.
+     *
+     * <p>Integrations SHOULD use modeled traits as much as possible to drive
+     * configuration. This is intended for configuration that doesn't make sense
+     * as a trait, such as configuring a documentation theme.
+     *
+     * @param settings Settings used to generate code.
+     * @param integrationSettings Settings used to configure integrations.
+     */
+    default void configure(S settings, ObjectNode integrationSettings) {}
+
+    /**
      * Gets the names of integrations that this integration must come before.
      *
      * <p>Dependencies are soft. Dependencies on integration names that cannot be found
@@ -103,7 +148,7 @@ public interface SmithyIntegration<S, W extends SymbolWriter<W, ?>, C extends Co
      * <p>By default, this method will return the given {@code model} as-is.
      *
      * @param model Model being generated.
-     * @param settings Setting used to generate code.
+     * @param settings Settings used to generate code.
      * @return Returns the updated model.
      */
     default Model preprocessModel(Model model, S settings) {
@@ -122,7 +167,7 @@ public interface SmithyIntegration<S, W extends SymbolWriter<W, ?>, C extends Co
      * <p>This integration method should be called only after {@link #preprocessModel}.
      *
      * @param model Model being generated.
-     * @param settings Setting used to generate.
+     * @param settings Settings used to generate.
      * @param symbolProvider The original {@code SymbolProvider}.
      * @return The decorated {@code SymbolProvider}.
      */

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -145,6 +145,8 @@ public final class CodegenDirector<
     /**
      * Sets the required settings object used for code generation.
      *
+     * <p>{@link #integrationSettings} MUST also be set.
+     *
      * @param settings Settings object.
      */
     public void settings(S settings) {
@@ -205,7 +207,8 @@ public final class CodegenDirector<
      * }</pre>
      *
      * <p>In this example, the value of the {@code integrations} key is what must
-     * be passed to this method.
+     * be passed to this method. The value of the {@code my-integration} key will
+     * then be provided to an integration with the name {@code my-integration}.
      *
      * @param integrationSettings Settings used to configure integrations.
      */
@@ -411,7 +414,7 @@ public final class CodegenDirector<
         List<I> integrations = SmithyIntegration.sort(integrationFinder.get());
         integrations.forEach(i -> {
             LOGGER.finest(() -> "Found integration " + i.getClass().getCanonicalName());
-            i.configure(settings, integrationSettings);
+            i.configure(settings, integrationSettings.getObjectMember(i.name()).orElse(Node.objectNode()));
         });
         return integrations;
     }

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CapturingIntegration.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CapturingIntegration.java
@@ -12,6 +12,11 @@ public class CapturingIntegration implements TestIntegration {
     public ObjectNode integrationSettings = Node.objectNode();
 
     @Override
+    public String name() {
+        return "capturing-integration";
+    }
+
+    @Override
     public void configure(TestSettings settings, ObjectNode integrationSettings) {
         this.integrationSettings = integrationSettings;
     }

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CapturingIntegration.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CapturingIntegration.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.codegen.core.directed;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+
+public class CapturingIntegration implements TestIntegration {
+    public ObjectNode integrationSettings = Node.objectNode();
+
+    @Override
+    public void configure(TestSettings settings, ObjectNode integrationSettings) {
+        this.integrationSettings = integrationSettings;
+    }
+}

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
@@ -19,6 +19,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +36,7 @@ import software.amazon.smithy.codegen.core.WriterDelegator;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.ExpectationNotMetException;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 public class CodegenDirectorTest {
@@ -41,6 +45,8 @@ public class CodegenDirectorTest {
         public final List<ShapeId> generatedShapes = new ArrayList<>();
         public final List<ShapeId> generatedEnumTypeEnums = new ArrayList<>();
         public final List<ShapeId> generatedStringTypeEnums = new ArrayList<>();
+
+        public final List<TestIntegration> integrations = new ArrayList<>();
 
         @Override
         public SymbolProvider createSymbolProvider(CreateSymbolProviderDirective<TestSettings> directive) {
@@ -52,6 +58,8 @@ public class CodegenDirectorTest {
 
         @Override
         public TestContext createContext(CreateContextDirective<TestSettings, TestIntegration> directive) {
+            integrations.clear();
+            integrations.addAll(directive.integrations());
             WriterDelegator<TestWriter> delegator = new WriterDelegator<>(
                     directive.fileManifest(),
                     directive.symbolProvider(),
@@ -338,5 +346,41 @@ public class CodegenDirectorTest {
                 ShapeId.from("smithy.example#RecursiveB"),
                 ShapeId.from("smithy.example#Foo")
         ));
+    }
+
+    @Test
+    public void testConfiguresIntegrations() {
+        TestDirected testDirected = new TestDirected();
+        CodegenDirector<TestWriter, TestIntegration, TestContext, TestSettings> runner
+            = new CodegenDirector<>();
+        FileManifest manifest = new MockManifest();
+        Model model = Model.assembler()
+            .addImport(getClass().getResource("needs-sorting.smithy"))
+            .assemble()
+            .unwrap();
+
+        ObjectNode integrationSettings = Node.objectNode().withMember("spam", "eggs");
+        ObjectNode settings = Node.objectNode()
+            .withMember("foo", "hi")
+            .withMember("integrations", integrationSettings);
+        runner.settings(TestSettings.class, settings);
+        runner.directedCodegen(testDirected);
+        runner.fileManifest(manifest);
+        runner.service(ShapeId.from("smithy.example#Foo"));
+        runner.model(model);
+        runner.integrationClass(TestIntegration.class);
+        runner.performDefaultCodegenTransforms();
+        runner.shapeGenerationOrder(ShapeGenerationOrder.NONE);
+        runner.run();
+
+        assertThat(testDirected.integrations, not(empty()));
+        CapturingIntegration capturingIntegration = null;
+        for (TestIntegration integration : testDirected.integrations) {
+            if (integration instanceof CapturingIntegration) {
+                capturingIntegration = (CapturingIntegration) integration;
+            }
+        }
+        assertThat(capturingIntegration, notNullValue());
+        assertThat(capturingIntegration.integrationSettings, equalTo(integrationSettings));
     }
 }

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/directed/CodegenDirectorTest.java
@@ -360,9 +360,11 @@ public class CodegenDirectorTest {
             .unwrap();
 
         ObjectNode integrationSettings = Node.objectNode().withMember("spam", "eggs");
+        ObjectNode allIntegrationSettings = Node.objectNode()
+                .withMember("capturing-integration", integrationSettings);
         ObjectNode settings = Node.objectNode()
             .withMember("foo", "hi")
-            .withMember("integrations", integrationSettings);
+            .withMember("integrations", allIntegrationSettings);
         runner.settings(TestSettings.class, settings);
         runner.directedCodegen(testDirected);
         runner.fileManifest(manifest);

--- a/smithy-codegen-core/src/test/resources/META-INF/services/software.amazon.smithy.codegen.core.directed.TestIntegration
+++ b/smithy-codegen-core/src/test/resources/META-INF/services/software.amazon.smithy.codegen.core.directed.TestIntegration
@@ -1,0 +1,1 @@
+software.amazon.smithy.codegen.core.directed.CapturingIntegration


### PR DESCRIPTION
This adds a configuration step for integrations, allowing them to use `smithy-build.json` settings that aren't used by the generator that they target.

Generators using the node mapper helper for their settings will have this set for free. Others will need to grab it themselves.


### FAQ

#### Why not just have integration drive configuration through traits

Yes that's the *ideal* but some things just don't make sense as traits. For example, a trait that controls whether a documentation generator scans your system for the presence of a build tool and all the other dependencies you need doesn't make sense as a trait.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
