### PR TITLE
Allow the ModifiedTrait diff evaluator to take account traits added to

### DIFF
--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedShapeTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedShapeTest.java
@@ -149,6 +149,6 @@ public class AddedShapeTest {
         assertThat(TestHelper.findEvents(events, "AddedShape").size(), equalTo(1));
         assertThat(enumShapeB.getMember("BAR").isPresent(), equalTo(true));
         assertThat(TestHelper.findEvents(events, enumShapeB.getMember("BAR").get().toShapeId()).size(),
-                equalTo(1));
+                equalTo(2));
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ModifiedTraitTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ModifiedTraitTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 
 import java.util.Arrays;
@@ -343,5 +344,20 @@ public class ModifiedTraitTest {
                         .build()));
 
         assertThat(TestHelper.findEvents(ModelDiff.compare(oldModel, newModel), "ModifiedTrait"), empty());
+    }
+
+    @Test
+    public void findDifferencesInTraitAdditionInNewOperation() {
+        Model oldModel = Model.assembler()
+                .addImport(getClass().getResource("added-operation-old.smithy"))
+                .assemble()
+                .unwrap();
+        Model newModel = Model.assembler()
+                .discoverModels()
+                .addImport(getClass().getResource("added-operation-new.smithy"))
+                .assemble()
+                .unwrap();
+
+        assertThat(TestHelper.findEvents(ModelDiff.compare(oldModel, newModel), "ModifiedTrait").size(), greaterThan(0));
     }
 }

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/added-operation-new.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/added-operation-new.smithy
@@ -1,0 +1,18 @@
+$version: "2.0"
+
+namespace smithy.example
+
+operation A {
+    input: AInput,
+    output: AOutput
+}
+
+@input
+structure AInput {
+    foo: String,
+}
+
+@output
+structure AOutput {
+    baz: String,
+}

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/added-operation-old.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/evaluators/added-operation-old.smithy
@@ -1,0 +1,3 @@
+$version: "2.0"
+
+namespace smithy.example


### PR DESCRIPTION
newly added shapes: none

*Issue #, if available:*

*Description of changes:*
This allows the ModifiedTrait diff evaluator to consider traits that are added to newly added shapes. For our specific use case, we need to know about added waiters even when it's added as a part of a new operation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
