### PR TITLE
Add robots.txt with a single disallow for 1.0 pages

### DIFF
--- a/docs/root/robots.txt
+++ b/docs/root/robots.txt
@@ -1,0 +1,3 @@
+# Block all crawlers from accessing the 1.0 docs
+User-agent: *
+Disallow: /1.0/


### PR DESCRIPTION
*Description of changes:*
- Submitting queries for smithy docs returns hits for 1.0 docs (usually at or near the top of results), adding a robots.txt with a disallow for 1.0 will make this less likely to happen

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
