### PR TITLE
Resolve dupe apply to mixed members

### DIFF
--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -1341,4 +1341,31 @@ public class ModelAssemblerTest {
         assertThat(result.getValidationEvents(Severity.ERROR).get(0).getMessage(),
                    equalTo("Error creating trait `smithy.foo#baz`: Oops!"));
     }
+
+    @Test
+    public void resolvesDuplicateTraitApplicationsToDuplicateMixedInMembers() throws Exception {
+        String model = IoUtils.readUtf8File(Paths.get(getClass().getResource("mixins/apply-to-mixed-member.json").toURI()));
+        // Should be able to de-conflict the apply statements when the same model is loaded multiple times.
+        // See https://github.com/smithy-lang/smithy/issues/2004
+        Model.assembler()
+                .addUnparsedModel("test.json", model)
+                .addUnparsedModel("test2.json", model)
+                .addUnparsedModel("test3.json", model)
+                .assemble()
+                .unwrap();
+    }
+
+    @Test
+    public void resolvesDuplicateTraitApplicationsToSameMixedInMember() throws Exception {
+        String modelToApplyTo = IoUtils.readUtf8File(Paths.get(getClass().getResource("mixins/mixed-member.smithy").toURI()));
+        String modelWithApply = IoUtils.readUtf8File(Paths.get(getClass().getResource("mixins/member-apply-other-namespace.smithy").toURI()));
+        // Should be able to load when you have multiple identical apply statements to the same mixed in member.
+        // See https://github.com/smithy-lang/smithy/issues/2004
+        Model.assembler()
+                .addUnparsedModel("mixed-member.smithy", modelToApplyTo)
+                .addUnparsedModel("member-apply-1.smithy", modelWithApply)
+                .addUnparsedModel("member-apply-2.smithy", modelWithApply)
+                .assemble()
+                .unwrap();
+    }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/apply-to-mixed-member.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/apply-to-mixed-member.json
@@ -1,0 +1,34 @@
+{
+    "smithy": "2.0",
+    "shapes": {
+        "com.example#Common": {
+            "type": "structure",
+            "members": {
+                "description": {
+                    "target": "smithy.api#String",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#mixin": {}
+            }
+        },
+        "com.example#Thing": {
+            "type": "structure",
+            "mixins": [
+                {
+                    "target": "com.example#Common"
+                }
+            ],
+            "members": {}
+        },
+        "com.example#Thing$description": {
+            "type": "apply",
+            "traits": {
+                "smithy.api#default": "test"
+            }
+        }
+    }
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/member-apply-other-namespace.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/member-apply-other-namespace.smithy
@@ -1,0 +1,7 @@
+$version: "2.0"
+
+namespace com.example.other
+
+use com.example#Thing
+
+apply Thing$description @default("test")

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/mixed-member.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/mixed-member.smithy
@@ -1,0 +1,11 @@
+$version: "2.0"
+
+namespace com.example
+
+@mixin
+structure Common {
+    @required
+    description: String
+}
+
+structure Thing with [Common] {}


### PR DESCRIPTION
Fixes https://github.com/smithy-lang/smithy/issues/2004.

When an apply statement targets a mixed in member, the trait application is stored until the mixed in member has been synthesized. However, if you load the same model file multiple times in the same loader, the trait application is only stored once, and removed when it is claimed, so when de-conflicting the duplicate mixed-in member definitions, only one of them will have the trait applied, resulting in a conflict.

This commit updates the loader to keep track of when these unclaimed traits have been claimed, rather than just removing them when claimed. As long as the traits have been claimed once, we know they aren't being applied to a non-existent shape. This allows the traits to be claimed multiple times if necessary.

Test cases were added for two different situations:
1. If the exact same model is loaded multiple times, so there are multiple instances where the traits need to be claimed. In this case there shouldn't be conflicts like in the issue.
2. If the apply statement is loaded multiple times, but the member it targets is only loaded once. In this case there shouldn't be any unclaimed traits, even though there are technically multiple of the same apply
statements.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
