### PR TITLE
Add backticks to diff messages for trait changes

### DIFF
--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/FormatCommandTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/FormatCommandTest.java
@@ -32,14 +32,14 @@ public class FormatCommandTest {
         IntegUtils.run("bad-formatting", ListUtils.of("format", "model/other.smithy"), result -> {
             assertThat(result.getExitCode(), equalTo(0));
 
-            String model = result.getFile("model/other.smithy").replace("\r\n", "\n");
-            assertThat(model, equalTo("$version: \"2.0\"\n"
-                                      + "\n"
-                                      + "namespace smithy.example\n"
-                                      + "\n"
-                                      + "string MyString\n"
-                                      + "\n"
-                                      + "string MyString2\n"));
+            String model = result.getFile("model/other.smithy");
+            assertThat(model, equalTo(String.format("$version: \"2.0\"%n"
+                                      + "%n"
+                                      + "namespace smithy.example%n"
+                                      + "%n"
+                                      + "string MyString%n"
+                                      + "%n"
+                                      + "string MyString2%n")));
         });
     }
 
@@ -48,24 +48,24 @@ public class FormatCommandTest {
         IntegUtils.run("bad-formatting", ListUtils.of("format", "model"), result -> {
             assertThat(result.getExitCode(), equalTo(0));
 
-            String main = result.getFile("model/main.smithy").replace("\r\n", "\n");
-            assertThat(main, equalTo("$version: \"2.0\"\n"
-                                     + "\n"
-                                     + "metadata this_is_a_long_string = {\n"
-                                     + "    this_is_a_long_string1: \"a\"\n"
-                                     + "    this_is_a_long_string2: \"b\"\n"
-                                     + "    this_is_a_long_string3: \"c\"\n"
-                                     + "    this_is_a_long_string4: \"d\"\n"
-                                     + "}\n"));
+            String main = result.getFile("model/main.smithy");
+            assertThat(main, equalTo(String.format("$version: \"2.0\"%n"
+                                     + "%n"
+                                     + "metadata this_is_a_long_string = {%n"
+                                     + "    this_is_a_long_string1: \"a\"%n"
+                                     + "    this_is_a_long_string2: \"b\"%n"
+                                     + "    this_is_a_long_string3: \"c\"%n"
+                                     + "    this_is_a_long_string4: \"d\"%n"
+                                     + "}%n")));
 
-            String other = result.getFile("model/other.smithy").replace("\r\n", "\n");
-            assertThat(other, equalTo("$version: \"2.0\"\n"
-                                      + "\n"
-                                      + "namespace smithy.example\n"
-                                      + "\n"
-                                      + "string MyString\n"
-                                      + "\n"
-                                      + "string MyString2\n"));
+            String other = result.getFile("model/other.smithy");
+            assertThat(other, equalTo(String.format("$version: \"2.0\"%n"
+                                      + "%n"
+                                      + "namespace smithy.example%n"
+                                      + "%n"
+                                      + "string MyString%n"
+                                      + "%n"
+                                      + "string MyString2%n")));
         });
     }
 }

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ModifiedTrait.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ModifiedTrait.java
@@ -227,7 +227,7 @@ public final class ModifiedTrait extends AbstractDiffEvaluator {
                 }
 
                 String message;
