### PR TITLE
Add protocol tests for 0/false in query params

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -218,6 +218,22 @@ apply AllQueryStringTypes @httpRequestTests([
             }
         }
     },
+    {
+        id: "RestJsonZeroAndFalseQueryValues"
+        documentation: "Query values of 0 and false are serialized"
+        protocol: restJson1
+        method: "GET"
+        uri: "/AllQueryStringTypesInput"
+        body: ""
+        queryParams: [
+            "Integer=0"
+            "Boolean=false"
+        ]
+        params: {
+            queryInteger: 0
+            queryBoolean: false
+        }
+    }
 ])
 
 @suppress(["HttpQueryParamsTrait"])

--- a/smithy-aws-protocol-tests/model/restXml/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-query.smithy
@@ -180,6 +180,22 @@ apply AllQueryStringTypes @httpRequestTests([
             queryDouble: "-Infinity",
         }
     },
+    {
+        id: "RestXmlZeroAndFalseQueryValues"
+        documentation: "Query values of 0 and false are serialized"
+        protocol: restXml
+        method: "GET"
+        uri: "/AllQueryStringTypesInput"
+        body: ""
+        queryParams: [
+            "Integer=0"
+            "Boolean=false"
+        ]
+        params: {
+            queryInteger: 0
+            queryBoolean: false
+        }
+    }
 ])
 
 @suppress(["HttpQueryParamsTrait"])


### PR DESCRIPTION
Previously we didn't have protocol tests specifically for 0/false in query params, which allowed for situations like
https://github.com/smithy-lang/smithy-rs/pull/3252 to occur.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.