### PR TITLE
Change line break formatting in brackets

### DIFF
--- a/smithy-syntax/src/test/java/software/amazon/smithy/syntax/ParseAndFormatTest.java
+++ b/smithy-syntax/src/test/java/software/amazon/smithy/syntax/ParseAndFormatTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.IdlTokenizer;
+import software.amazon.smithy.model.loader.ModelAssembler;
 import software.amazon.smithy.utils.IoUtils;
 
 // A parameterized test that finds models in corpus, parses them, skipping files that end with ".formatted.smithy".
@@ -32,9 +33,19 @@ public class ParseAndFormatTest {
         }
 
         // Ensure that the tests can be parsed by smithy-model too.
-        Model.assembler().addImport(filename).disableValidation().assemble().unwrap();
+        Model.assembler()
+                .addImport(filename)
+                .putProperty(ModelAssembler.ALLOW_UNKNOWN_TRAITS, true)
+                .disableValidation()
+                .assemble()
+                .unwrap();
         if (!formattedFile.equals(filename)) {
-            Model.assembler().addImport(formattedFile).disableValidation().assemble().unwrap();
+            Model.assembler()
+                    .addImport(formattedFile)
+                    .putProperty(ModelAssembler.ALLOW_UNKNOWN_TRAITS, true)
+                    .disableValidation()
+                    .assemble()
+                    .unwrap();
         }
 
         String model = IoUtils.readUtf8File(filename);

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/array-of-objects.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/array-of-objects.formatted.smithy
@@ -1,0 +1,15 @@
+$version: "2.0"
+
+namespace smithy.example
+
+@examples([
+    {
+        title: "Foo"
+        documentation: "Foo"
+    }
+    {
+        title: "Bar"
+        documentation: "Bar"
+    }
+])
+operation Foo {}

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/array-of-objects.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/array-of-objects.smithy
@@ -1,0 +1,17 @@
+$version: "2.0"
+
+namespace smithy.example
+
+@examples(
+    [
+        {
+            title: "Foo"
+            documentation: "Foo"
+        }
+        {
+            title: "Bar"
+            documentation: "Bar"
+        }
+    ]
+)
+operation Foo {}

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/brackets.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/brackets.formatted.smithy
@@ -1,0 +1,192 @@
+$version: "2.0"
+
+// Single line
+metadata a = { a: "b" }
+
+// Multiline
+metadata b = {
+    a: "foobarbazbux"
+    b: "foobarbazbux"
+    c: "foobarbazbux"
+    d: "foobarbazbux"
+    e: "foobarbazbux"
+    f: "foobarbazbux"
+}
+
+// Leading and trailing WS
+metadata c = {
+    // Foo
+    a: "b"
+}
+
+metadata d = {
+    a: "b"
+    // Foo
+}
+
+// Parent is array
+metadata e = [
+    {
+        foo: "bar"
+    }
+]
+
+// Line breaking values
+metadata f = [
+    """
+    foo
+    """
+]
+
+metadata g = [
+    "abc
+def"
+]
+
+metadata h = {
+    a: [
+        {
+            foo: "bar"
+        }
+    ]
+}
+
+namespace smithy.example
+
+// TraitStructure
+// Single line
+@externalDocumentation(a: "http://foo.com", c: "http://foo.com")
+structure A {}
+
+// Multi-line
+@externalDocumentation(
+    a: "http://foo.com"
+    b: "http://foo.com"
+    c: "http://foo.com"
+    d: "http://foo.com"
+    e: "http://foo.com"
+    f: "http://foo.com"
+    g: "http://foo.com"
+    h: "http://foo.com"
+    i: "http://foo.com"
+    j: "http://foo.com"
+)
+structure B {}
+
+// Leading WS
+@externalDocumentation(
+    // Foo
+    a: "http://foo.com"
+)
+structure C {}
+
+// Trailing WS
+@externalDocumentation(
+    a: "http://foo.com"
+    // Foo
+)
+structure D {}
+
+// Object values
+@foo(
+    a: { bar: "baz" }
+)
+structure E {}
+
+// Array values
+@foo(
+    a: ["bar", "baz"]
+)
+structure F {}
+
+// TraitNode
+// Single line
+@foo(["foo", "bar"])
+structure G {}
+
+@foo({ foo: "bar", baz: "foo" })
+structure H {}
+
+// Multiline
+@foo([
+    "foobarbaz"
+    "foobarbaz"
+    "foobarbaz"
+    "foobarbaz"
+    "foobarbaz"
+    "foobarbaz"
+    "foobarbaz"
+    "foobarbaz"
+    "foobarbaz"
+])
+structure I {}
+
+@foo({
+    a: "foobarbaz"
+    b: "foobarbaz"
+    c: "foobarbaz"
+    d: "foobarbaz"
+    e: "foobarbaz"
+    f: "foobarbaz"
+    g: "foobarbaz"
+    h: "foobarbaz"
+    i: "foobarbaz"
+})
+structure J {}
+
+// Leading WS
+@foo(
+    // Foo
+    ["a"]
+)
+structure K {}
+
+// Trailing WS
+@foo(
+    ["a"]
+    // Foo
+)
+structure L {}
+
+// Line breaking NodeValues
+@foo(
+    """
+    foo
+    """
+)
+structure M {}
+
+@foo(
+    "a
+bc"
+)
+structure N {}
+
+// Nested comments
+@foo([
+    "abc"
+    // Foo
+    "def"
+    // Bar
+])
+structure O {}
+
+// Nested objects
+@foo([
+    {}
+])
+structure P {}
+
+@foo([
+    {
+        foo: "bar"
+    }
+])
+structure Q {}
+
+@foo([
+    [
+        []
+    ]
+])
+structure R {}

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/brackets.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/brackets.smithy
@@ -1,0 +1,184 @@
+$version: "2.0"
+
+// Single line
+metadata a = { a: "b" }
+
+// Multiline
+metadata b = {
+    a: "foobarbazbux"
+    b: "foobarbazbux"
+    c: "foobarbazbux"
+    d: "foobarbazbux"
+    e: "foobarbazbux"
+    f: "foobarbazbux"
+}
+
+// Leading and trailing WS
+metadata c = {
+    // Foo
+    a: "b"
+}
+
+metadata d = {
+    a: "b" // Foo
+}
+
+// Parent is array
+metadata e = [
+    {
+        foo: "bar"
+    }
+]
+
+// Line breaking values
+metadata f = [
+    """
+    foo
+    """
+]
+
+metadata g = [
+    "abc
+def"
+]
+
+metadata h = {
+    a: [
+        {
+            foo: "bar"
+        }
+    ]
+
+}
+
+namespace smithy.example
+
+// TraitStructure
+// Single line
+@externalDocumentation(a: "http://foo.com", c: "http://foo.com")
+structure A {}
+
+// Multi-line
+@externalDocumentation(
+    a: "http://foo.com"
+    b: "http://foo.com"
+    c: "http://foo.com"
+    d: "http://foo.com"
+    e: "http://foo.com"
+    f: "http://foo.com"
+    g: "http://foo.com"
+    h: "http://foo.com"
+    i: "http://foo.com"
+    j: "http://foo.com"
+)
+structure B {}
+
+// Leading WS
+@externalDocumentation(
+    // Foo
+    a: "http://foo.com"
+)
+structure C {}
+
+// Trailing WS
+@externalDocumentation(
+    a: "http://foo.com" // Foo
+)
+structure D {}
+
+// Object values
+@foo(
+    a: { bar: "baz" }
+)
+structure E {}
+
+// Array values
+@foo(
+    a: ["bar", "baz"]
+)
+structure F {}
+
+// TraitNode
+// Single line
+@foo(["foo", "bar"])
+structure G {}
+
+@foo({ foo: "bar", baz: "foo" })
+structure H {}
+
+// Multiline
+@foo([
+    "foobarbaz"
+    "foobarbaz"
+    "foobarbaz"
+    "foobarbaz"
+    "foobarbaz"
+    "foobarbaz"
+    "foobarbaz"
+    "foobarbaz"
+    "foobarbaz"
+])
+structure I {}
+
+@foo({
+    a: "foobarbaz"
+    b: "foobarbaz"
+    c: "foobarbaz"
+    d: "foobarbaz"
+    e: "foobarbaz"
+    f: "foobarbaz"
+    g: "foobarbaz"
+    h: "foobarbaz"
+    i: "foobarbaz"
+})
+structure J {}
+
+// Leading WS
+@foo(
+    // Foo
+    [
+        "a"
+    ]
+)
+structure K {}
+
+// Trailing WS
+@foo(
+    [
+        "a"
+    ] // Foo
+)
+structure L {}
+
+// Line breaking NodeValues
+@foo(
+    """
+    foo
+    """
+)
+structure M {}
+
+@foo(
+    "a
+bc"
+)
+structure N {}
+
+// Nested comments
+@foo([
+    "abc" // Foo
+    "def" // Bar
+])
+structure O {}
+
+// Nested objects
+@foo([{}])
+structure P {}
+
+@foo([{
+    foo: "bar"
+      }])
+structure Q {}
+
+@foo([[[]]])
+structure R {}

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/entity-shapes-line-break.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/entity-shapes-line-break.formatted.smithy
@@ -30,7 +30,7 @@ operation GetTime2 {
 
 @http(method: "X", uri: "/foo", code: 200)
 resource Sprocket2 {
-    identifiers: {username: String, id: String, otherId: String}
+    identifiers: { username: String, id: String, otherId: String }
 }
 
 @error("client")

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/entity-shapes.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/entity-shapes.smithy
@@ -33,12 +33,12 @@ operation GetTime2 {
 }
 
 resource Sprocket1 {
-    identifiers: {username: String}
+    identifiers: { username: String }
 }
 
 @http(method: "X", uri: "/foo", code: 200)
 resource Sprocket2 {
-    identifiers: {username: String, id: String, otherId: String}
+    identifiers: { username: String, id: String, otherId: String }
     collectionOperations: [
         SomeOperation
     ]
@@ -54,7 +54,7 @@ structure SomeOperationFoo {}
 
 @http(method: "X", uri: "/foo3", code: 200)
 resource Sprocket3 {
-    identifiers: {username: String, id: String, otherId: String}
+    identifiers: { username: String, id: String, otherId: String }
     // It's empty, so on a single line.
     collectionOperations: []
 }

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/nested-arrays-and-objects.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/nested-arrays-and-objects.formatted.smithy
@@ -1,0 +1,24 @@
+$version: "2.0"
+
+metadata foo = {
+    bar: ["baz", "foo", "bar", "baz"]
+    baz: {
+        foo: ["bar"]
+    }
+}
+
+metadata bar = [
+    {
+        foo: [
+            {
+                bar: ["baz", "foo"]
+                baz: ["foo", "bar"]
+            }
+            {
+                foo: "bar"
+            }
+        ]
+    }
+]
+
+namespace smithy.example

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/nested-arrays-and-objects.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/nested-arrays-and-objects.smithy
@@ -1,0 +1,7 @@
+$version: "2.0"
+
+metadata foo = {bar: ["baz", "foo", "bar", "baz"], baz: {foo: ["bar"]}}
+
+metadata bar = [{foo: [{bar: ["baz", "foo"], baz: ["foo", "bar"]}, {foo: "bar"}]}]
+
+namespace smithy.example

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/section-statement-blank-lines.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/section-statement-blank-lines.formatted.smithy
@@ -2,7 +2,7 @@
 // newline.
 $version: "2.0"
 $foo: 100
-$baz: {abc: 123}
+$baz: { abc: 123 }
 
 $bar: {
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/single-line-object.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/single-line-object.formatted.smithy
@@ -1,0 +1,9 @@
+$version: "2.0"
+
+metadata foo = [
+    {
+        bar: { baz: "2" }
+    }
+]
+
+namespace smithy.example

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/single-line-object.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/single-line-object.smithy
@@ -1,0 +1,9 @@
+$version: "2.0"
+
+metadata foo = [
+    {
+        bar: {baz: "2"}
+    }
+]
+
+namespace smithy.example

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/trait-textblock.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/trait-textblock.formatted.smithy
@@ -24,3 +24,11 @@ string Bar
     """
 )
 string Baz
+
+@documentation(
+    """
+    This is the documentation for Bux.
+    Lorem ipsum dolor.
+    """
+)
+string Bux

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/trait-textblock.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/trait-textblock.smithy
@@ -24,3 +24,9 @@ Lorem ipsum dolor.
 """
 )
 string Baz
+
+@documentation("""
+    This is the documentation for Bux.
+    Lorem ipsum dolor.
+""")
+string Bux

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/traits-lots-of-tags.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/traits-lots-of-tags.formatted.smithy
@@ -1,0 +1,20 @@
+$version: "2.0"
+
+namespace smithy.example
+
+@tags([
+    "abcdefghijklmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstuvwxyz"
+])
+string Foo


### PR DESCRIPTION
This commit updates how the formatter decides whether or not to put a line break after an opening bracket and before the closing bracket (bracket meaning `()`, `{}`, and `[]`). Previously, all bracket types followed the same logic - which included breaking when there are any array or object descendants. This lead to trait bodies being formatted like:
```
@someTrait(
    [
        {
	    key: "value"
	}
    ]
)
structure SomeStruct {}
```
With this change, it will be formatted like:
```
@someTrait([
    {
        key: "value"
    }
])
structure SomeStruct {}
```
the same also applies if the trait has a single object member:
```
@someTrait({
    foo: "bar"
    // ... more members to cause break onto separate lines
})
structure SomeStruct {}
```
Object nodes now also have a single space of padding inside the brackets when on a single line. Previously, it was like:
```
metadata foo = {bar: "baz"}
```
now:
```
metadata foo = { bar: "baz" }
```
Finally, when object nodes are elements of an array, they now always line break if not empty. Previously:
```
metadata foo = [
    {bar: "baz"}
]
```
now (with above padding changes):
```
metadata foo = [
    {
        bar: "baz"
    }
]
```
A few test cases were updated for this behavior, and a few more added to test the nuances of this formatting method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
