### PR TITLE
Correcting erroneous outer tags

### DIFF
--- a/smithy-aws-protocol-tests/model/restXml/document-maps.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-maps.smithy
@@ -72,7 +72,7 @@ apply XmlMaps @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlMapsRequest>
+              <XmlMapsResponse>
                   <myMap>
                       <entry>
                           <key>foo</key>
@@ -87,7 +87,7 @@ apply XmlMaps @httpResponseTests([
                           </value>
                       </entry>
                   </myMap>
-              </XmlMapsRequest>
+              </XmlMapsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {

--- a/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-structs.smithy
@@ -577,9 +577,9 @@ apply XmlEmptyBlobs @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlBlobsRequest>
+              <XmlEmptyBlobsResponse>
                   <data></data>
-              </XmlBlobsRequest>
+              </XmlEmptyBlobsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {
@@ -596,9 +596,9 @@ apply XmlEmptyBlobs @httpResponseTests([
         protocol: restXml,
         code: 200,
         body: """
-              <XmlBlobsResponse>
+              <XmlEmptyBlobsResponse>
                   <data/>
-              </XmlBlobsResponse>
+              </XmlEmptyBlobsResponse>
               """,
         bodyMediaType: "application/xml",
         headers: {


### PR DESCRIPTION
*Issue #, if available:*
The ABAP codegen strictly tests XML using XSLT which makes it sensitive to incorrect outer tags. We stumbled on these errors in the protocol tests, introduced in a recent commit.

*Description of changes:*
Correcting the outer tags in three protocol tests.  These have been tested against the ABAP codegen.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
