### PR TITLE
Add support for authenticating HTTP proxy

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/model/MavenRepository.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/model/MavenRepository.java
@@ -27,11 +27,15 @@ public final class MavenRepository implements ToSmithyBuilder<MavenRepository> {
     private final String url;
     private final String httpCredentials;
     private final String id;
+    private final String proxyHost;
+    private final String proxyCredentials;
 
     public MavenRepository(Builder builder) {
         this.url = SmithyBuilder.requiredState("url", builder.url);
         this.httpCredentials = builder.httpCredentials;
         this.id = builder.id;
+        this.proxyHost = builder.proxyHost;
+        this.proxyCredentials = builder.proxyCredentials;
     }
 
     public static Builder builder() {
@@ -41,10 +45,13 @@ public final class MavenRepository implements ToSmithyBuilder<MavenRepository> {
     public static MavenRepository fromNode(Node node) {
         Builder builder = builder();
         node.expectObjectNode()
-                .warnIfAdditionalProperties(Arrays.asList("url", "httpCredentials"))
+                .warnIfAdditionalProperties(
+                        Arrays.asList("url", "httpCredentials", "id", "proxyHost", "proxyCredentials"))
                 .expectStringMember("url", builder::url)
                 .getStringMember("httpCredentials", builder::httpCredentials)
-                .getStringMember("id", builder::id);
+                .getStringMember("id", builder::id)
+                .getStringMember("proxyHost", builder::proxyHost)
+                .getStringMember("proxyCredentials", builder::proxyCredentials);
         return builder.build();
     }
 
@@ -58,6 +65,14 @@ public final class MavenRepository implements ToSmithyBuilder<MavenRepository> {
 
     public Optional<String> getHttpCredentials() {
         return Optional.ofNullable(httpCredentials);
+    }
+
+    public Optional<String> getProxyCredentials() {
+        return Optional.ofNullable(proxyCredentials);
+    }
+
+    public Optional<String> getProxyHost() {
+        return Optional.ofNullable(proxyHost);
     }
 
     @Override
@@ -88,6 +103,8 @@ public final class MavenRepository implements ToSmithyBuilder<MavenRepository> {
         private String url;
         private String httpCredentials;
         private String id;
+        private String proxyHost;
+        private String proxyCredentials;
 
         private Builder() {}
 
@@ -106,15 +123,34 @@ public final class MavenRepository implements ToSmithyBuilder<MavenRepository> {
             return this;
         }
 
+        public Builder proxyHost(String proxyHost) {
+            this.proxyHost = proxyHost;
+            validateColonSeparatedValue(proxyHost,
+                    "Invalid proxyHost: expected in the format of host:port");
+            return this;
+        }
+
+        public Builder proxyCredentials(String proxyCredentials) {
+            this.proxyCredentials = proxyCredentials;
+            validateColonSeparatedValue(proxyCredentials,
+                    "Invalid proxyCredentials: expected in the format of user:pass");
+            return this;
+        }
+
         public Builder httpCredentials(String httpCredentials) {
             this.httpCredentials = httpCredentials;
-            if (httpCredentials != null) {
-                int position = httpCredentials.indexOf(':');
-                if (position < 1 || position == httpCredentials.length() - 1) {
-                    throw new IllegalArgumentException("Invalid httpCredentials: expected in the format of user:pass");
+            validateColonSeparatedValue(httpCredentials,
+                    "Invalid httpCredentials: expected in the format of user:pass");
+            return this;
+        }
+
+        private void validateColonSeparatedValue(String value, String errorMessage) {
+            if (value != null) {
+                int position = value.indexOf(':');
+                if (position < 1 || position == value.length() - 1) {
+                    throw new IllegalArgumentException(errorMessage);
                 }
             }
-            return this;
         }
     }
 }

--- a/smithy-cli/src/it/java/software/amazon/smithy/cli/MavenResolverTest.java
+++ b/smithy-cli/src/it/java/software/amazon/smithy/cli/MavenResolverTest.java
@@ -6,14 +6,19 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.integration.ClientAndProxy.startClientAndProxy;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.mockserver.integration.ClientAndProxy;
 import org.mockserver.integration.ClientAndServer;
+import org.mockserver.mockserver.MockServer;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import software.amazon.smithy.model.node.Node;
@@ -103,6 +108,87 @@ public class MavenResolverTest {
         } finally {
             if (mockServer!=null) {
                 mockServer.stop();
+            }
+        }
+    }
+
+    @Test
+    public void usesProxyConfiguration() {
+        ClientAndServer mockServer = null;
+        ClientAndProxy proxyServer = null;
+        try {
+            mockServer = startClientAndServer(1234);
+            proxyServer = startClientAndProxy(2323);
+
+            HttpRequest request = HttpRequest.request()
+                    .withMethod("GET")
+                    .withPath("/maven/not/there/software/amazon/smithy/smithy-aws-iam-traits/.*\\.jar");
+
+            mockServer.when(request).respond(
+                    HttpResponse
+                            .response()
+                            .withStatusCode(200)
+                            .withBody("FAKE JAR CONTENT")
+            );
+
+            IntegUtils.runWithEmptyCache("maven-proxy", ListUtils.of("validate", "--debug"),
+                    Collections.emptyMap(), result -> {
+                        assertThat(result.getExitCode(), equalTo(0));
+                        assertThat(result.getOutput(), containsString("Resolving Maven dependencies for Smithy CLI"));
+                        assertThat(result.getOutput(),
+                                containsString("Opening connection {}->http://localhost:2323->http://localhost:1234"));
+                        assertThat(result.getOutput(), containsString("Connecting to localhost/127.0.0.1:2323"));
+                    });
+            // Check that expected request was forwarded by the proxy
+            proxyServer.verify(request);
+
+        } finally {
+            if (mockServer != null) {
+                mockServer.stop();
+            }
+            if (proxyServer != null) {
+                proxyServer.stop();
+            }
+        }
+    }
+
+    @Test
+    public void usesProxyConfigurationFromEnv() {
+        ClientAndServer mockServer = null;
+        ClientAndProxy proxyServer = null;
+        try {
+            mockServer = startClientAndServer(1234);
+            proxyServer = startClientAndProxy(2323);
+
+            HttpRequest request = HttpRequest.request()
+                    .withMethod("GET")
+                    .withPath("/maven/not/there/software/amazon/smithy/smithy-aws-iam-traits/.*\\.jar");
+
+            mockServer.when(request).respond(
+                    HttpResponse
+                            .response()
+                            .withStatusCode(200)
+                            .withBody("FAKE JAR CONTENT")
+            );
+
+            Map<String, String> envMap = MapUtils.of(EnvironmentVariable.PROXY_HOST.toString(), "localhost:2323");
+            IntegUtils.runWithEmptyCache("maven-proxy-env", ListUtils.of("validate", "--debug"),
+                    envMap, result -> {
+                        assertThat(result.getExitCode(), equalTo(0));
+                        assertThat(result.getOutput(), containsString("Resolving Maven dependencies for Smithy CLI"));
+                        assertThat(result.getOutput(),
+                                containsString("Opening connection {}->http://localhost:2323->http://localhost:1234"));
+                        assertThat(result.getOutput(), containsString("Connecting to localhost/127.0.0.1:2323"));
+                    });
+            // Check that expected request was forwarded by the proxy
+            proxyServer.verify(request);
+
+        } finally {
+            if (mockServer != null) {
+                mockServer.stop();
+            }
+            if (proxyServer != null) {
+                proxyServer.stop();
             }
         }
     }

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/maven-proxy-env/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/maven-proxy-env/smithy-build.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0",
+    "maven": {
+        "repositories": [
+            {
+                // Use HTTP instead of HTTPS because we're running a mock server during tests
+                "url": "http://localhost:1234/maven/not/there"
+            }
+        ],
+        "dependencies": [
+            // Normally, this could refer to SMITHY_VERSION, but that doesn't work for pre-release builds.
+            "software.amazon.smithy:smithy-aws-iam-traits:1.26.0"
+        ]
+    }
+}

--- a/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/maven-proxy/smithy-build.json
+++ b/smithy-cli/src/it/resources/software/amazon/smithy/cli/projects/maven-proxy/smithy-build.json
@@ -1,0 +1,17 @@
+{
+    "version": "1.0",
+    "maven": {
+        "repositories": [
+            {
+                // Use HTTP instead of HTTPS because we're running a mock server during tests
+                "url": "http://localhost:1234/maven/not/there",
+                "proxyHost": "localhost:2323",
+                "proxyCredentials": "user:pass"
+            }
+        ],
+        "dependencies": [
+            // Normally, this could refer to SMITHY_VERSION, but that doesn't work for pre-release builds.
+            "software.amazon.smithy:smithy-aws-iam-traits:1.26.0"
+        ]
+    }
+}

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/EnvironmentVariable.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/EnvironmentVariable.java
@@ -89,7 +89,38 @@ public enum EnvironmentVariable {
      *     <li>If not set and the operating system is detected as Windows, colors are disabled.</li>
      * </ul>
      */
-    TERM;
+    TERM,
+
+    /**
+     * Used to determine a proxy host to use for Maven dependency resolution.
+     *
+     * <p>Set both the host and port information as a ":" separated string.
+     * <pre>
+     * {@code export PROXY=host:port}
+     * </pre>
+     * <strong>NOTE:</strong> this setting will be used for all repositories
+     * defined in the smithy-build maven configuration unless a repo-specific
+     * configuration is provided.
+     *
+     */
+    PROXY_HOST,
+
+    /**
+     * Used to determine a proxy credentials to use for Maven dependency resolution through
+     * a proxy.
+     *
+     * <p>Use this setting in conjunction with the {@link #PROXY_HOST} variable to configure
+     * proxy settings for dependency resolution.
+     *
+     * <p>Set both the username and password information as a ":" separated string.
+     * <pre>
+     * {@code export PROXY_CRED=user:pass}
+     * </pre>
+     * <strong>NOTE:</strong> this setting will be used for all repositories
+     * defined in the smithy-build maven configuration unless a repo-specific
+     * configuration is provided.
+     */
+    PROXY_CRED;
 
     private static final Logger LOGGER = Logger.getLogger(EnvironmentVariable.class.getName());
 


### PR DESCRIPTION
resolves #2029 

*Description of changes:*
Adds support for a proxy configuration for maven repositories. 

This proxy configuration can be added one of 2 ways: 
1. Via environment variables: `PROXY_HOST` and `PROXY_CRED` . These will set a common proxy configuration for all repositories
2. Via a specific configuration on the Maven repository definition. For example, 
``` json
    "maven": {
        "repositories": [
            {
                "url": "http://localhost:1234/maven/not/there",
                "proxyHost": "localhost:2323",
                "proxyCredentials": "user:pass"
            }
        ],
        "dependencies": [
            // Normally, this could refer to SMITHY_VERSION, but that doesn't work for pre-release builds.
            "software.amazon.smithy:smithy-aws-iam-traits:1.26.0"
        ]
    }
```
The per-repo configuration of the proxy will override any settings set by the environment variables.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
