### PR TITLE
Update unwrap docs

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidatedResult.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidatedResult.java
@@ -121,11 +121,11 @@ public final class ValidatedResult<T> {
     }
 
     /**
-     * Get the result, but throw if there are any ERROR events or if the
+     * Get the result, but throw if there are any ERROR or DANGER events or if the
      * result is empty.
      *
      * @return Returns the result.
-     * @throws ValidatedResultException if there are any ERROR events.
+     * @throws ValidatedResultException if there are any ERROR or DANGER events.
      * @throws IllegalStateException if there is no result.
      */
     public T unwrap() {


### PR DESCRIPTION
*Description of changes:*
The documentation of `unwrap` currently mentions only `ERROR`, but in the implementation, `isBroken` with following implementation is used:

```
    public boolean isBroken() {
        for (ValidationEvent event : events) {
            if (event.getSeverity() == Severity.ERROR || event.getSeverity() == Severity.DANGER) {
                return true;
            }
        }
        return false;
    }

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
