### PR TITLE
Scalar RemovedShape events from ERROR -> NOTE

### DIFF
--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedShape.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedShape.java
@@ -19,13 +19,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 import software.amazon.smithy.diff.Differences;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.PrivateTrait;
+import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
 /**
  * Creates an ERROR event when a non-private non-scalar shape is removed.
- * Creates a NOTE event when a non-private scalar shape is removed.
+ * Creates a WARNING event when a non-private scalar shape is removed.
  */
 public final class RemovedShape extends AbstractDiffEvaluator {
     @Override
@@ -33,8 +35,14 @@ public final class RemovedShape extends AbstractDiffEvaluator {
         return differences.removedShapes()
                 .filter(shape -> !shape.hasTrait(PrivateTrait.class))
                 .filter(shape -> !isMemberOfRemovedShape(shape, differences))
-                .map(shape -> isScalarType(shape)
-                        ? note(shape, String.format("Removed %s `%s`", shape.getType(), shape.getId()))
+                .map(shape -> isInconsequentialType(shape)
+                        ? ValidationEvent.builder()
+                            .severity(Severity.WARNING)
+                            .message(String.format("Removed %s `%s`", shape.getType(), shape.getId()))
+                            .shapeId(shape.getId())
+                            .id(getEventId() + ".ScalarShape")
+                            .sourceLocation(shape.getSourceLocation())
+                            .build()
                         : error(shape, String.format("Removed %s `%s`", shape.getType(), shape.getId())))
                 .collect(Collectors.toList());
     }
@@ -45,18 +53,19 @@ public final class RemovedShape extends AbstractDiffEvaluator {
                 .isPresent();
     }
 
-    private boolean isScalarType(Shape shape) {
-        return shape.isBigDecimalShape()
-            || shape.isBigIntegerShape()
-            || shape.isBlobShape()
-            || shape.isBooleanShape()
-            || shape.isByteShape()
-            || shape.isDoubleShape()
-            || shape.isFloatShape()
-            || shape.isShortShape()
-            || shape.isTimestampShape()
-            || shape.isLongShape()
-            || (shape.isStringShape() && !shape.hasTrait(EnumTrait.class))
-            || (shape.isIntegerShape() && !shape.isIntEnumShape());
+    private boolean isInconsequentialType(Shape shape) {
+        ShapeType shapeType = shape.getType();
+        return shapeType == ShapeType.BIG_DECIMAL
+                || shapeType == ShapeType.BIG_INTEGER
+                || shapeType == ShapeType.BLOB
+                || shapeType == ShapeType.BOOLEAN
+                || shapeType == ShapeType.BYTE
+                || shapeType == ShapeType.DOUBLE
+                || shapeType == ShapeType.FLOAT
+                || shapeType == ShapeType.SHORT
+                || shapeType == ShapeType.TIMESTAMP
+                || shapeType == ShapeType.LONG
+                || ((shapeType == ShapeType.STRING) && !shape.hasTrait(EnumTrait.class))
+                || (shapeType == ShapeType.INTEGER);
     }
 }

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedShape.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedShape.java
@@ -46,8 +46,7 @@ public final class RemovedShape extends AbstractDiffEvaluator {
     }
 
     private boolean isScalarType(Shape shape) {
-        return shape.isIntegerShape()
-            || shape.isBigDecimalShape()
+        return shape.isBigDecimalShape()
             || shape.isBigIntegerShape()
             || shape.isBlobShape()
             || shape.isBooleanShape()
@@ -57,6 +56,7 @@ public final class RemovedShape extends AbstractDiffEvaluator {
             || shape.isShortShape()
             || shape.isTimestampShape()
             || shape.isLongShape()
-            || (shape.isStringShape() && !shape.hasTrait(EnumTrait.class));
+            || (shape.isStringShape() && !shape.hasTrait(EnumTrait.class))
+            || (shape.isIntegerShape() && !shape.isIntEnumShape());
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/ModelDiffTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/ModelDiffTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.SensitiveTrait;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidatedResult;
@@ -77,7 +78,7 @@ public class ModelDiffTest {
     @Test
     public void findsBreakingChanges() {
         Model oldModel = Model.builder()
-                .addShape(StringShape.builder().id("smithy.example#Str").build())
+                .addShape(StructureShape.builder().id("smithy.example#Str").build())
                 .build();
         Model newModel = Model.builder().build();
         ModelDiff.Result result = ModelDiff.builder().oldModel(oldModel).newModel(newModel).compare();

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedShapeTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedShapeTest.java
@@ -23,10 +23,24 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.diff.ModelDiff;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.BigDecimalShape;
+import software.amazon.smithy.model.shapes.BigIntegerShape;
+import software.amazon.smithy.model.shapes.BlobShape;
+import software.amazon.smithy.model.shapes.BooleanShape;
+import software.amazon.smithy.model.shapes.ByteShape;
+import software.amazon.smithy.model.shapes.DoubleShape;
+import software.amazon.smithy.model.shapes.FloatShape;
+import software.amazon.smithy.model.shapes.IntegerShape;
 import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.LongShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShortShape;
 import software.amazon.smithy.model.shapes.StringShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.TimestampShape;
+import software.amazon.smithy.model.traits.EnumDefinition;
+import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.PrivateTrait;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -34,10 +48,50 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 public class RemovedShapeTest {
     @Test
     public void detectsShapeRemoval() {
-        Shape shapeA1 = StringShape.builder().id("foo.baz#Baz").build();
-        Shape shapeB1 = StringShape.builder().id("foo.baz#Bam").build();
+        Shape shapeA1 = StructureShape.builder().id("foo.baz#Baz").build();
+        Shape shapeB1 = StructureShape.builder().id("foo.baz#Bam").build();
         Model modelA = Model.assembler().addShapes(shapeA1, shapeB1).assemble().unwrap();
         Model modelB = Model.assembler().addShapes(shapeB1).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "RemovedShape").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, shapeA1.getId()).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, Severity.ERROR).size(), equalTo(1));
+    }
+
+    @Test
+    public void emitsNotesForScalarShapes() {
+        Shape[] scalarShapes = new Shape[] {
+                IntegerShape.builder().id("foo.baz#BazOne").build(),
+                BigDecimalShape.builder().id("foo.baz#BazTwo").build(),
+                BigIntegerShape.builder().id("foo.baz#BazThree").build(),
+                BlobShape.builder().id("foo.baz#BazFour").build(),
+                BooleanShape.builder().id("foo.baz#BazFive").build(),
+                ByteShape.builder().id("foo.baz#BazSix").build(),
+                DoubleShape.builder().id("foo.baz#BazSeven").build(),
+                FloatShape.builder().id("foo.baz#BazEight").build(),
+                ShortShape.builder().id("foo.baz#BazNine").build(),
+                TimestampShape.builder().id("foo.baz#BazTen").build(),
+                LongShape.builder().id("foo.baz#BazEleven").build(),
+                StringShape.builder().id("foo.baz#BazTwelve").build()
+        };
+        Model modelA = Model.assembler().addShapes(scalarShapes).assemble().unwrap();
+        Model modelB = Model.assembler().assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "RemovedShape").size(), equalTo(12));
+        assertThat("Scalar removals should be NOTE severity",
+                events.stream().allMatch(event -> Severity.NOTE.equals(event.getSeverity())));
+    }
+
+    @Test
+    public void emitsErrorForEnumString() {
+        Shape shapeA1 = StringShape.builder()
+                .id("foo.baz#Baz")
+                .addTrait(EnumTrait.builder().addEnum(EnumDefinition.builder().value("val").build()).build())
+                .build();
+        Model modelA = Model.assembler().addShapes(shapeA1).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes().assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
         assertThat(TestHelper.findEvents(events, "RemovedShape").size(), equalTo(1));

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedShapeTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedShapeTest.java
@@ -29,7 +29,9 @@ import software.amazon.smithy.model.shapes.BlobShape;
 import software.amazon.smithy.model.shapes.BooleanShape;
 import software.amazon.smithy.model.shapes.ByteShape;
 import software.amazon.smithy.model.shapes.DoubleShape;
+import software.amazon.smithy.model.shapes.EnumShape;
 import software.amazon.smithy.model.shapes.FloatShape;
+import software.amazon.smithy.model.shapes.IntEnumShape;
 import software.amazon.smithy.model.shapes.IntegerShape;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.LongShape;
@@ -89,6 +91,21 @@ public class RemovedShapeTest {
         Shape shapeA1 = StringShape.builder()
                 .id("foo.baz#Baz")
                 .addTrait(EnumTrait.builder().addEnum(EnumDefinition.builder().value("val").build()).build())
+                .build();
+        Model modelA = Model.assembler().addShapes(shapeA1).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes().assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+
+        assertThat(TestHelper.findEvents(events, "RemovedShape").size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, shapeA1.getId()).size(), equalTo(1));
+        assertThat(TestHelper.findEvents(events, Severity.ERROR).size(), equalTo(1));
+    }
+
+    @Test
+    public void emitsErrorForIntEnum() {
+        Shape shapeA1 = IntEnumShape.builder()
+                .id("foo.baz#Baz")
+                .addMember("FOO", 1)
                 .build();
         Model modelA = Model.assembler().addShapes(shapeA1).assemble().unwrap();
         Model modelB = Model.assembler().addShapes().assemble().unwrap();

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedShapeTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedShapeTest.java
@@ -62,7 +62,7 @@ public class RemovedShapeTest {
     }
 
     @Test
-    public void emitsNotesForScalarShapes() {
+    public void emitsWarningsForScalarShapes() {
         Shape[] scalarShapes = new Shape[] {
                 IntegerShape.builder().id("foo.baz#BazOne").build(),
                 BigDecimalShape.builder().id("foo.baz#BazTwo").build(),
@@ -81,9 +81,9 @@ public class RemovedShapeTest {
         Model modelB = Model.assembler().assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
 
-        assertThat(TestHelper.findEvents(events, "RemovedShape").size(), equalTo(12));
-        assertThat("Scalar removals should be NOTE severity",
-                events.stream().allMatch(event -> Severity.NOTE.equals(event.getSeverity())));
+        assertThat(TestHelper.findEvents(events, "RemovedShape.ScalarShape").size(), equalTo(12));
+        assertThat("Scalar removals should be WARNING severity",
+                events.stream().allMatch(event -> Severity.WARNING.equals(event.getSeverity())));
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*
For scalar shapes (and non-enum strings), removing them is safe and therefore can be lowered from an ERROR to a NOTE

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
