### PR TITLE
Add timestampFormat to restXml protocol traits

### DIFF
--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.protocols.smithy
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.protocols.smithy
@@ -51,15 +51,15 @@ structure HttpConfiguration {
 @protocolDefinition(
     noInlineDocumentSupport: true
     traits: [
+        timestampFormat
+        cors
+        endpoint
+        hostLabel
         awsQueryError
         xmlAttribute
         xmlFlattened
         xmlName
         xmlNamespace
-        timestampFormat
-        cors
-        endpoint
-        hostLabel
     ]
 )
 @trait(selector: "service [trait|xmlNamespace]")
@@ -92,15 +92,15 @@ structure awsQueryCompatible {}
 @protocolDefinition(
     noInlineDocumentSupport: true
     traits: [
+        timestampFormat
+        cors
+        endpoint
+        hostLabel
         ec2QueryName
         xmlAttribute
         xmlFlattened
         xmlName
         xmlNamespace
-        timestampFormat
-        cors
-        endpoint
-        hostLabel
     ]
 )
 @trait(selector: "service [trait|xmlNamespace]")
@@ -135,6 +135,7 @@ structure httpChecksum {
 /// A RESTful protocol that sends JSON in structured payloads.
 @protocolDefinition(
     traits: [
+        timestampFormat
         cors
         endpoint
         hostLabel
@@ -148,7 +149,6 @@ structure httpChecksum {
         httpQueryParams
         httpResponseCode
         jsonName
-        timestampFormat
     ]
 )
 @trait(selector: "service")
@@ -159,6 +159,7 @@ structure restJson1 with [HttpConfiguration] {}
 @protocolDefinition(
     noInlineDocumentSupport: true
     traits: [
+        timestampFormat
         cors
         endpoint
         hostLabel


### PR DESCRIPTION
This adds timestampFormat to the restXml protocol traits list. It also reorders the traits list on the other protocols so that all of them begin with those handful of shared traits so that it's easy to compare visually.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
