### PR TITLE
Fix tree node start and end locations

### DIFF
--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/SortUseStatements.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/SortUseStatements.java
@@ -172,22 +172,16 @@ final class SortUseStatements implements Function<TokenTree, TokenTree> {
 
             if (lineComment != null) {
                 br.appendChild(sp);
-                // Modify the position of the comment so that the formatter knows it's a trailing line comment.
-                CapturedToken updatedLineComment = lineComment.getTree()
-                        .tokens()
-                        .findFirst()
-                        .get()
-                        .toBuilder()
-                        // Set the line and column to zero so the formatter knows it's on the same line as the
-                        // statement, making it an end-of-line comment.
-                        .startLine(0)
-                        .endLine(0)
-                        .build();
-                TokenTree commentTree = TokenTree.of(TreeType.COMMENT);
-                commentTree.appendChild(TokenTree.of(updatedLineComment));
-                br.appendChild(commentTree);
+                br.appendChild(lineComment.getTree());
             } else {
-                br.appendChild(TokenTree.of(CapturedToken.builder().token(IdlToken.NEWLINE).lexeme("\n").build()));
+                br.appendChild(TokenTree.of(CapturedToken.builder()
+                        .token(IdlToken.NEWLINE)
+                        .lexeme("\n")
+                        // Set the start line to be the start line of the use statement
+                        // so the formatter  knows it's a line comment.
+                        .startLine(id.getStartLine())
+                        .endLine(id.getStartLine() + 1)
+                        .build()));
             }
 
             TokenTree ws = TokenTree.of(TreeType.WS);

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TokenTreeLeaf.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TokenTreeLeaf.java
@@ -79,7 +79,9 @@ final class TokenTreeLeaf implements TokenTree {
         if (token.getErrorMessage() != null) {
             return token.getIdlToken() + "(" + token.getErrorMessage() + ')';
         } else {
-            return token.getIdlToken().getDebug(token.getLexeme());
+            return token.getIdlToken().getDebug(token.getLexeme())
+                    + " (" + getStartLine() + ", " + getStartColumn() + ")"
+                    + " - (" + getEndLine() + ", " + getEndColumn() + ")";
         }
     }
 

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TokenTreeNode.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TokenTreeNode.java
@@ -109,22 +109,50 @@ class TokenTreeNode implements TokenTree {
 
     @Override
     public final int getStartLine() {
-        return getChildren().isEmpty() ? 0 : getChildren().get(0).getStartLine();
+        // Start line of 0 indicates an empty child, so ignore it.
+        for (TokenTree child : getChildren()) {
+            int startLine = child.getStartLine();
+            if (startLine > 0) {
+                return startLine;
+            }
+        }
+        return 0;
     }
 
     @Override
     public final int getStartColumn() {
-        return getChildren().isEmpty() ? 0 : getChildren().get(0).getStartColumn();
+        // Start column of 0 indicates an empty child, so ignore it.
+        for (TokenTree child : getChildren()) {
+            int startColumn = child.getStartColumn();
+            if (startColumn > 0) {
+                return startColumn;
+            }
+        }
+        return 0;
     }
 
     @Override
     public final int getEndLine() {
-        return children.isEmpty() ? getStartLine() : children.get(children.size() - 1).getEndLine();
+        // End line of 0 indicates an empty child, so ignore it.
+        for (int i = children.size() - 1; i >= 0; i--) {
+            int endLine = children.get(i).getEndLine();
+            if (endLine > 0) {
+                return endLine;
+            }
+        }
+        return 0;
     }
 
     @Override
     public final int getEndColumn() {
-        return children.isEmpty() ? getStartColumn() : children.get(children.size() - 1).getEndColumn();
+        // End column of 0 indicates an empty child, so ignore it.
+        for (int i = children.size() - 1; i >= 0; i--) {
+            int endColumn = children.get(i).getEndColumn();
+            if (endColumn > 0) {
+                return endColumn;
+            }
+        }
+        return 0;
     }
 
     @Override

--- a/smithy-syntax/src/test/java/software/amazon/smithy/syntax/TokenTreeTest.java
+++ b/smithy-syntax/src/test/java/software/amazon/smithy/syntax/TokenTreeTest.java
@@ -85,4 +85,54 @@ public class TokenTreeTest {
         assertThat(tree.replaceChild(child1, child2), is(false));
         assertThat(tree.zipper().getFirstChild(TreeType.COMMA).getTree(), is(child2));
     }
+
+    @Test
+    public void emptyTreeLocationsDontBubbleUpToParent() {
+        // If a tree's first/last child is empty, meaning it has a location of
+        // (0, 0) - (0, 0), that should not be considered the starting/ending
+        // location of the tree.
+        IdlTokenizer shapeStatementTokenizer = IdlTokenizer.create("structure Foo {}");
+        TokenTree shapeStatement = TokenTree.of(shapeStatementTokenizer, TreeType.SHAPE_STATEMENT);
+        assertThat(shapeStatement.getStartLine(), equalTo(1));
+        assertThat(shapeStatement.getStartColumn(), equalTo(1));
+        assertThat(shapeStatement.getEndLine(), equalTo(1));
+        assertThat(shapeStatement.getEndColumn(), equalTo(17));
+
+        // There are no traits, so this will be an empty tree with location
+        // (0, 0) - (0, 0).
+        TokenTree traitStatements = shapeStatement.getChildren().get(0);
+        assertThat(traitStatements.getStartLine(), equalTo(0));
+        assertThat(traitStatements.getStartColumn(), equalTo(0));
+        assertThat(traitStatements.getEndLine(), equalTo(0));
+        assertThat(traitStatements.getEndColumn(), equalTo(0));
+
+        // The SHAPE_STATEMENT location should come from the SHAPE child.
+        TokenTree shape = shapeStatement.getChildren().get(1);
+        assertThat(shape.getStartLine(), equalTo(shapeStatement.getStartLine()));
+        assertThat(shape.getStartColumn(), equalTo(shapeStatement.getStartColumn()));
+        assertThat(shape.getEndLine(), equalTo(shapeStatement.getEndLine()));
+        assertThat(shape.getEndColumn(), equalTo(shapeStatement.getEndColumn()));
+
+        IdlTokenizer shapeSectionTokenizer = IdlTokenizer.create("namespace com.foo\n");
+        TokenTree shapeSection = TokenTree.of(shapeSectionTokenizer, TreeType.SHAPE_SECTION);
+        assertThat(shapeSection.getStartLine(), equalTo(1));
+        assertThat(shapeSection.getStartColumn(), equalTo(1));
+        assertThat(shapeSection.getEndLine(), equalTo(2));
+        assertThat(shapeSection.getEndColumn(), equalTo(1));
+
+        // There are shape statements, so this will be an empty tree with location
+        // (0, 0) - (0, 0).
+        TokenTree shapeStatements = shapeSection.getChildren().get(2);
+        assertThat(shapeStatements.getStartLine(), equalTo(0));
+        assertThat(shapeStatements.getStartColumn(), equalTo(0));
+        assertThat(shapeStatements.getEndLine(), equalTo(0));
+        assertThat(shapeStatements.getEndColumn(), equalTo(0));
+
+        // The SHAPE_SECTION location should come from the NAMESPACE_STATEMENT child.
+        TokenTree namespaceStatement = shapeSection.getChildren().get(0);
+        assertThat(namespaceStatement.getStartLine(), equalTo(shapeSection.getStartLine()));
+        assertThat(namespaceStatement.getStartColumn(), equalTo(shapeSection.getStartColumn()));
+        assertThat(namespaceStatement.getEndLine(), equalTo(shapeSection.getEndLine()));
+        assertThat(namespaceStatement.getEndColumn(), equalTo(shapeSection.getEndColumn()));
+    }
 }

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/br-comments-with-multiple-use.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/br-comments-with-multiple-use.formatted.smithy
@@ -1,0 +1,12 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use smithy.api#length // def
+use smithy.api#sensitive // abc
+
+// Comment
+/// A
+@sensitive
+@length(min: 1)
+string A

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/br-comments-with-multiple-use.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/br-comments-with-multiple-use.smithy
@@ -1,0 +1,12 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use smithy.api#sensitive // abc
+use smithy.api#length // def
+
+// Comment
+/// A
+@sensitive
+@length(min: 1)
+string A


### PR DESCRIPTION
Some tree types are guaranteed to have certain children, even if those children are empty. For example, SHAPE_STATEMENT always has a TRAIT_STATEMENT as its first child. Since trees with children have their start/end line and column locations computed from the respective locations of their first and last child, trees with 0 children ("empty" trees) will have a location of (0,0)-(0,0). If an empty child is the first or last child of its parent, the 0 location will bubble up to that parent.

This commit changes the way start/end line and column locations are computed for trees with children, such that empty children are ignored. This required a change to use statement sorting, which relied on the 0 location bubbling up to the parent to indicate to the formatter whether the use statement has a line comment.

Additional tests were added for the formatter and tree location computation. TokenTreeLeaf toString was also updated to include tree location, useful for debugging purposes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
