### PR TITLE
Enable custom inline suffixes in IDL serializer

### DIFF
--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializerTest.java
@@ -259,4 +259,22 @@ public class SmithyIdlModelSerializerTest {
         String serializedString = serialized.entrySet().iterator().next().getValue();
         Assertions.assertEquals(expectedOutput, serializedString);
     }
+
+    @Test
+    public void handlesCustomInlineSuffixes() {
+        URL resource = getClass().getResource("idl-serialization/custom-inline-io.smithy");
+        Model model = Model.assembler().addImport(resource).assemble().unwrap();
+
+        Assertions.assertTrue(model.getShape(ShapeId.from("com.example#InlineOperationRequest")).isPresent());
+        Assertions.assertTrue(model.getShape(ShapeId.from("com.example#InlineOperationResponse")).isPresent());
+
+        Map<Path, String> reserialized = SmithyIdlModelSerializer.builder()
+                .inlineInputSuffix("Request")
+                .inlineOutputSuffix("Response")
+                .build()
+                .serialize(model);
+        String modelResult = reserialized.values().iterator().next().replace("\r\n", "\n");
+
+        assertThat(modelResult, equalTo(IoUtils.readUtf8Url(resource).replace("\r\n", "\n")));
+    }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/custom-inline-io.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/custom-inline-io.smithy
@@ -1,0 +1,16 @@
+$version: "2.0"
+$operationInputSuffix: "Request"
+$operationOutputSuffix: "Response"
+
+namespace com.example
+
+service InlineService {
+    operations: [
+        InlineOperation
+    ]
+}
+
+operation InlineOperation {
+    input := {}
+    output := {}
+}


### PR DESCRIPTION
This updates the IDL serializer to allow for customizing the inline input / output suffixes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
