### PR TITLE
Split input and output shapes for rest-xml tests

### DIFF
--- a/smithy-aws-protocol-tests/model/restXml/document-lists.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-lists.smithy
@@ -1,6 +1,8 @@
 // This file defines test cases that serialize lists in XML documents.
 
 $version: "2.0"
+$operationInputSuffix: "Request"
+$operationOutputSuffix: "Response"
 
 namespace aws.protocoltests.restxml
 
@@ -33,8 +35,8 @@ use smithy.test#httpResponseTests
 @idempotent
 @http(uri: "/XmlLists", method: "PUT")
 operation XmlLists {
-    input: XmlListsInputOutput,
-    output: XmlListsInputOutput,
+    input := with [XmlListsInputOutput] {}
+    output := with [XmlListsInputOutput] {}
 }
 
 apply XmlLists @httpRequestTests([
@@ -45,7 +47,7 @@ apply XmlLists @httpRequestTests([
         method: "PUT",
         uri: "/XmlLists",
         body: """
-              <XmlListsInputOutput>
+              <XmlListsRequest>
                   <stringList>
                       <member>foo</member>
                       <member>bar</member>
@@ -110,7 +112,7 @@ apply XmlLists @httpRequestTests([
                       <value>7</value>
                       <other>8</other>
                   </flattenedStructureList>
-              </XmlListsInputOutput>
+              </XmlListsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -159,7 +161,7 @@ apply XmlLists @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlListsInputOutput>
+              <XmlListsResponse>
                   <stringList>
                       <member>foo</member>
                       <member>bar</member>
@@ -228,7 +230,7 @@ apply XmlLists @httpResponseTests([
                       <value>7</value>
                       <other>8</other>
                   </flattenedStructureList>
-              </XmlListsInputOutput>
+              </XmlListsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -276,8 +278,8 @@ apply XmlLists @httpResponseTests([
 @http(uri: "/XmlEmptyLists", method: "PUT")
 @tags(["client-only"])
 operation XmlEmptyLists {
-    input: XmlListsInputOutput,
-    output: XmlListsInputOutput,
+    input := with [XmlListsInputOutput] {}
+    output := with [XmlListsInputOutput] {}
 }
 
 apply XmlEmptyLists @httpRequestTests([
@@ -288,10 +290,10 @@ apply XmlEmptyLists @httpRequestTests([
         method: "PUT",
         uri: "/XmlEmptyLists",
         body: """
-              <XmlListsInputOutput>
+              <XmlEmptyListsRequest>
                       <stringList></stringList>
                       <stringSet></stringSet>
-              </XmlListsInputOutput>
+              </XmlEmptyListsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -312,10 +314,10 @@ apply XmlEmptyLists @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlListsInputOutput>
+              <XmlEmptyListsResponse>
                       <stringList/>
                       <stringSet></stringSet>
-              </XmlListsInputOutput>
+              </XmlEmptyListsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -329,6 +331,7 @@ apply XmlEmptyLists @httpResponseTests([
     }
 ])
 
+@mixin
 structure XmlListsInputOutput {
     stringList: StringList,
 

--- a/smithy-aws-protocol-tests/model/restXml/document-maps.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-maps.smithy
@@ -1,6 +1,8 @@
 // This file defines test cases that serialize maps in XML payloads.
 
 $version: "2.0"
+$operationInputSuffix: "Request"
+$operationOutputSuffix: "Response"
 
 namespace aws.protocoltests.restxml
 
@@ -13,8 +15,12 @@ use smithy.test#httpResponseTests
 /// The example tests basic map serialization.
 @http(uri: "/XmlMaps", method: "POST")
 operation XmlMaps {
-    input: XmlMapsInputOutput,
-    output: XmlMapsInputOutput
+    input := {
+        myMap: XmlMapsInputOutputMap
+    }
+    output := {
+        myMap: XmlMapsInputOutputMap
+    }
 }
 
 apply XmlMaps @httpRequestTests([
@@ -25,7 +31,7 @@ apply XmlMaps @httpRequestTests([
         method: "POST",
         uri: "/XmlMaps",
         body: """
-              <XmlMapsInputOutput>
+              <XmlMapsRequest>
                   <myMap>
                       <entry>
                           <key>foo</key>
@@ -40,7 +46,7 @@ apply XmlMaps @httpRequestTests([
                           </value>
                       </entry>
                   </myMap>
-              </XmlMapsInputOutput>
+              </XmlMapsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -66,7 +72,7 @@ apply XmlMaps @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlMapsInputOutput>
+              <XmlMapsRequest>
                   <myMap>
                       <entry>
                           <key>foo</key>
@@ -81,7 +87,7 @@ apply XmlMaps @httpResponseTests([
                           </value>
                       </entry>
                   </myMap>
-              </XmlMapsInputOutput>
+              </XmlMapsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -103,8 +109,12 @@ apply XmlMaps @httpResponseTests([
 @http(uri: "/XmlEmptyMaps", method: "POST")
 @tags(["client-only"])
 operation XmlEmptyMaps {
-    input: XmlMapsInputOutput,
-    output: XmlMapsInputOutput
+    input := {
+        myMap: XmlMapsInputOutputMap
+    }
+    output := {
+        myMap: XmlMapsInputOutputMap
+    }
 }
 
 apply XmlEmptyMaps @httpRequestTests([
@@ -115,9 +125,9 @@ apply XmlEmptyMaps @httpRequestTests([
         method: "POST",
         uri: "/XmlEmptyMaps",
         body: """
-              <XmlMapsInputOutput>
+              <XmlEmptyMapsRequest>
                   <myMap></myMap>
-              </XmlMapsInputOutput>
+              </XmlEmptyMapsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -137,9 +147,9 @@ apply XmlEmptyMaps @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlMapsInputOutput>
+              <XmlEmptyMapsResponse>
                   <myMap></myMap>
-              </XmlMapsInputOutput>
+              </XmlEmptyMapsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -156,9 +166,9 @@ apply XmlEmptyMaps @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlMapsInputOutput>
+              <XmlEmptyMapsResponse>
                   <myMap/>
-              </XmlMapsInputOutput>
+              </XmlEmptyMapsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -171,10 +181,6 @@ apply XmlEmptyMaps @httpResponseTests([
     }
 ])
 
-structure XmlMapsInputOutput {
-    myMap: XmlMapsInputOutputMap,
-}
-
 map XmlMapsInputOutputMap {
     key: String,
     value: GreetingStruct
@@ -183,8 +189,12 @@ map XmlMapsInputOutputMap {
 // This example tests maps with @xmlName on members.
 @http(uri: "/XmlMapsXmlName", method: "POST")
 operation XmlMapsXmlName {
-    input: XmlMapsXmlNameInputOutput,
-    output: XmlMapsXmlNameInputOutput
+    input := {
+        myMap: XmlMapsXmlNameInputOutputMap
+    }
+    output := {
+        myMap: XmlMapsXmlNameInputOutputMap
+    }
 }
 
 apply XmlMapsXmlName @httpRequestTests([
@@ -195,7 +205,7 @@ apply XmlMapsXmlName @httpRequestTests([
         method: "POST",
         uri: "/XmlMapsXmlName",
         body: """
-              <XmlMapsXmlNameInputOutput>
+              <XmlMapsXmlNameRequest>
                   <myMap>
                       <entry>
                           <Attribute>foo</Attribute>
@@ -210,7 +220,7 @@ apply XmlMapsXmlName @httpRequestTests([
                           </Setting>
                       </entry>
                   </myMap>
-              </XmlMapsXmlNameInputOutput>
+              </XmlMapsXmlNameRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -236,7 +246,7 @@ apply XmlMapsXmlName @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlMapsXmlNameInputOutput>
+              <XmlMapsXmlNameResponse>
                   <myMap>
                       <entry>
                           <Attribute>foo</Attribute>
@@ -251,7 +261,7 @@ apply XmlMapsXmlName @httpResponseTests([
                           </Setting>
                       </entry>
                   </myMap>
-              </XmlMapsXmlNameInputOutput>
+              </XmlMapsXmlNameResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -270,10 +280,6 @@ apply XmlMapsXmlName @httpResponseTests([
     }
 ])
 
-structure XmlMapsXmlNameInputOutput {
-    myMap: XmlMapsXmlNameInputOutputMap,
-}
-
 map XmlMapsXmlNameInputOutputMap {
     @xmlName("Attribute")
     key: String,
@@ -285,8 +291,14 @@ map XmlMapsXmlNameInputOutputMap {
 /// Flattened maps
 @http(uri: "/FlattenedXmlMap", method: "POST")
 operation FlattenedXmlMap {
-    input: FlattenedXmlMapInputOutput,
-    output: FlattenedXmlMapInputOutput
+    input := {
+        @xmlFlattened
+        myMap: FooEnumMap
+    }
+    output := {
+        @xmlFlattened
+        myMap: FooEnumMap
+    }
 }
 
 apply FlattenedXmlMap @httpRequestTests([
@@ -297,7 +309,7 @@ apply FlattenedXmlMap @httpRequestTests([
         method: "POST",
         uri: "/FlattenedXmlMap",
         body: """
-              <FlattenedXmlMapInputOutput>
+              <FlattenedXmlMapRequest>
                   <myMap>
                       <key>foo</key>
                       <value>Foo</value>
@@ -306,7 +318,7 @@ apply FlattenedXmlMap @httpRequestTests([
                       <key>baz</key>
                       <value>Baz</value>
                   </myMap>
-              </FlattenedXmlMapInputOutput>""",
+              </FlattenedXmlMapRequest>""",
         bodyMediaType: "application/xml",
         headers: {
             "Content-Type": "application/xml"
@@ -327,7 +339,7 @@ apply FlattenedXmlMap @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <FlattenedXmlMapInputOutput>
+              <FlattenedXmlMapResponse>
                   <myMap>
                       <key>foo</key>
                       <value>Foo</value>
@@ -336,7 +348,7 @@ apply FlattenedXmlMap @httpResponseTests([
                       <key>baz</key>
                       <value>Baz</value>
                   </myMap>
-              </FlattenedXmlMapInputOutput>""",
+              </FlattenedXmlMapResponse>""",
         bodyMediaType: "application/xml",
         headers: {
             "Content-Type": "application/xml"
@@ -350,16 +362,19 @@ apply FlattenedXmlMap @httpResponseTests([
     }
 ])
 
-structure FlattenedXmlMapInputOutput {
-    @xmlFlattened
-    myMap: FooEnumMap,
-}
-
 /// Flattened maps with @xmlName
 @http(uri: "/FlattenedXmlMapWithXmlName", method: "POST")
 operation FlattenedXmlMapWithXmlName {
-    input: FlattenedXmlMapWithXmlNameInputOutput,
-    output: FlattenedXmlMapWithXmlNameInputOutput
+    input := {
+        @xmlFlattened
+        @xmlName("KVP")
+        myMap: FlattenedXmlMapWithXmlNameInputOutputMap,
+    }
+    output := {
+        @xmlFlattened
+        @xmlName("KVP")
+        myMap: FlattenedXmlMapWithXmlNameInputOutputMap
+    }
 }
 
 apply FlattenedXmlMapWithXmlName @httpRequestTests([
@@ -370,7 +385,7 @@ apply FlattenedXmlMapWithXmlName @httpRequestTests([
         method: "POST",
         uri: "/FlattenedXmlMapWithXmlName",
         body: """
-              <FlattenedXmlMapWithXmlNameInputOutput>
+              <FlattenedXmlMapWithXmlNameRequest>
                   <KVP>
                       <K>a</K>
                       <V>A</V>
@@ -379,7 +394,7 @@ apply FlattenedXmlMapWithXmlName @httpRequestTests([
                       <K>b</K>
                       <V>B</V>
                   </KVP>
-              </FlattenedXmlMapWithXmlNameInputOutput>""",
+              </FlattenedXmlMapWithXmlNameRequest>""",
         bodyMediaType: "application/xml",
         headers: {
             "Content-Type": "application/xml"
@@ -400,7 +415,7 @@ apply FlattenedXmlMapWithXmlName @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <FlattenedXmlMapWithXmlNameInputOutput>
+              <FlattenedXmlMapWithXmlNameResponse>
                   <KVP>
                       <K>a</K>
                       <V>A</V>
@@ -409,7 +424,7 @@ apply FlattenedXmlMapWithXmlName @httpResponseTests([
                       <K>b</K>
                       <V>B</V>
                   </KVP>
-              </FlattenedXmlMapWithXmlNameInputOutput>""",
+              </FlattenedXmlMapWithXmlNameResponse>""",
         bodyMediaType: "application/xml",
         headers: {
             "Content-Type": "application/xml"
@@ -422,12 +437,6 @@ apply FlattenedXmlMapWithXmlName @httpResponseTests([
         }
     }
 ])
-
-structure FlattenedXmlMapWithXmlNameInputOutput {
-    @xmlFlattened
-    @xmlName("KVP")
-    myMap: FlattenedXmlMapWithXmlNameInputOutputMap,
-}
 
 map FlattenedXmlMapWithXmlNameInputOutputMap {
     @xmlName("K")
@@ -492,10 +501,11 @@ map FlattenedXmlMapWithXmlNamespaceOutputMap {
 
 @http(uri: "/NestedXmlMaps", method: "POST")
 operation NestedXmlMaps {
-    input: NestedXmlMapsInputOutput,
-    output: NestedXmlMapsInputOutput,
+    input := with [NestedXmlMapsInputOutput] {}
+    output := with [NestedXmlMapsInputOutput] {}
 }
 
+@mixin
 structure NestedXmlMapsInputOutput {
     nestedMap: NestedMap,
 
@@ -516,7 +526,7 @@ apply NestedXmlMaps @httpRequestTests([
         method: "POST",
         uri: "/NestedXmlMaps",
         body: """
-            <NestedXmlMapsInputOutput>
+            <NestedXmlMapsRequest>
                 <nestedMap>
                     <entry>
                         <key>foo</key>
@@ -528,7 +538,7 @@ apply NestedXmlMaps @httpRequestTests([
                         </value>
                     </entry>
                 </nestedMap>
-            </NestedXmlMapsInputOutput>""",
+            </NestedXmlMapsRequest>""",
         bodyMediaType: "application/xml",
         headers: {
             "Content-Type": "application/xml",
@@ -550,7 +560,7 @@ apply NestedXmlMaps @httpRequestTests([
         method: "POST",
         uri: "/NestedXmlMaps",
         body: """
-            <NestedXmlMapsInputOutput>
+            <NestedXmlMapsRequest>
                 <flatNestedMap>
                     <key>foo</key>
                     <value>
@@ -560,7 +570,7 @@ apply NestedXmlMaps @httpRequestTests([
                         </entry>
                     </value>
                 </flatNestedMap>
-            </NestedXmlMapsInputOutput>""",
+            </NestedXmlMapsRequest>""",
         bodyMediaType: "application/xml",
         headers: {
             "Content-Type": "application/xml",
@@ -582,7 +592,7 @@ apply NestedXmlMaps @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-            <NestedXmlMapsInputOutput>
+            <NestedXmlMapsResponse>
                 <nestedMap>
                     <entry>
                         <key>foo</key>
@@ -594,7 +604,7 @@ apply NestedXmlMaps @httpResponseTests([
                         </value>
                     </entry>
                 </nestedMap>
-            </NestedXmlMapsInputOutput>""",
+            </NestedXmlMapsResponse>""",
         bodyMediaType: "application/xml",
         headers: {
             "Content-Type": "application/xml",
@@ -615,7 +625,7 @@ apply NestedXmlMaps @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-            <NestedXmlMapsInputOutput>
+            <NestedXmlMapsResponse>
                 <flatNestedMap>
                     <key>foo</key>
                     <value>
@@ -625,7 +635,7 @@ apply NestedXmlMaps @httpResponseTests([
                         </entry>
                     </value>
                 </flatNestedMap>
-            </NestedXmlMapsInputOutput>""",
+            </NestedXmlMapsResponse>""",
         bodyMediaType: "application/xml",
         headers: {
             "Content-Type": "application/xml",
@@ -643,8 +653,8 @@ apply NestedXmlMaps @httpResponseTests([
 /// Maps with @xmlNamespace and @xmlName
 @http(uri: "/XmlMapWithXmlNamespace", method: "POST")
 operation XmlMapWithXmlNamespace {
-    input: XmlMapWithXmlNamespaceInputOutput
-    output: XmlMapWithXmlNamespaceInputOutput
+    input := with [XmlMapWithXmlNamespaceInputOutput] {}
+    output := with [XmlMapWithXmlNamespaceInputOutput] {}
 }
 
 apply XmlMapWithXmlNamespace @httpRequestTests([
@@ -655,7 +665,7 @@ apply XmlMapWithXmlNamespace @httpRequestTests([
         method: "POST",
         uri: "/XmlMapWithXmlNamespace",
         body: """
-              <XmlMapWithXmlNamespaceInputOutput>
+              <XmlMapWithXmlNamespaceRequest>
                   <KVP xmlns="https://the-member.example.com">
                       <entry>
                           <K xmlns="https://the-key.example.com">a</K>
@@ -666,7 +676,7 @@ apply XmlMapWithXmlNamespace @httpRequestTests([
                           <V xmlns="https://the-value.example.com">B</V>
                       </entry>
                   </KVP>
-              </XmlMapWithXmlNamespaceInputOutput>""",
+              </XmlMapWithXmlNamespaceRequest>""",
         bodyMediaType: "application/xml",
         headers: {
             "Content-Type": "application/xml"
@@ -687,7 +697,7 @@ apply XmlMapWithXmlNamespace @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlMapWithXmlNamespaceInputOutput>
+              <XmlMapWithXmlNamespaceResponse>
                   <KVP xmlns="https://the-member.example.com">
                       <entry>
                           <K xmlns="https://the-key.example.com">a</K>
@@ -698,7 +708,7 @@ apply XmlMapWithXmlNamespace @httpResponseTests([
                           <V xmlns="https://the-value.example.com">B</V>
                       </entry>
                   </KVP>
-              </XmlMapWithXmlNamespaceInputOutput>""",
+              </XmlMapWithXmlNamespaceResponse>""",
         bodyMediaType: "application/xml",
         headers: {
             "Content-Type": "application/xml"
@@ -712,6 +722,7 @@ apply XmlMapWithXmlNamespace @httpResponseTests([
     }
 ])
 
+@mixin
 structure XmlMapWithXmlNamespaceInputOutput {
     @xmlName("KVP")
     @xmlNamespace(uri: "https://the-member.example.com")

--- a/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
@@ -2,6 +2,8 @@
 // in the payload of HTTP requests and responses.
 
 $version: "2.0"
+$operationInputSuffix: "Request"
+$operationOutputSuffix: "Response"
 
 namespace aws.protocoltests.restxml
 
@@ -25,8 +27,8 @@ use smithy.test#httpResponseTests
 @idempotent
 @http(uri: "/SimpleScalarProperties", method: "PUT")
 operation SimpleScalarProperties {
-    input: SimpleScalarPropertiesInputOutput,
-    output: SimpleScalarPropertiesInputOutput
+    input := with [SimpleScalarPropertiesInputOutput] {}
+    output := with [SimpleScalarPropertiesInputOutput] {}
 }
 
 apply SimpleScalarProperties @httpRequestTests([
@@ -37,7 +39,7 @@ apply SimpleScalarProperties @httpRequestTests([
         method: "PUT",
         uri: "/SimpleScalarProperties",
         body: """
-              <SimpleScalarPropertiesInputOutput>
+              <SimpleScalarPropertiesRequest>
                   <stringValue>string</stringValue>
                   <trueBooleanValue>true</trueBooleanValue>
                   <falseBooleanValue>false</falseBooleanValue>
@@ -47,7 +49,7 @@ apply SimpleScalarProperties @httpRequestTests([
                   <longValue>4</longValue>
                   <floatValue>5.5</floatValue>
                   <DoubleDribble>6.5</DoubleDribble>
-              </SimpleScalarPropertiesInputOutput>
+              </SimpleScalarPropertiesRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -74,9 +76,9 @@ apply SimpleScalarProperties @httpRequestTests([
         method: "PUT",
         uri: "/SimpleScalarProperties",
         body: """
-              <SimpleScalarPropertiesInputOutput>
+              <SimpleScalarPropertiesRequest>
                   <stringValue>&lt;string&gt;</stringValue>
-              </SimpleScalarPropertiesInputOutput>
+              </SimpleScalarPropertiesRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -95,9 +97,9 @@ apply SimpleScalarProperties @httpRequestTests([
         method: "PUT",
         uri: "/SimpleScalarProperties",
         body: """
-              <SimpleScalarPropertiesInputOutput>
+              <SimpleScalarPropertiesRequest>
                   <stringValue>  string with white    space  </stringValue>
-              </SimpleScalarPropertiesInputOutput>
+              </SimpleScalarPropertiesRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -116,9 +118,9 @@ apply SimpleScalarProperties @httpRequestTests([
         method: "PUT",
         uri: "/SimpleScalarProperties",
         body: """
-              <SimpleScalarPropertiesInputOutput>
+              <SimpleScalarPropertiesRequest>
                   <stringValue>   </stringValue>
-              </SimpleScalarPropertiesInputOutput>
+              </SimpleScalarPropertiesRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -137,10 +139,10 @@ apply SimpleScalarProperties @httpRequestTests([
         method: "PUT",
         uri: "/SimpleScalarProperties",
         body: """
-              <SimpleScalarPropertiesInputOutput>
+              <SimpleScalarPropertiesRequest>
                   <floatValue>NaN</floatValue>
                   <DoubleDribble>NaN</DoubleDribble>
-              </SimpleScalarPropertiesInputOutput>
+              </SimpleScalarPropertiesRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -158,10 +160,10 @@ apply SimpleScalarProperties @httpRequestTests([
         method: "PUT",
         uri: "/SimpleScalarProperties",
         body: """
-              <SimpleScalarPropertiesInputOutput>
+              <SimpleScalarPropertiesRequest>
                   <floatValue>Infinity</floatValue>
                   <DoubleDribble>Infinity</DoubleDribble>
-              </SimpleScalarPropertiesInputOutput>
+              </SimpleScalarPropertiesRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -179,10 +181,10 @@ apply SimpleScalarProperties @httpRequestTests([
         method: "PUT",
         uri: "/SimpleScalarProperties",
         body: """
-              <SimpleScalarPropertiesInputOutput>
+              <SimpleScalarPropertiesRequest>
                   <floatValue>-Infinity</floatValue>
                   <DoubleDribble>-Infinity</DoubleDribble>
-              </SimpleScalarPropertiesInputOutput>
+              </SimpleScalarPropertiesRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -202,7 +204,7 @@ apply SimpleScalarProperties @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <SimpleScalarPropertiesInputOutput>
+              <SimpleScalarPropertiesResponse>
                   <stringValue>string</stringValue>
                   <trueBooleanValue>true</trueBooleanValue>
                   <falseBooleanValue>false</falseBooleanValue>
@@ -212,7 +214,7 @@ apply SimpleScalarProperties @httpResponseTests([
                   <longValue>4</longValue>
                   <floatValue>5.5</floatValue>
                   <DoubleDribble>6.5</DoubleDribble>
-              </SimpleScalarPropertiesInputOutput>
+              </SimpleScalarPropertiesResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -245,9 +247,9 @@ apply SimpleScalarProperties @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <SimpleScalarPropertiesInputOutput>
+              <SimpleScalarPropertiesResponse>
                   <stringValue>escaped data: &amp;lt;&#xD;&#10;</stringValue>
-              </SimpleScalarPropertiesInputOutput>
+              </SimpleScalarPropertiesResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -266,9 +268,9 @@ apply SimpleScalarProperties @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <SimpleScalarPropertiesInputOutput>
+              <SimpleScalarPropertiesResponse>
                   <stringValue>&lt;string&gt;</stringValue>
-              </SimpleScalarPropertiesInputOutput>
+              </SimpleScalarPropertiesResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -287,11 +289,11 @@ apply SimpleScalarProperties @httpResponseTests([
         code: 200,
         body: """
               <?xml version = "1.0" encoding = "UTF-8"?>
-              <SimpleScalarPropertiesInputOutput>
+              <SimpleScalarPropertiesResponse>
                   <![CDATA[characters representing CDATA]]>
                   <stringValue>string</stringValue>
                   <!--xml comment-->
-              </SimpleScalarPropertiesInputOutput>
+              </SimpleScalarPropertiesResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -310,9 +312,9 @@ apply SimpleScalarProperties @httpResponseTests([
         code: 200,
         body: """
               <?xml version = "1.0" encoding = "UTF-8"?>
-              <SimpleScalarPropertiesInputOutput>
+              <SimpleScalarPropertiesResponse>
                   <stringValue> string with white    space </stringValue>
-              </SimpleScalarPropertiesInputOutput>
+              </SimpleScalarPropertiesResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -331,9 +333,9 @@ apply SimpleScalarProperties @httpResponseTests([
         code: 200,
         body: """
               <?xml version = "1.0" encoding = "UTF-8"?>
-              <SimpleScalarPropertiesInputOutput>
+              <SimpleScalarPropertiesResponse>
                   <stringValue>  </stringValue>
-              </SimpleScalarPropertiesInputOutput>
+              </SimpleScalarPropertiesResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -351,10 +353,10 @@ apply SimpleScalarProperties @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <SimpleScalarPropertiesInputOutput>
+              <SimpleScalarPropertiesResponse>
                   <floatValue>NaN</floatValue>
                   <DoubleDribble>NaN</DoubleDribble>
-              </SimpleScalarPropertiesInputOutput>
+              </SimpleScalarPropertiesResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -371,10 +373,10 @@ apply SimpleScalarProperties @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <SimpleScalarPropertiesInputOutput>
+              <SimpleScalarPropertiesResponse>
                   <floatValue>Infinity</floatValue>
                   <DoubleDribble>Infinity</DoubleDribble>
-              </SimpleScalarPropertiesInputOutput>
+              </SimpleScalarPropertiesResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -391,10 +393,10 @@ apply SimpleScalarProperties @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <SimpleScalarPropertiesInputOutput>
+              <SimpleScalarPropertiesResponse>
                   <floatValue>-Infinity</floatValue>
                   <DoubleDribble>-Infinity</DoubleDribble>
-              </SimpleScalarPropertiesInputOutput>
+              </SimpleScalarPropertiesResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -407,6 +409,7 @@ apply SimpleScalarProperties @httpResponseTests([
     },
 ])
 
+@mixin
 structure SimpleScalarPropertiesInputOutput {
     @httpHeader("X-Foo")
     foo: String,
@@ -429,8 +432,12 @@ structure SimpleScalarPropertiesInputOutput {
 @http(uri: "/XmlEmptyStrings", method: "PUT")
 @tags(["client-only"])
 operation XmlEmptyStrings {
-    input: XmlEmptyStringsInputOutput,
-    output: XmlEmptyStringsInputOutput
+    input := {
+        emptyString: String
+    }
+    output := {
+        emptyString: String
+    }
 }
 
 apply XmlEmptyStrings @httpRequestTests([
@@ -441,9 +448,9 @@ apply XmlEmptyStrings @httpRequestTests([
            method: "PUT",
            uri: "/XmlEmptyStrings",
            body: """
-                 <XmlEmptyStringsInputOutput>
+                 <XmlEmptyStringsRequest>
                      <emptyString></emptyString>
-                 </XmlEmptyStringsInputOutput>
+                 </XmlEmptyStringsRequest>
                  """,
            bodyMediaType: "application/xml",
            headers: {
@@ -463,9 +470,9 @@ apply XmlEmptyStrings @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlEmptyStringsInputOutput>
+              <XmlEmptyStringsResponse>
                   <emptyString></emptyString>
-              </XmlEmptyStringsInputOutput>
+              </XmlEmptyStringsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -482,9 +489,9 @@ apply XmlEmptyStrings @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlEmptyStringsInputOutput>
+              <XmlEmptyStringsResponse>
                   <emptyString/>
-              </XmlEmptyStringsInputOutput>
+              </XmlEmptyStringsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -497,15 +504,15 @@ apply XmlEmptyStrings @httpResponseTests([
     }
 ])
 
-structure XmlEmptyStringsInputOutput {
-    emptyString: String
-}
-
 /// Blobs are base64 encoded
 @http(uri: "/XmlBlobs", method: "POST")
 operation XmlBlobs {
-    input: XmlBlobsInputOutput,
-    output: XmlBlobsInputOutput
+    input := {
+        data: Blob
+    }
+    output := {
+        data: Blob
+    }
 }
 
 apply XmlBlobs @httpRequestTests([
@@ -516,9 +523,9 @@ apply XmlBlobs @httpRequestTests([
         method: "POST",
         uri: "/XmlBlobs",
         body: """
-              <XmlBlobsInputOutput>
+              <XmlBlobsRequest>
                   <data>dmFsdWU=</data>
-              </XmlBlobsInputOutput>
+              </XmlBlobsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -537,9 +544,9 @@ apply XmlBlobs @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlBlobsInputOutput>
+              <XmlBlobsResponse>
                   <data>dmFsdWU=</data>
-              </XmlBlobsInputOutput>
+              </XmlBlobsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -555,8 +562,12 @@ apply XmlBlobs @httpResponseTests([
 @http(uri: "/XmlEmptyBlobs", method: "POST")
 @tags(["client-only"])
 operation XmlEmptyBlobs {
-    input: XmlBlobsInputOutput,
-    output: XmlBlobsInputOutput
+    input := {
+        data: Blob
+    }
+    output := {
+        data: Blob
+    }
 }
 
 apply XmlEmptyBlobs @httpResponseTests([
@@ -566,9 +577,9 @@ apply XmlEmptyBlobs @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlBlobsInputOutput>
+              <XmlBlobsRequest>
                   <data></data>
-              </XmlBlobsInputOutput>
+              </XmlBlobsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -585,9 +596,9 @@ apply XmlEmptyBlobs @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlBlobsInputOutput>
+              <XmlBlobsResponse>
                   <data/>
-              </XmlBlobsInputOutput>
+              </XmlBlobsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -600,17 +611,13 @@ apply XmlEmptyBlobs @httpResponseTests([
     }
 ])
 
-structure XmlBlobsInputOutput {
-    data: Blob
-}
-
 /// This tests how timestamps are serialized, including using the
 /// default format of date-time and various @timestampFormat trait
 /// values.
 @http(uri: "/XmlTimestamps", method: "POST")
 operation XmlTimestamps {
-    input: XmlTimestampsInputOutput,
-    output: XmlTimestampsInputOutput
+    input := with [XmlTimestampsInputOutput] {}
+    output := with [XmlTimestampsInputOutput] {}
 }
 
 apply XmlTimestamps @httpRequestTests([
@@ -621,9 +628,9 @@ apply XmlTimestamps @httpRequestTests([
         method: "POST",
         uri: "/XmlTimestamps",
         body: """
-              <XmlTimestampsInputOutput>
+              <XmlTimestampsRequest>
                   <normal>2014-04-29T18:30:38Z</normal>
-              </XmlTimestampsInputOutput>
+              </XmlTimestampsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -640,9 +647,9 @@ apply XmlTimestamps @httpRequestTests([
         method: "POST",
         uri: "/XmlTimestamps",
         body: """
-              <XmlTimestampsInputOutput>
+              <XmlTimestampsRequest>
                   <dateTime>2014-04-29T18:30:38Z</dateTime>
-              </XmlTimestampsInputOutput>
+              </XmlTimestampsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -659,9 +666,9 @@ apply XmlTimestamps @httpRequestTests([
         method: "POST",
         uri: "/XmlTimestamps",
         body: """
-              <XmlTimestampsInputOutput>
+              <XmlTimestampsRequest>
                   <dateTimeOnTarget>2014-04-29T18:30:38Z</dateTimeOnTarget>
-              </XmlTimestampsInputOutput>
+              </XmlTimestampsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -678,9 +685,9 @@ apply XmlTimestamps @httpRequestTests([
         method: "POST",
         uri: "/XmlTimestamps",
         body: """
-              <XmlTimestampsInputOutput>
+              <XmlTimestampsRequest>
                   <epochSeconds>1398796238</epochSeconds>
-              </XmlTimestampsInputOutput>
+              </XmlTimestampsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -697,9 +704,9 @@ apply XmlTimestamps @httpRequestTests([
         method: "POST",
         uri: "/XmlTimestamps",
         body: """
-              <XmlTimestampsInputOutput>
+              <XmlTimestampsRequest>
                   <epochSecondsOnTarget>1398796238</epochSecondsOnTarget>
-              </XmlTimestampsInputOutput>
+              </XmlTimestampsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -716,9 +723,9 @@ apply XmlTimestamps @httpRequestTests([
         method: "POST",
         uri: "/XmlTimestamps",
         body: """
-              <XmlTimestampsInputOutput>
+              <XmlTimestampsRequest>
                   <httpDate>Tue, 29 Apr 2014 18:30:38 GMT</httpDate>
-              </XmlTimestampsInputOutput>
+              </XmlTimestampsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -735,9 +742,9 @@ apply XmlTimestamps @httpRequestTests([
         method: "POST",
         uri: "/XmlTimestamps",
         body: """
-              <XmlTimestampsInputOutput>
+              <XmlTimestampsRequest>
                   <httpDateOnTarget>Tue, 29 Apr 2014 18:30:38 GMT</httpDateOnTarget>
-              </XmlTimestampsInputOutput>
+              </XmlTimestampsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -756,9 +763,9 @@ apply XmlTimestamps @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlTimestampsInputOutput>
+              <XmlTimestampsResponse>
                   <normal>2014-04-29T18:30:38Z</normal>
-              </XmlTimestampsInputOutput>
+              </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -774,9 +781,9 @@ apply XmlTimestamps @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlTimestampsInputOutput>
+              <XmlTimestampsResponse>
                   <dateTime>2014-04-29T18:30:38Z</dateTime>
-              </XmlTimestampsInputOutput>
+              </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -792,9 +799,9 @@ apply XmlTimestamps @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlTimestampsInputOutput>
+              <XmlTimestampsResponse>
                   <dateTimeOnTarget>2014-04-29T18:30:38Z</dateTimeOnTarget>
-              </XmlTimestampsInputOutput>
+              </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -810,9 +817,9 @@ apply XmlTimestamps @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlTimestampsInputOutput>
+              <XmlTimestampsResponse>
                   <epochSeconds>1398796238</epochSeconds>
-              </XmlTimestampsInputOutput>
+              </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -828,9 +835,9 @@ apply XmlTimestamps @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlTimestampsInputOutput>
+              <XmlTimestampsResponse>
                   <epochSecondsOnTarget>1398796238</epochSecondsOnTarget>
-              </XmlTimestampsInputOutput>
+              </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -846,9 +853,9 @@ apply XmlTimestamps @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlTimestampsInputOutput>
+              <XmlTimestampsResponse>
                   <httpDate>Tue, 29 Apr 2014 18:30:38 GMT</httpDate>
-              </XmlTimestampsInputOutput>
+              </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -864,9 +871,9 @@ apply XmlTimestamps @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlTimestampsInputOutput>
+              <XmlTimestampsResponse>
                   <httpDateOnTarget>Tue, 29 Apr 2014 18:30:38 GMT</httpDateOnTarget>
-              </XmlTimestampsInputOutput>
+              </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -878,6 +885,7 @@ apply XmlTimestamps @httpResponseTests([
     },
 ])
 
+@mixin
 structure XmlTimestampsInputOutput {
     normal: Timestamp,
 
@@ -901,8 +909,8 @@ structure XmlTimestampsInputOutput {
 @idempotent
 @http(uri: "/XmlEnums", method: "PUT")
 operation XmlEnums {
-    input: XmlEnumsInputOutput,
-    output: XmlEnumsInputOutput
+    input := with [XmlEnumsInputOutput] {}
+    output := with [XmlEnumsInputOutput] {}
 }
 
 apply XmlEnums @httpRequestTests([
@@ -913,7 +921,7 @@ apply XmlEnums @httpRequestTests([
         method: "PUT",
         uri: "/XmlEnums",
         body: """
-              <XmlEnumsInputOutput>
+              <XmlEnumsRequest>
                   <fooEnum1>Foo</fooEnum1>
                   <fooEnum2>0</fooEnum2>
                   <fooEnum3>1</fooEnum3>
@@ -935,7 +943,7 @@ apply XmlEnums @httpRequestTests([
                           <value>0</value>
                       </entry>
                   </fooEnumMap>
-              </XmlEnumsInputOutput>
+              </XmlEnumsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -962,7 +970,7 @@ apply XmlEnums @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlEnumsInputOutput>
+              <XmlEnumsResponse>
                   <fooEnum1>Foo</fooEnum1>
                   <fooEnum2>0</fooEnum2>
                   <fooEnum3>1</fooEnum3>
@@ -984,7 +992,7 @@ apply XmlEnums @httpResponseTests([
                           <value>0</value>
                       </entry>
                   </fooEnumMap>
-              </XmlEnumsInputOutput>
+              </XmlEnumsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -1004,6 +1012,7 @@ apply XmlEnums @httpResponseTests([
     }
 ])
 
+@mixin
 structure XmlEnumsInputOutput {
     fooEnum1: FooEnum,
     fooEnum2: FooEnum,
@@ -1017,8 +1026,8 @@ structure XmlEnumsInputOutput {
 @idempotent
 @http(uri: "/XmlIntEnums", method: "PUT")
 operation XmlIntEnums {
-    input: XmlIntEnumsInputOutput,
-    output: XmlIntEnumsInputOutput
+    input := with [XmlIntEnumsInputOutput] {}
+    output := with [XmlIntEnumsInputOutput] {}
 }
 
 apply XmlIntEnums @httpRequestTests([
@@ -1029,7 +1038,7 @@ apply XmlIntEnums @httpRequestTests([
         method: "PUT",
         uri: "/XmlIntEnums",
         body: """
-              <XmlIntEnumsInputOutput>
+              <XmlIntEnumsRequest>
                   <intEnum1>1</intEnum1>
                   <intEnum2>2</intEnum2>
                   <intEnum3>3</intEnum3>
@@ -1051,7 +1060,7 @@ apply XmlIntEnums @httpRequestTests([
                           <value>2</value>
                       </entry>
                   </intEnumMap>
-              </XmlIntEnumsInputOutput>
+              </XmlIntEnumsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -1078,7 +1087,7 @@ apply XmlIntEnums @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlIntEnumsInputOutput>
+              <XmlIntEnumsResponse>
                   <intEnum1>1</intEnum1>
                   <intEnum2>2</intEnum2>
                   <intEnum3>3</intEnum3>
@@ -1100,7 +1109,7 @@ apply XmlIntEnums @httpResponseTests([
                           <value>2</value>
                       </entry>
                   </intEnumMap>
-              </XmlIntEnumsInputOutput>
+              </XmlIntEnumsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -1120,6 +1129,7 @@ apply XmlIntEnums @httpResponseTests([
     }
 ])
 
+@mixin
 structure XmlIntEnumsInputOutput {
     intEnum1: IntegerEnum,
     intEnum2: IntegerEnum,
@@ -1133,8 +1143,12 @@ structure XmlIntEnumsInputOutput {
 @idempotent
 @http(uri: "/RecursiveShapes", method: "PUT")
 operation RecursiveShapes {
-    input: RecursiveShapesInputOutput,
-    output: RecursiveShapesInputOutput
+    input := {
+        nested: RecursiveShapesInputOutputNested1
+    }
+    output := {
+        nested: RecursiveShapesInputOutputNested1
+    }
 }
 
 apply RecursiveShapes @httpRequestTests([
@@ -1145,7 +1159,7 @@ apply RecursiveShapes @httpRequestTests([
         method: "PUT",
         uri: "/RecursiveShapes",
         body: """
-              <RecursiveShapesInputOutput>
+              <RecursiveShapesRequest>
                   <nested>
                       <foo>Foo1</foo>
                       <nested>
@@ -1158,7 +1172,7 @@ apply RecursiveShapes @httpRequestTests([
                           </recursiveMember>
                       </nested>
                   </nested>
-              </RecursiveShapesInputOutput>
+              </RecursiveShapesRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -1188,7 +1202,7 @@ apply RecursiveShapes @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <RecursiveShapesInputOutput>
+              <RecursiveShapesResponse>
                   <nested>
                       <foo>Foo1</foo>
                       <nested>
@@ -1201,7 +1215,7 @@ apply RecursiveShapes @httpResponseTests([
                           </recursiveMember>
                       </nested>
                   </nested>
-              </RecursiveShapesInputOutput>
+              </RecursiveShapesResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -1224,10 +1238,6 @@ apply RecursiveShapes @httpResponseTests([
     }
 ])
 
-structure RecursiveShapesInputOutput {
-    nested: RecursiveShapesInputOutputNested1
-}
-
 structure RecursiveShapesInputOutputNested1 {
     foo: String,
     nested: RecursiveShapesInputOutputNested2
@@ -1241,8 +1251,8 @@ structure RecursiveShapesInputOutputNested2 {
 // XML namespace
 @http(uri: "/XmlNamespaces", method: "POST")
 operation XmlNamespaces {
-    input: XmlNamespacesInputOutput,
-    output: XmlNamespacesInputOutput
+    input := with [XmlNamespacesInputOutput] {}
+    output := with [XmlNamespacesInputOutput] {}
 }
 
 apply XmlNamespaces @httpRequestTests([
@@ -1253,7 +1263,7 @@ apply XmlNamespaces @httpRequestTests([
         method: "POST",
         uri: "/XmlNamespaces",
         body: """
-              <XmlNamespacesInputOutput xmlns="http://foo.com">
+              <XmlNamespacesRequest xmlns="http://foo.com">
                   <nested>
                       <foo xmlns:baz="http://baz.com">Foo</foo>
                       <values xmlns="http://qux.com">
@@ -1261,7 +1271,7 @@ apply XmlNamespaces @httpRequestTests([
                           <member xmlns="http://bux.com">Baz</member>
                       </values>
                   </nested>
-              </XmlNamespacesInputOutput>
+              </XmlNamespacesRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -1286,7 +1296,7 @@ apply XmlNamespaces @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlNamespacesInputOutput xmlns="http://foo.com">
+              <XmlNamespacesResponse xmlns="http://foo.com">
                   <nested>
                       <foo xmlns:baz="http://baz.com">Foo</foo>
                       <values xmlns="http://qux.com">
@@ -1294,7 +1304,7 @@ apply XmlNamespaces @httpResponseTests([
                           <member xmlns="http://bux.com">Baz</member>
                       </values>
                   </nested>
-              </XmlNamespacesInputOutput>
+              </XmlNamespacesResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -1312,6 +1322,7 @@ apply XmlNamespaces @httpResponseTests([
     }
 ])
 
+@mixin
 @xmlNamespace(uri: "http://foo.com")
 structure XmlNamespacesInputOutput {
     nested: XmlNamespaceNested

--- a/smithy-aws-protocol-tests/model/restXml/document-unions.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-unions.smithy
@@ -2,6 +2,8 @@
 // in the payload of HTTP requests and responses.
 
 $version: "2.0"
+$operationInputSuffix: "Request"
+$operationOutputSuffix: "Response"
 
 namespace aws.protocoltests.restxml
 
@@ -14,8 +16,12 @@ use smithy.test#httpResponseTests
 @idempotent
 @http(uri: "/XmlUnions", method: "PUT")
 operation XmlUnions {
-    input: XmlUnionsInputOutput,
-    output: XmlUnionsInputOutput
+    input := {
+        unionValue: XmlUnionShape
+    }
+    output := {
+        unionValue: XmlUnionShape
+    }
 }
 
 apply XmlUnions @httpRequestTests([
@@ -26,7 +32,7 @@ apply XmlUnions @httpRequestTests([
         method: "PUT",
         uri: "/XmlUnions",
         body: """
-              <XmlUnionsInputOutput>
+              <XmlUnionsRequest>
                   <unionValue>
                      <structValue>
                         <stringValue>string</stringValue>
@@ -39,7 +45,7 @@ apply XmlUnions @httpRequestTests([
                         <doubleValue>6.5</doubleValue>
                      </structValue>
                   </unionValue>
-              </XmlUnionsInputOutput>
+              </XmlUnionsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -67,11 +73,11 @@ apply XmlUnions @httpRequestTests([
         method: "PUT",
         uri: "/XmlUnions",
         body: """
-              <XmlUnionsInputOutput>
+              <XmlUnionsRequest>
                  <unionValue>
                     <stringValue>some string</stringValue>
                  </unionValue>
-              </XmlUnionsInputOutput>
+              </XmlUnionsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -90,11 +96,11 @@ apply XmlUnions @httpRequestTests([
         method: "PUT",
         uri: "/XmlUnions",
         body: """
-              <XmlUnionsInputOutput>
+              <XmlUnionsRequest>
                  <unionValue>
                     <booleanValue>true</booleanValue>
                  </unionValue>
-              </XmlUnionsInputOutput>
+              </XmlUnionsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -113,13 +119,13 @@ apply XmlUnions @httpRequestTests([
         method: "PUT",
         uri: "/XmlUnions",
         body: """
-              <XmlUnionsInputOutput>
+              <XmlUnionsRequest>
                  <unionValue>
                     <unionValue>
                        <booleanValue>true</booleanValue>
                     </unionValue>
                  </unionValue>
-              </XmlUnionsInputOutput>
+              </XmlUnionsRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -142,7 +148,7 @@ apply XmlUnions @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlUnionsInputOutput>
+              <XmlUnionsResponse>
                   <unionValue>
                      <structValue>
                         <stringValue>string</stringValue>
@@ -155,7 +161,7 @@ apply XmlUnions @httpResponseTests([
                         <doubleValue>6.5</doubleValue>
                      </structValue>
                   </unionValue>
-              </XmlUnionsInputOutput>
+              </XmlUnionsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -182,11 +188,11 @@ apply XmlUnions @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlUnionsInputOutput>
+              <XmlUnionsResponse>
                  <unionValue>
                     <stringValue>some string</stringValue>
                  </unionValue>
-              </XmlUnionsInputOutput>
+              </XmlUnionsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -204,11 +210,11 @@ apply XmlUnions @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlUnionsInputOutput>
+              <XmlUnionsResponse>
                  <unionValue>
                     <booleanValue>true</booleanValue>
                  </unionValue>
-              </XmlUnionsInputOutput>
+              </XmlUnionsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -226,13 +232,13 @@ apply XmlUnions @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlUnionsInputOutput>
+              <XmlUnionsResponse>
                  <unionValue>
                     <unionValue>
                        <booleanValue>true</booleanValue>
                     </unionValue>
                  </unionValue>
-              </XmlUnionsInputOutput>
+              </XmlUnionsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -247,10 +253,6 @@ apply XmlUnions @httpResponseTests([
         }
     },
 ])
-
-structure XmlUnionsInputOutput {
-    unionValue: XmlUnionShape,
-}
 
 union XmlUnionShape {
     stringValue: String,

--- a/smithy-aws-protocol-tests/model/restXml/document-xml-attributes.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-xml-attributes.smithy
@@ -1,6 +1,8 @@
 // This file defines test cases that serialize XML attributes.
 
 $version: "2.0"
+$operationInputSuffix: "Request"
+$operationOutputSuffix: "Response"
 
 namespace aws.protocoltests.restxml
 
@@ -12,8 +14,8 @@ use smithy.test#httpResponseTests
 @idempotent
 @http(uri: "/XmlAttributes", method: "PUT")
 operation XmlAttributes {
-    input: XmlAttributesInputOutput,
-    output: XmlAttributesInputOutput
+    input := with [XmlAttributesInputOutput] {}
+    output := with [XmlAttributesInputOutput] {}
 }
 
 apply XmlAttributes @httpRequestTests([
@@ -24,9 +26,9 @@ apply XmlAttributes @httpRequestTests([
         method: "PUT",
         uri: "/XmlAttributes",
         body: """
-              <XmlAttributesInputOutput test="test">
+              <XmlAttributesRequest test="test">
                   <foo>hi</foo>
-              </XmlAttributesInputOutput>
+              </XmlAttributesRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -44,9 +46,9 @@ apply XmlAttributes @httpRequestTests([
         method: "PUT",
         uri: "/XmlAttributes",
         body: """
-              <XmlAttributesInputOutput test="&lt;test&amp;mock&gt;">
+              <XmlAttributesRequest test="&lt;test&amp;mock&gt;">
                   <foo>hi</foo>
-              </XmlAttributesInputOutput>
+              </XmlAttributesRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -66,9 +68,9 @@ apply XmlAttributes @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlAttributesInputOutput test="test">
+              <XmlAttributesResponse test="test">
                   <foo>hi</foo>
-              </XmlAttributesInputOutput>
+              </XmlAttributesResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -81,6 +83,7 @@ apply XmlAttributes @httpResponseTests([
     }
 ])
 
+@mixin
 structure XmlAttributesInputOutput {
     foo: String,
 
@@ -93,8 +96,14 @@ structure XmlAttributesInputOutput {
 @idempotent
 @http(uri: "/XmlAttributesOnPayload", method: "PUT")
 operation XmlAttributesOnPayload {
-    input: XmlAttributesOnPayloadInputOutput,
-    output: XmlAttributesOnPayloadInputOutput
+    input := {
+        @httpPayload
+        payload: XmlAttributesPayloadRequest
+    }
+    output := {
+        @httpPayload
+        payload: XmlAttributesPayloadResponse
+    }
 }
 
 apply XmlAttributesOnPayload @httpRequestTests([
@@ -105,9 +114,9 @@ apply XmlAttributesOnPayload @httpRequestTests([
         method: "PUT",
         uri: "/XmlAttributesOnPayload",
         body: """
-              <XmlAttributesInputOutput test="test">
+              <XmlAttributesPayloadRequest test="test">
                   <foo>hi</foo>
-              </XmlAttributesInputOutput>
+              </XmlAttributesPayloadRequest>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -129,9 +138,9 @@ apply XmlAttributesOnPayload @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlAttributesInputOutput test="test">
+              <XmlAttributesPayloadResponse test="test">
                   <foo>hi</foo>
-              </XmlAttributesInputOutput>
+              </XmlAttributesPayloadResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -146,7 +155,6 @@ apply XmlAttributesOnPayload @httpResponseTests([
     }
 ])
 
-structure XmlAttributesOnPayloadInputOutput {
-    @httpPayload
-    payload: XmlAttributesInputOutput
-}
+structure XmlAttributesPayloadRequest with [XmlAttributesInputOutput] {}
+
+structure XmlAttributesPayloadResponse with [XmlAttributesInputOutput] {}

--- a/smithy-aws-protocol-tests/model/restXml/endpoints.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/endpoints.smithy
@@ -2,6 +2,7 @@
 // trait and other features that modify the host.
 
 $version: "2.0"
+$operationInputSuffix: "Request"
 
 namespace aws.protocoltests.restxml
 
@@ -26,7 +27,6 @@ use smithy.test#httpRequestTests
 @http(uri: "/EndpointOperation", method: "POST")
 operation EndpointOperation {}
 
-
 @httpRequestTests([
     {
         id: "RestXmlEndpointTraitWithHostLabel",
@@ -38,9 +38,9 @@ operation EndpointOperation {}
         method: "POST",
         uri: "/EndpointWithHostLabelOperation",
         body: """
-              <HostLabelInput>
+              <EndpointWithHostLabelOperationRequest>
                   <label>bar</label>
-              </HostLabelInput>
+              </EndpointWithHostLabelOperationRequest>
               """,
         bodyMediaType: "application/xml",
         host: "example.com",
@@ -53,13 +53,11 @@ operation EndpointOperation {}
 @endpoint(hostPrefix: "foo.{label}.")
 @http(uri: "/EndpointWithHostLabelOperation", method: "POST")
 operation EndpointWithHostLabelOperation {
-    input: HostLabelInput,
-}
-
-structure HostLabelInput {
-    @required
-    @hostLabel
-    label: String,
+    input := {
+        @required
+        @hostLabel
+        label: String
+    }
 }
 
 @httpRequestTests([


### PR DESCRIPTION
This PR splits InputOutput shapes into separate request and response shapes for rest-xml protocol tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
