### PR TITLE
Add basic website analytics

### DIFF
--- a/docs/_templates/base.html
+++ b/docs/_templates/base.html
@@ -1,0 +1,6 @@
+{% extends "!base.html" %}
+
+{%- block extrahead -%}
+<script src="https://a0.awsstatic.com/s_code/js/3.0/awshome_s_code.js"></script>
+<script src="https://d2c.aws.amazon.com/client/loader/v1/d2c-load.js"></script>
+{%- endblock -%}


### PR DESCRIPTION
*Description of changes:*
Adds basic website analytics to the Smithy documentation site. The script header added in this PR will be added to the `<head>` of every page on the docs site.

In particular we will be tracking the following as a way to gauge external adoption of and engagement around Smithy: 
- Page views per page
- Number of unique visitors
- Referring domain

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
