### PR TITLE
Fix recommended trait provider

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/RecommendedTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/RecommendedTrait.java
@@ -86,7 +86,7 @@ public final class RecommendedTrait extends AbstractTrait implements ToSmithyBui
         public RecommendedTrait createTrait(ShapeId target, Node value) {
             Builder builder = builder().sourceLocation(value.getSourceLocation());
             value.expectObjectNode().getStringMember("reason", builder::reason);
-            RecommendedTrait result = builder().build();
+            RecommendedTrait result = builder.build();
             result.setNodeCache(value);
             return result;
         }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/RecommendedTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/RecommendedTraitTest.java
@@ -1,0 +1,22 @@
+package software.amazon.smithy.model.traits;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.RecommendedTrait.Provider;
+
+public class RecommendedTraitTest {
+    @Test
+    public void providerProperlySetsReason() {
+        String reason = "just because";
+        ObjectNode node = Node.objectNode().withMember("reason", reason);
+        Provider provider = new Provider();
+        RecommendedTrait result = provider.createTrait(ShapeId.from("ns.example#Foo$bar"), node);
+        assertTrue(result.getReason().isPresent());
+        assertEquals(result.getReason().get(), reason);
+    }
+}


### PR DESCRIPTION
This fixes the trait provider for the recommended trait, which was discarding the `reason` by accidentally creating a new builder after it was set.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
