### PR TITLE
Rephrase auth trait documentation

### DIFF
--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.auth.smithy
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.auth.smithy
@@ -14,11 +14,11 @@ structure cognitoUserPools {
     providerArns: StringList
 }
 
-/// Signature Version 4 is the process to add authentication information to
-/// AWS requests sent by HTTP. For security, most requests to AWS must be
-/// signed with an access key, which consists of an access key ID and secret
-/// access key. These two keys are commonly referred to as your security
-/// credentials.
+/// [Signature Version 4](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
+/// is the process to add authentication information to AWS requests sent by HTTP. For
+/// security, most requests to AWS must be signed with an access key, which consists
+/// of an access key ID and secret access key. These two keys are commonly referred to
+/// as your security credentials.
 @authDefinition(traits: [unsignedPayload])
 @externalDocumentation(
     Reference: "https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html"

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -246,8 +246,7 @@ structure authDefinition {
     traits: TraitShapeIdList
 }
 
-/// Enables HTTP Basic Authentication as defined in RFC 2617 on a service
-/// or operation.
+/// HTTP Basic Authentication as defined in [RFC 2617](https://tools.ietf.org/html/rfc2617.html).
 @trait(
     selector: "service"
     breakingChanges: [
@@ -258,8 +257,7 @@ structure authDefinition {
 @externalDocumentation("RFC 2617": "https://tools.ietf.org/html/rfc2617.html")
 structure httpBasicAuth {}
 
-/// Enables HTTP Digest Authentication as defined in RFC 2617 on a service
-/// or operation.
+/// HTTP Digest Authentication as defined in [RFC 2617](https://tools.ietf.org/html/rfc2617.html).
 @trait(
     selector: "service"
     breakingChanges: [
@@ -270,8 +268,7 @@ structure httpBasicAuth {}
 @externalDocumentation("RFC 2617": "https://tools.ietf.org/html/rfc2617.html")
 structure httpDigestAuth {}
 
-/// Enables HTTP Bearer Authentication as defined in RFC 6750 on a service
-/// or operation.
+/// HTTP Bearer Authentication as defined in [RFC 6750](https://tools.ietf.org/html/rfc6750.html).
 @trait(
     selector: "service"
     breakingChanges: [


### PR DESCRIPTION
This rephrases the documentation for auth traits to read more like documentation for the auth type rather than documentation for a function. This allows it to be more naturally used in documentation generation without change. This also adds inline links to external documentation rather than solely relying on the external docs trait. While that trait is useful still, rendered docs are more natural if there's inline links too.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
