### PR TITLE
Upgrade sphinx for docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=4.2.0,<4.3.0
+sphinx>=5.0.0
 pygments==2.15.0
 furo==2022.6.21
 
@@ -7,6 +7,6 @@ sphinx-inline-tabs==2022.1.2b11
 Sphinx-Substitution-Extensions==2022.2.16
 
 # Use by old docs.
-sphinx-tabs==3.2.0
+sphinx-tabs>=3.4.4
 
 sphinx_copybutton==0.5.0

--- a/docs/setup.py
+++ b/docs/setup.py
@@ -3,13 +3,13 @@
 from setuptools import setup, find_packages
 
 requires = [
-    "sphinx==4.2.0",
+    "sphinx>=5.0.0",
     "pygments==2.15.0",
     "sphinx_copybutton==0.5.0",
     # Used by new docs.
     "sphinx-inline-tabs==2022.1.2b11",
     # Used by old docs.
-    "sphinx-tabs==3.2.0"
+    "sphinx-tabs>=3.4.4"
 ]
 
 # Register the custom Smithy loader with Pygments.


### PR DESCRIPTION
*Description of changes:*
- Doc builds are failing in CI due to `The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.`
- A few other sphinx plugins are also updating to require >=5, so this change updates our version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