-                String pretty = Node.prettyPrintJson(right.toNode());
+                String pretty = Node.prettyPrintJsonWithBackticks(right.toNode());
                 if (path.isEmpty()) {
                     message = String.format("Added trait `%s` with value %s", trait, pretty);
                 } else {
@@ -260,7 +260,7 @@ public final class ModifiedTrait extends AbstractDiffEvaluator {
                     return Collections.emptyList();
                 }
 
-                String pretty = Node.prettyPrintJson(left.toNode());
+                String pretty = Node.prettyPrintJsonWithBackticks(left.toNode());
                 String message;
                 if (path.isEmpty()) {
                     message = String.format("Removed trait `%s`. Previous trait value: %s", trait, pretty);
@@ -294,8 +294,8 @@ public final class ModifiedTrait extends AbstractDiffEvaluator {
                     return Collections.emptyList();
                 }
 
-                String leftPretty = Node.prettyPrintJson(left.toNode());
-                String rightPretty = Node.prettyPrintJson(right.toNode());
+                String leftPretty = Node.prettyPrintJsonWithBackticks(left.toNode());
+                String rightPretty = Node.prettyPrintJsonWithBackticks(right.toNode());
                 String message;
                 if (path.isEmpty()) {
                     message = String.format("Changed trait `%s` from %s to %s", trait, leftPretty, rightPretty);

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ModifiedTrait.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ModifiedTrait.java
@@ -42,6 +42,7 @@ import software.amazon.smithy.model.traits.synthetic.OriginalShapeIdTrait;
 import software.amazon.smithy.model.traits.synthetic.SyntheticEnumTrait;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.validation.ValidationUtils;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.SetUtils;
 import software.amazon.smithy.utils.StringUtils;
@@ -227,7 +228,7 @@ public final class ModifiedTrait extends AbstractDiffEvaluator {
                 }
 
                 String message;
-                String pretty = Node.prettyPrintJsonWithBackticks(right.toNode());
+                String pretty = ValidationUtils.tickedPrettyPrintedNode(right);
                 if (path.isEmpty()) {
                     message = String.format("Added trait `%s` with value %s", trait, pretty);
                 } else {
@@ -260,7 +261,7 @@ public final class ModifiedTrait extends AbstractDiffEvaluator {
                     return Collections.emptyList();
                 }
 
-                String pretty = Node.prettyPrintJsonWithBackticks(left.toNode());
+                String pretty = ValidationUtils.tickedPrettyPrintedNode(left);
                 String message;
                 if (path.isEmpty()) {
                     message = String.format("Removed trait `%s`. Previous trait value: %s", trait, pretty);
@@ -294,8 +295,8 @@ public final class ModifiedTrait extends AbstractDiffEvaluator {
                     return Collections.emptyList();
                 }
 
-                String leftPretty = Node.prettyPrintJsonWithBackticks(left.toNode());
-                String rightPretty = Node.prettyPrintJsonWithBackticks(right.toNode());
+                String leftPretty = ValidationUtils.tickedPrettyPrintedNode(left);
+                String rightPretty = ValidationUtils.tickedPrettyPrintedNode(right);
                 String message;
                 if (path.isEmpty()) {
                     message = String.format("Changed trait `%s` from %s to %s", trait, leftPretty, rightPretty);

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/TraitBreakingChange.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/TraitBreakingChange.java
@@ -214,15 +214,15 @@ public final class TraitBreakingChange extends AbstractDiffEvaluator {
         }
 
         private String createBreakingMessage(TraitDefinition.ChangeType type, String path, Node left, Node right) {
-            String leftPretty = Node.prettyPrintJson(left.toNode());
-            String rightPretty = Node.prettyPrintJson(right.toNode());
+            String leftPretty = Node.prettyPrintJsonWithBackticks(left.toNode());
+            String rightPretty = Node.prettyPrintJsonWithBackticks(right.toNode());
 
             switch (type) {
                 case ADD:
                     if (!path.isEmpty()) {
                         return String.format("Added trait contents to `%s` at path `%s` with value %s",
                                              trait.getId(), path, rightPretty);
-                    } else if (rightPretty.equals("{}")) {
+                    } else if (Node.objectNode().equals(right.toNode())) {
                         return String.format("Added trait `%s`", trait.getId());
                     } else {
                         return String.format("Added trait `%s` with value %s", trait.getId(), rightPretty);
@@ -231,7 +231,7 @@ public final class TraitBreakingChange extends AbstractDiffEvaluator {
                     if (!path.isEmpty()) {
                         return String.format("Removed trait contents from `%s` at path `%s`. Removed value: %s",
                                              trait.getId(), path, leftPretty);
-                    } else if (leftPretty.equals("{}")) {
+                    } else if (Node.objectNode().equals(left.toNode())) {
                         return String.format("Removed trait `%s`", trait.getId());
                     } else {
                         return String.format("Removed trait `%s`. Previous trait value: %s",

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/TraitBreakingChange.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/TraitBreakingChange.java
@@ -30,6 +30,7 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.validation.ValidationUtils;
 import software.amazon.smithy.utils.StringUtils;
 
 /**
@@ -214,15 +215,15 @@ public final class TraitBreakingChange extends AbstractDiffEvaluator {
         }
 
         private String createBreakingMessage(TraitDefinition.ChangeType type, String path, Node left, Node right) {
-            String leftPretty = Node.prettyPrintJsonWithBackticks(left.toNode());
-            String rightPretty = Node.prettyPrintJsonWithBackticks(right.toNode());
+            String leftPretty = ValidationUtils.tickedPrettyPrintedNode(left);
+            String rightPretty = ValidationUtils.tickedPrettyPrintedNode(right);
 
             switch (type) {
                 case ADD:
                     if (!path.isEmpty()) {
                         return String.format("Added trait contents to `%s` at path `%s` with value %s",
                                              trait.getId(), path, rightPretty);
-                    } else if (Node.objectNode().equals(right.toNode())) {
+                    } else if (Node.objectNode().equals(right)) {
                         return String.format("Added trait `%s`", trait.getId());
                     } else {
                         return String.format("Added trait `%s` with value %s", trait.getId(), rightPretty);
@@ -231,7 +232,7 @@ public final class TraitBreakingChange extends AbstractDiffEvaluator {
                     if (!path.isEmpty()) {
                         return String.format("Removed trait contents from `%s` at path `%s`. Removed value: %s",
                                              trait.getId(), path, leftPretty);
-                    } else if (Node.objectNode().equals(left.toNode())) {
+                    } else if (Node.objectNode().equals(left)) {
                         return String.format("Removed trait `%s`", trait.getId());
                     } else {
                         return String.format("Removed trait `%s`. Previous trait value: %s",

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedPaginatedTraitTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedPaginatedTraitTest.java
@@ -74,7 +74,7 @@ public class ChangedPaginatedTraitTest {
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
-                   containsString("Removed trait contents from `smithy.api#paginated` at path `/items`. Removed value: \"things\""));
+                   containsString("Removed trait contents from `smithy.api#paginated` at path `/items`. Removed value: `things`"));
     }
 
     @Test
@@ -91,7 +91,7 @@ public class ChangedPaginatedTraitTest {
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
-                   containsString("Added trait contents to `smithy.api#paginated` at path `/items` with value \"things\""));
+                   containsString("Added trait contents to `smithy.api#paginated` at path `/items` with value `things`"));
     }
 
     @Test
@@ -108,7 +108,7 @@ public class ChangedPaginatedTraitTest {
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
-                   containsString("Changed trait contents of `smithy.api#paginated` at path `/items` from \"things\" to \"otherThings\""));
+                   containsString("Changed trait contents of `smithy.api#paginated` at path `/items` from `things` to `otherThings`"));
     }
 
     @Test
@@ -125,7 +125,7 @@ public class ChangedPaginatedTraitTest {
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
-                   containsString("Removed trait contents from `smithy.api#paginated` at path `/pageSize`. Removed value: \"maxResults\""));
+                   containsString("Removed trait contents from `smithy.api#paginated` at path `/pageSize`. Removed value: `maxResults`"));
     }
 
     @Test
@@ -157,7 +157,7 @@ public class ChangedPaginatedTraitTest {
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
-                   containsString("Changed trait contents of `smithy.api#paginated` at path `/pageSize` from \"maxResults\" to \"otherMaxResults\""));
+                   containsString("Changed trait contents of `smithy.api#paginated` at path `/pageSize` from `maxResults` to `otherMaxResults`"));
     }
 
     @Test
@@ -173,7 +173,7 @@ public class ChangedPaginatedTraitTest {
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
-                   containsString("Changed trait contents of `smithy.api#paginated` at path `/inputToken` from \"token\" to \"otherToken\""));
+                   containsString("Changed trait contents of `smithy.api#paginated` at path `/inputToken` from `token` to `otherToken`"));
     }
 
     @Test
@@ -189,6 +189,6 @@ public class ChangedPaginatedTraitTest {
 
         assertThat(changedTraitEvents.size(), equalTo(1));
         assertThat(changedTraitEvents.get(0).getMessage(),
-                   containsString("Changed trait contents of `smithy.api#paginated` at path `/outputToken` from \"token\" to \"otherToken\""));
+                   containsString("Changed trait contents of `smithy.api#paginated` at path `/outputToken` from `token` to `otherToken`"));
     }
 }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ModifiedTraitTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ModifiedTraitTest.java
@@ -203,7 +203,9 @@ public class ModifiedTraitTest {
                 .assemble()
                 .unwrap();
         List<ValidationEvent> events = TestHelper.findEvents(ModelDiff.compare(modelA, modelB), "ModifiedTrait");
-        List<String> messages = events.stream().map(ValidationEvent::getMessage).collect(Collectors.toList());
+        List<String> messages = events.stream().map(ValidationEvent::getMessage)
+                .map(message -> message.replaceAll("\r\n", "\n")) // normalize line separators
+                .collect(Collectors.toList());
 
         assertThat(events, hasSize(4));
         assertThat(events.stream().filter(e -> e.getMessage().contains("Removed"))
@@ -232,7 +234,9 @@ public class ModifiedTraitTest {
                 .assemble()
                 .unwrap();
         List<ValidationEvent> events = TestHelper.findEvents(ModelDiff.compare(modelA, modelB), "ModifiedTrait");
-        List<String> messages = events.stream().map(ValidationEvent::getMessage).collect(Collectors.toList());
+        List<String> messages = events.stream().map(ValidationEvent::getMessage)
+                .map(message -> message.replaceAll("\r\n", "\n")) // normalize line separators
+                .collect(Collectors.toList());
 
         assertThat(events, hasSize(4));
         assertThat(events.stream().filter(e -> e.getMessage().contains("Removed"))
@@ -262,7 +266,9 @@ public class ModifiedTraitTest {
                 .assemble()
                 .unwrap();
         List<ValidationEvent> events = TestHelper.findEvents(ModelDiff.compare(modelA, modelB), "ModifiedTrait");
-        List<String> messages = events.stream().map(ValidationEvent::getMessage).collect(Collectors.toList());
+        List<String> messages = events.stream().map(ValidationEvent::getMessage)
+                .map(message -> message.replaceAll("\r\n", "\n")) // normalize line separators
+                .collect(Collectors.toList());
 
         assertThat(events, hasSize(4));
         assertThat(events.stream().filter(e -> e.getMessage().contains("Removed"))

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ModifiedTraitTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ModifiedTraitTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.Matchers.hasSize;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -203,9 +202,7 @@ public class ModifiedTraitTest {
                 .assemble()
                 .unwrap();
         List<ValidationEvent> events = TestHelper.findEvents(ModelDiff.compare(modelA, modelB), "ModifiedTrait");
-        List<String> messages = events.stream().map(ValidationEvent::getMessage)
-                .map(message -> message.replaceAll("\r\n", "\n")) // normalize line separators
-                .collect(Collectors.toList());
+        List<String> messages = events.stream().map(ValidationEvent::getMessage).collect(Collectors.toList());
 
         assertThat(events, hasSize(4));
         assertThat(events.stream().filter(e -> e.getMessage().contains("Removed"))
@@ -216,10 +213,14 @@ public class ModifiedTraitTest {
                 "Changed trait contents of `smithy.example#aTrait` at path `/foo/1` from `b` to `B`",
                 "Added trait contents to `smithy.example#aTrait` at path `/foo/3` with value `4`",
                 "Removed trait contents from `smithy.example#aTrait` at path `/foo/2`. Removed value: `3`",
-                "Removed trait contents from `smithy.example#aTrait` at path `/foo`. Removed value: \n"
-                        + "```\n"
-                        + "[\n    \"1\",\n    \"2\",\n    \"3\"\n]\n"
-                        + "```"
+                String.format("Removed trait contents from `smithy.example#aTrait` at path `/foo`. Removed value: %n"
+                        + "```%n"
+                        + "[%n"
+                        + "    \"1\",%n"
+                        + "    \"2\",%n"
+                        + "    \"3\"%n"
+                        + "]%n"
+                        + "```%n")
         ));
     }
 
@@ -234,9 +235,7 @@ public class ModifiedTraitTest {
                 .assemble()
                 .unwrap();
         List<ValidationEvent> events = TestHelper.findEvents(ModelDiff.compare(modelA, modelB), "ModifiedTrait");
-        List<String> messages = events.stream().map(ValidationEvent::getMessage)
-                .map(message -> message.replaceAll("\r\n", "\n")) // normalize line separators
-                .collect(Collectors.toList());
+        List<String> messages = events.stream().map(ValidationEvent::getMessage).collect(Collectors.toList());
 
         assertThat(events, hasSize(4));
         assertThat(events.stream().filter(e -> e.getMessage().contains("Removed"))
@@ -247,11 +246,15 @@ public class ModifiedTraitTest {
                 "Changed trait contents of `smithy.example#aTrait` at path `/foo/1` from `b` to `B`",
                 "Added trait contents to `smithy.example#aTrait` at path `/foo/3` with value `4`",
                 "Removed trait contents from `smithy.example#aTrait` at path `/foo/2`. Removed value: `3`",
-                "Removed trait contents from `smithy.example#aTrait` at path `/foo`. "
-                        + "Removed value: \n"
-                        + "```\n"
-                        + "[\n    \"1\",\n    \"2\",\n    \"3\"\n]\n"
-                        + "```"
+                String.format("Removed trait contents from `smithy.example#aTrait` at path `/foo`. "
+                        + "Removed value: %n"
+                        + "```%n"
+                        + "[%n"
+                        + "    \"1\",%n"
+                        + "    \"2\",%n"
+                        + "    \"3\"%n"
+                        + "]%n"
+                        + "```%n")
         ));
     }
 
@@ -266,9 +269,7 @@ public class ModifiedTraitTest {
                 .assemble()
                 .unwrap();
         List<ValidationEvent> events = TestHelper.findEvents(ModelDiff.compare(modelA, modelB), "ModifiedTrait");
-        List<String> messages = events.stream().map(ValidationEvent::getMessage)
-                .map(message -> message.replaceAll("\r\n", "\n")) // normalize line separators
-                .collect(Collectors.toList());
+        List<String> messages = events.stream().map(ValidationEvent::getMessage).collect(Collectors.toList());
 
         assertThat(events, hasSize(4));
         assertThat(events.stream().filter(e -> e.getMessage().contains("Removed"))
@@ -277,11 +278,15 @@ public class ModifiedTraitTest {
                 .filter(e -> e.getSourceLocation().getFilename().endsWith("b.smithy")).count(), equalTo(2L));
         assertThat(messages, containsInAnyOrder(
                 "Changed trait contents of `smithy.example#aTrait` at path `/foo/bam` from `b` to `B`",
-                "Removed trait contents from `smithy.example#aTrait` at path `/foo`. "
-                        + "Removed value: \n"
-                        + "```\n"
-                        + "{\n    \"baz\": \"1\",\n    \"bam\": \"2\",\n    \"boo\": \"3\"\n}\n"
-                        + "```",
+                String.format("Removed trait contents from `smithy.example#aTrait` at path `/foo`. "
+                        + "Removed value: %n"
+                        + "```%n"
+                        + "{%n"
+                        + "    \"baz\": \"1\",%n"
+                        + "    \"bam\": \"2\",%n"
+                        + "    \"boo\": \"3\"%n"
+                        + "}%n"
+                        + "```%n"),
                 "Added trait contents to `smithy.example#aTrait` at path `/foo/qux` with value `4`",
                 "Removed trait contents from `smithy.example#aTrait` at path `/foo/boo`. Removed value: `3`"
         ));

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ModifiedTraitTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ModifiedTraitTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.hasSize;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -160,9 +161,9 @@ public class ModifiedTraitTest {
                 equalTo(2L));
 
         assertThat(messages, containsInAnyOrder(
-                "Changed trait `smithy.example#b` from \"hello\" to \"hello!\"",
-                "Removed trait `smithy.example#a`. Previous trait value: {}",
-                "Added trait `smithy.example#c` with value \"foo\""
+                "Changed trait `smithy.example#b` from `hello` to `hello!`",
+                "Removed trait `smithy.example#a`. Previous trait value: `{}`",
+                "Added trait `smithy.example#c` with value `foo`"
         ));
     }
 
@@ -186,8 +187,8 @@ public class ModifiedTraitTest {
                 equalTo(2L));
 
         assertThat(messages, containsInAnyOrder(
-                "Added trait contents to `smithy.example#aTrait` at path `/bar` with value \"no\"",
-                "Changed trait contents of `smithy.example#aTrait` at path `/baz/foo` from \"bye\" to \"adios\""
+                "Added trait contents to `smithy.example#aTrait` at path `/bar` with value `no`",
+                "Changed trait contents of `smithy.example#aTrait` at path `/baz/foo` from `bye` to `adios`"
         ));
     }
 
@@ -210,11 +211,13 @@ public class ModifiedTraitTest {
         assertThat(events.stream().filter(e -> !e.getMessage().contains("Removed"))
                 .filter(e -> e.getSourceLocation().getFilename().endsWith("b.smithy")).count(), equalTo(2L));
         assertThat(messages, containsInAnyOrder(
-                "Changed trait contents of `smithy.example#aTrait` at path `/foo/1` from \"b\" to \"B\"",
-                "Added trait contents to `smithy.example#aTrait` at path `/foo/3` with value \"4\"",
-                "Removed trait contents from `smithy.example#aTrait` at path `/foo/2`. Removed value: \"3\"",
-                "Removed trait contents from `smithy.example#aTrait` at path `/foo`. Removed value: "
-                + "[\n    \"1\",\n    \"2\",\n    \"3\"\n]"
+                "Changed trait contents of `smithy.example#aTrait` at path `/foo/1` from `b` to `B`",
+                "Added trait contents to `smithy.example#aTrait` at path `/foo/3` with value `4`",
+                "Removed trait contents from `smithy.example#aTrait` at path `/foo/2`. Removed value: `3`",
+                "Removed trait contents from `smithy.example#aTrait` at path `/foo`. Removed value: \n"
+                        + "```\n"
+                        + "[\n    \"1\",\n    \"2\",\n    \"3\"\n]\n"
+                        + "```"
         ));
     }
 
@@ -237,10 +240,14 @@ public class ModifiedTraitTest {
         assertThat(events.stream().filter(e -> !e.getMessage().contains("Removed"))
                 .filter(e -> e.getSourceLocation().getFilename().endsWith("b.smithy")).count(), equalTo(2L));
         assertThat(messages, containsInAnyOrder(
-                "Changed trait contents of `smithy.example#aTrait` at path `/foo/1` from \"b\" to \"B\"",
-                "Added trait contents to `smithy.example#aTrait` at path `/foo/3` with value \"4\"",
-                "Removed trait contents from `smithy.example#aTrait` at path `/foo/2`. Removed value: \"3\"",
-                "Removed trait contents from `smithy.example#aTrait` at path `/foo`. Removed value: [\n    \"1\",\n    \"2\",\n    \"3\"\n]"
+                "Changed trait contents of `smithy.example#aTrait` at path `/foo/1` from `b` to `B`",
+                "Added trait contents to `smithy.example#aTrait` at path `/foo/3` with value `4`",
+                "Removed trait contents from `smithy.example#aTrait` at path `/foo/2`. Removed value: `3`",
+                "Removed trait contents from `smithy.example#aTrait` at path `/foo`. "
+                        + "Removed value: \n"
+                        + "```\n"
+                        + "[\n    \"1\",\n    \"2\",\n    \"3\"\n]\n"
+                        + "```"
         ));
     }
 
@@ -263,10 +270,14 @@ public class ModifiedTraitTest {
         assertThat(events.stream().filter(e -> !e.getMessage().contains("Removed"))
                 .filter(e -> e.getSourceLocation().getFilename().endsWith("b.smithy")).count(), equalTo(2L));
         assertThat(messages, containsInAnyOrder(
-                "Changed trait contents of `smithy.example#aTrait` at path `/foo/bam` from \"b\" to \"B\"",
-                "Removed trait contents from `smithy.example#aTrait` at path `/foo`. Removed value: {\n    \"baz\": \"1\",\n    \"bam\": \"2\",\n    \"boo\": \"3\"\n}",
-                "Added trait contents to `smithy.example#aTrait` at path `/foo/qux` with value \"4\"",
-                "Removed trait contents from `smithy.example#aTrait` at path `/foo/boo`. Removed value: \"3\""
+                "Changed trait contents of `smithy.example#aTrait` at path `/foo/bam` from `b` to `B`",
+                "Removed trait contents from `smithy.example#aTrait` at path `/foo`. "
+                        + "Removed value: \n"
+                        + "```\n"
+                        + "{\n    \"baz\": \"1\",\n    \"bam\": \"2\",\n    \"boo\": \"3\"\n}\n"
+                        + "```",
+                "Added trait contents to `smithy.example#aTrait` at path `/foo/qux` with value `4`",
+                "Removed trait contents from `smithy.example#aTrait` at path `/foo/boo`. Removed value: `3`"
         ));
     }
 
@@ -287,8 +298,8 @@ public class ModifiedTraitTest {
         assertThat(events.stream().filter(e -> e.getSourceLocation().getFilename().endsWith("b.smithy")).count(),
                 equalTo(2L));
         assertThat(messages, containsInAnyOrder(
-                "Changed trait contents of `smithy.example#aTrait` at path `/baz/foo` from \"a\" to \"b\"",
-                "Changed trait contents of `smithy.example#aTrait` at path `/baz/baz` from \"a\" to \"b\""
+                "Changed trait contents of `smithy.example#aTrait` at path `/baz/foo` from `a` to `b`",
+                "Changed trait contents of `smithy.example#aTrait` at path `/baz/baz` from `a` to `b`"
         ));
     }
 
@@ -311,18 +322,18 @@ public class ModifiedTraitTest {
         assertThat(events.stream().filter(e -> e.getMessage().contains("Changed") || e.getMessage().contains("Added"))
                 .filter(e -> e.getSourceLocation().getFilename().endsWith("b.smithy")).count(), equalTo(9L));
         assertThat(messages, containsInAnyOrder(
-                "Added trait contents to `smithy.example#aTrait` at path `/a` with value \"a\"",
-                "Removed trait contents from `smithy.example#aTrait` at path `/b`. Removed value: \"a\"",
-                "Changed trait contents of `smithy.example#aTrait` at path `/c` from \"a\" to \"c\"",
-                "Changed trait contents of `smithy.example#aTrait` at path `/d` from \"a\" to \"d\"",
-                "Added trait contents to `smithy.example#aTrait` at path `/e` with value \"a\"",
-                "Removed trait contents from `smithy.example#aTrait` at path `/f`. Removed value: \"a\"",
-                "Changed trait contents of `smithy.example#aTrait` at path `/g` from \"a\" to \"h\"",
-                "Changed trait contents of `smithy.example#aTrait` at path `/h` from \"a\" to \"h\"",
-                "Added trait contents to `smithy.example#aTrait` at path `/i` with value \"a\"",
-                "Removed trait contents from `smithy.example#aTrait` at path `/j`. Removed value: \"a\"",
-                "Changed trait contents of `smithy.example#aTrait` at path `/k` from \"a\" to \"k\"",
-                "Changed trait contents of `smithy.example#aTrait` at path `/l` from \"a\" to \"l\""
+                "Added trait contents to `smithy.example#aTrait` at path `/a` with value `a`",
+                "Removed trait contents from `smithy.example#aTrait` at path `/b`. Removed value: `a`",
+                "Changed trait contents of `smithy.example#aTrait` at path `/c` from `a` to `c`",
+                "Changed trait contents of `smithy.example#aTrait` at path `/d` from `a` to `d`",
+                "Added trait contents to `smithy.example#aTrait` at path `/e` with value `a`",
+                "Removed trait contents from `smithy.example#aTrait` at path `/f`. Removed value: `a`",
+                "Changed trait contents of `smithy.example#aTrait` at path `/g` from `a` to `h`",
+                "Changed trait contents of `smithy.example#aTrait` at path `/h` from `a` to `h`",
+                "Added trait contents to `smithy.example#aTrait` at path `/i` with value `a`",
+                "Removed trait contents from `smithy.example#aTrait` at path `/j`. Removed value: `a`",
+                "Changed trait contents of `smithy.example#aTrait` at path `/k` from `a` to `k`",
+                "Changed trait contents of `smithy.example#aTrait` at path `/l` from `a` to `l`"
         ));
     }
 

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/TraitBreakingChangeTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/TraitBreakingChangeTest.java
@@ -131,7 +131,7 @@ public class TraitBreakingChangeTest {
                 assertThat(events.get(0).getId(), equalTo("TraitBreakingChange.Update.smithy.example#exampleTrait"));
                 assertThat(events.get(0).getMessage(),
                            equalTo("Changed trait contents of `smithy.example#exampleTrait` at path `/1` "
-                                   + "from \"b\" to \"B\""));
+                                   + "from `b` to `B`"));
             }
         );
     }
@@ -147,7 +147,7 @@ public class TraitBreakingChangeTest {
                     assertThat(events.get(0).getId(), equalTo("TraitBreakingChange.Remove.smithy.example#exampleTrait"));
                     assertThat(events.get(0).getMessage(),
                                equalTo("Removed trait contents from `smithy.example#exampleTrait` at path `/b`. "
-                                       + "Removed value: \"B\""));
+                                       + "Removed value: `B`"));
                 }
         );
     }
@@ -166,7 +166,7 @@ public class TraitBreakingChangeTest {
                 assertThat(events.get(0).getId(), equalTo("TraitBreakingChange.Update.smithy.example#exampleTrait"));
                 assertThat(events.get(0).getMessage(),
                            equalTo("Changed trait contents of `smithy.example#exampleTrait` at path `/b` "
-                                   + "from \"B\" to \"_B_\""));
+                                   + "from `B` to `_B_`"));
             }
         );
     }
@@ -184,7 +184,7 @@ public class TraitBreakingChangeTest {
                 assertThat(events.get(0).getId(), equalTo("TraitBreakingChange.Remove.smithy.example#exampleTrait"));
                 assertThat(events.get(0).getMessage(),
                            equalTo("Removed trait contents from `smithy.example#exampleTrait` at path "
-                                   + "`/foo/bar`. Removed value: \"hi\""));
+                                   + "`/foo/bar`. Removed value: `hi`"));
             }
         );
     }
@@ -202,7 +202,7 @@ public class TraitBreakingChangeTest {
                 assertThat(events.get(0).getId(), equalTo("TraitBreakingChange.Update.smithy.example#exampleTrait"));
                 assertThat(events.get(0).getMessage(),
                            equalTo("Changed trait contents of `smithy.example#exampleTrait` at path "
-                                   + "`/foo` from \"hi\" to \"bye\""));
+                                   + "`/foo` from `hi` to `bye`"));
             }
         );
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
@@ -156,6 +156,27 @@ public abstract class Node implements FromSourceLocation, ToNode {
     }
 
     /**
+     * Writes the contents of a Node to a pretty-printed JSON string,
+     * and surrounds the result in backticks.
+     *
+     * @param node Node to write.
+     * @return Returns a string suitable for Markdown rendering.
+     */
+    public static String prettyPrintJsonWithBackticks(Node node) {
+        String prettyPrinted = prettyPrintJson(node);
+        if (prettyPrinted.contains(System.lineSeparator()) || prettyPrinted.contains("\n")) {
+            return System.lineSeparator() + "```" + System.lineSeparator()
+                    + prettyPrinted + System.lineSeparator()
+                    + "```";
+        } else if (prettyPrinted.startsWith("\"") && prettyPrinted.endsWith("\"")) {
+            // for pure strings, replace the quotes with backticks
+            return "`" + prettyPrinted.substring(1, prettyPrinted.length() - 1) + "`";
+        } else {
+            return "`" + prettyPrinted + "`";
+        }
+    }
+
+    /**
      * Writes the contents of a Node to a non-pretty-printed JSON string.
      *
      * @param node Node to write.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/Node.java
@@ -156,27 +156,6 @@ public abstract class Node implements FromSourceLocation, ToNode {
     }
 
     /**
-     * Writes the contents of a Node to a pretty-printed JSON string,
-     * and surrounds the result in backticks.
-     *
-     * @param node Node to write.
-     * @return Returns a string suitable for Markdown rendering.
-     */
-    public static String prettyPrintJsonWithBackticks(Node node) {
-        String prettyPrinted = prettyPrintJson(node);
-        if (prettyPrinted.contains(System.lineSeparator()) || prettyPrinted.contains("\n")) {
-            return System.lineSeparator() + "```" + System.lineSeparator()
-                    + prettyPrinted + System.lineSeparator()
-                    + "```";
-        } else if (prettyPrinted.startsWith("\"") && prettyPrinted.endsWith("\"")) {
-            // for pure strings, replace the quotes with backticks
-            return "`" + prettyPrinted.substring(1, prettyPrinted.length() - 1) + "`";
-        } else {
-            return "`" + prettyPrinted + "`";
-        }
-    }
-
-    /**
      * Writes the contents of a Node to a non-pretty-printed JSON string.
      *
      * @param node Node to write.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/internal/PrettyPrintWriter.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/internal/PrettyPrintWriter.java
@@ -95,7 +95,7 @@ final class PrettyPrintWriter extends JsonWriter {
         if (indentString == null) {
             return false;
         }
-        writer.write('\n');
+        writer.write(System.lineSeparator());
         for (int i = 0; i < indent; i++) {
             writer.write(indentString);
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationUtils.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationUtils.java
@@ -99,9 +99,7 @@ public final class ValidationUtils {
     public static String tickedPrettyPrintedNode(Node node) {
         String prettyPrinted = Node.prettyPrintJson(node);
         if (prettyPrinted.contains(System.lineSeparator()) || prettyPrinted.contains("\n")) {
-            return System.lineSeparator() + "```" + System.lineSeparator()
-                    + prettyPrinted + System.lineSeparator()
-                    + "```";
+            return String.format("%n```%n%s%n```%n", prettyPrinted);
         } else if (prettyPrinted.startsWith("\"") && prettyPrinted.endsWith("\"")) {
             // for pure strings, replace the quotes with backticks
             return "`" + prettyPrinted.substring(1, prettyPrinted.length() - 1) + "`";

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationUtils.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/ValidationUtils.java
@@ -30,6 +30,7 @@ import java.util.StringJoiner;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ToShapeId;
 
@@ -87,6 +88,26 @@ public final class ValidationUtils {
 
     public static String tickedList(Stream<?> values) {
         return values.map(Object::toString).sorted().collect(Collectors.joining("`, `", "`", "`"));
+    }
+
+    /**
+     * Writes the contents of a Node to a pretty-printed JSON string surrounded in backticks.
+     *
+     * @param node Node to write.
+     * @return Returns a string suitable for Markdown rendering.
+     */
+    public static String tickedPrettyPrintedNode(Node node) {
+        String prettyPrinted = Node.prettyPrintJson(node);
+        if (prettyPrinted.contains(System.lineSeparator()) || prettyPrinted.contains("\n")) {
+            return System.lineSeparator() + "```" + System.lineSeparator()
+                    + prettyPrinted + System.lineSeparator()
+                    + "```";
+        } else if (prettyPrinted.startsWith("\"") && prettyPrinted.endsWith("\"")) {
+            // for pure strings, replace the quotes with backticks
+            return "`" + prettyPrinted.substring(1, prettyPrinted.length() - 1) + "`";
+        } else {
+            return "`" + prettyPrinted + "`";
+        }
     }
 
     @Deprecated

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/DefaultNodeWriterTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/DefaultNodeWriterTest.java
@@ -42,21 +42,21 @@ public class DefaultNodeWriterTest {
                 {new NullNode(SourceLocation.none()), "null"},
                 {new ArrayNode(
                         Arrays.asList(Node.from(1), Node.from(2)),
-                        SourceLocation.none()), String.format("[\n    1,\n    2\n]")},
+                        SourceLocation.none()), String.format("[%n    1,%n    2%n]")},
                 {Node.objectNode()
                          .withMember("foo", Node.from("foo"))
                          .withMember("baz", Node.from(1))
                          .withMember("bar", Node.objectNode()
                              .withMember("qux", Node.arrayNode()
                                      .withValue(Node.from("ipsum")))),
-                 String.format("{\n"
-                               + "    \"foo\": \"foo\",\n"
-                               + "    \"baz\": 1,\n"
-                               + "    \"bar\": {\n"
-                               + "        \"qux\": [\n"
-                               + "            \"ipsum\"\n"
-                               + "        ]\n"
-                               + "    }\n"
+                 String.format("{%n"
+                               + "    \"foo\": \"foo\",%n"
+                               + "    \"baz\": 1,%n"
+                               + "    \"bar\": {%n"
+                               + "        \"qux\": [%n"
+                               + "            \"ipsum\"%n"
+                               + "        ]%n"
+                               + "    }%n"
                                + "}")
                 },
                 {Node.objectNode()
@@ -66,17 +66,17 @@ public class DefaultNodeWriterTest {
                          .withMember("bam", Node.arrayNode()
                                  .withValue(Node.objectNode()
                                          .withMember("abc", Node.from(123)))),
-                        String.format("{\n"
-                                      + "    \"foo\": {\n"
-                                      + "        \"bar\": [\n"
-                                      + "            \"baz\"\n"
-                                      + "        ]\n"
-                                      + "    },\n"
-                                      + "    \"bam\": [\n"
-                                      + "        {\n"
-                                      + "            \"abc\": 123\n"
-                                      + "        }\n"
-                                      + "    ]\n"
+                        String.format("{%n"
+                                      + "    \"foo\": {%n"
+                                      + "        \"bar\": [%n"
+                                      + "            \"baz\"%n"
+                                      + "        ]%n"
+                                      + "    },%n"
+                                      + "    \"bam\": [%n"
+                                      + "        {%n"
+                                      + "            \"abc\": 123%n"
+                                      + "        }%n"
+                                      + "    ]%n"
                                       + "}")
                 }
         });

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeSerializerTest.java
@@ -11,18 +11,18 @@ public class NodeSerializerTest {
         Node node = Node.parse("{\"foo\": \"bar\", \"baz\": true, \"bam\": false, \"boo\": 10}");
 
         assertThat(Node.printJson(node), equalTo("{\"foo\":\"bar\",\"baz\":true,\"bam\":false,\"boo\":10}"));
-        assertThat(Node.prettyPrintJson(node), equalTo("{\n"
-                                                       + "    \"foo\": \"bar\",\n"
-                                                       + "    \"baz\": true,\n"
-                                                       + "    \"bam\": false,\n"
-                                                       + "    \"boo\": 10\n"
-                                                       + "}"));
-        assertThat(Node.prettyPrintJson(node, "\t"), equalTo("{\n"
-                                                             + "\t\"foo\": \"bar\",\n"
-                                                             + "\t\"baz\": true,\n"
-                                                             + "\t\"bam\": false,\n"
-                                                             + "\t\"boo\": 10\n"
-                                                             + "}"));
+        assertThat(Node.prettyPrintJson(node), equalTo(String.format("{%n"
+                                                       + "    \"foo\": \"bar\",%n"
+                                                       + "    \"baz\": true,%n"
+                                                       + "    \"bam\": false,%n"
+                                                       + "    \"boo\": 10%n"
+                                                       + "}")));
+        assertThat(Node.prettyPrintJson(node, "\t"), equalTo(String.format("{%n"
+                                                             + "\t\"foo\": \"bar\",%n"
+                                                             + "\t\"baz\": true,%n"
+                                                             + "\t\"bam\": false,%n"
+                                                             + "\t\"boo\": 10%n"
+                                                             + "}")));
     }
 
     @Test
@@ -45,24 +45,24 @@ public class NodeSerializerTest {
         assertThat(Node.printJson(node), equalTo(
                 "[{\"foo\":\"\uD83D\uDCA9\",\"baz\":true,\"bam\":false,"
                 + "\"boo\":10},10,true,false,{},[],\"\",\" \",null,-1,-1.0]"));
-        assertThat(Node.prettyPrintJson(node), equalTo(
-                "[\n"
-                + "    {\n"
-                + "        \"foo\": \"\uD83D\uDCA9\",\n"
-                + "        \"baz\": true,\n"
-                + "        \"bam\": false,\n"
-                + "        \"boo\": 10\n"
-                + "    },\n"
-                + "    10,\n"
-                + "    true,\n"
-                + "    false,\n"
-                + "    {},\n" // optimized empty object
-                + "    [],\n" // optimized empty array
-                + "    \"\",\n"
-                + "    \" \",\n"
-                + "    null,\n"
-                + "    -1,\n"
-                + "    -1.0\n"
-                + "]"));
+        assertThat(Node.prettyPrintJson(node), equalTo(String.format(
+                "[%n"
+                + "    {%n"
+                + "        \"foo\": \"\uD83D\uDCA9\",%n"
+                + "        \"baz\": true,%n"
+                + "        \"bam\": false,%n"
+                + "        \"boo\": 10%n"
+                + "    },%n"
+                + "    10,%n"
+                + "    true,%n"
+                + "    false,%n"
+                + "    {},%n" // optimized empty object
+                + "    [],%n" // optimized empty array
+                + "    \"\",%n"
+                + "    \" \",%n"
+                + "    null,%n"
+                + "    -1,%n"
+                + "    -1.0%n"
+                + "]")));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeTest.java
@@ -178,7 +178,7 @@ public class NodeTest {
     @Test
     public void prettyPrintsJson() {
         assertThat(Node.prettyPrintJson(Node.parse("{\"foo\": true}")),
-                   equalTo(String.format("{\n    \"foo\": true\n}")));
+                   equalTo(String.format("{%n    \"foo\": true%n}")));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/ContextualValidationEventFormatterTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/ContextualValidationEventFormatterTest.java
@@ -31,17 +31,15 @@ public class ContextualValidationEventFormatterTest {
                 .build();
 
         String format = new ContextualValidationEventFormatter().format(event);
-        // Normalize line endings for Windows.
-        format = format.replace("\r\n", "\n");
 
         assertThat(format, startsWith("ERROR: example.smithy#Foo (foo)"));
-        assertThat(format, containsString("\n     @ "));
-        assertThat(format, endsWith(
-                "\n     |"
-                + "\n   3 | structure Foo {"
-                + "\n     | ^"
-                + "\n     = This is the message"
-                + "\n"));
+        assertThat(format, containsString(String.format("%n     @ ")));
+        assertThat(format, endsWith(String.format(
+                "%n     |"
+                + "%n   3 | structure Foo {"
+                + "%n     | ^"
+                + "%n     = This is the message"
+                + "%n")));
     }
 
     @Test
@@ -54,12 +52,11 @@ public class ContextualValidationEventFormatterTest {
                 .build();
 
         String format = new ContextualValidationEventFormatter().format(event);
-        // Normalize line endings for Windows.
-        format = format.replace("\r\n", "\n");
 
-        assertThat(format, equalTo(
+        assertThat(format, equalTo(String.format(
                 "ERROR: - (foo)"
-                + "\n     = This is the message"
-                + "\n"));
+                + "%n     = This is the message"
+                + "%n")
+        ));
     }
 }


### PR DESCRIPTION
*Description of changes:*
Adds backticks (or triple backticks) around trait values within diff event messages. This better supports markdown rendering of the messages.

Also changes pretty-printing to use platform-specific line separator through "%n"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
