### PR TITLE
Mitigate possible NSE exception in PrivateAccessValidator.java

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PrivateAccessValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PrivateAccessValidator.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.model.validation.validators;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.NeighborProviderIndex;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PrivateAccessValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/PrivateAccessValidator.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.model.validation.validators;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
 import software.amazon.smithy.model.neighbor.NeighborProvider;


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

Within `PrivateAccessValidator#getPrivateAccessValiationEvent`, an unchecked call to `Optional#get` occurs. This might throw a `NoSuchElementException` if the optional is indeed empty.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
