### PR TITLE
Infer default inline io suffixes

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/default.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/default.smithy
@@ -1,0 +1,8 @@
+$version: "2.0"
+
+namespace com.example
+
+operation UsesDefaults {
+    input := {}
+    output := {}
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/main.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/main.smithy
@@ -1,0 +1,14 @@
+$version: "2.0"
+
+namespace com.example
+
+service InlineService {
+    operations: [
+        MixedWithCustomA
+        MixedWithCustomB
+        MixedWithDefault
+        SharedCustomA
+        SharedCustomB
+        UsesDefaults
+    ]
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/mixed.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/mixed.smithy
@@ -1,0 +1,30 @@
+$version: "2.0"
+
+namespace com.example
+
+operation MixedWithCustomA {
+    input: MixedWithCustomARequest
+    output: MixedWithCustomAResponse
+}
+
+operation MixedWithCustomB {
+    input: MixedWithCustomBGiven
+    output: MixedWithCustomBTaken
+}
+
+operation MixedWithDefault {
+    input := {}
+    output := {}
+}
+
+@input
+structure MixedWithCustomARequest {}
+
+@output
+structure MixedWithCustomAResponse {}
+
+@input
+structure MixedWithCustomBGiven {}
+
+@output
+structure MixedWithCustomBTaken {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/shared.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/shared.smithy
@@ -1,0 +1,15 @@
+$version: "2.0"
+$operationInputSuffix: "Request"
+$operationOutputSuffix: "Response"
+
+namespace com.example
+
+operation SharedCustomA {
+    input := {}
+    output := {}
+}
+
+operation SharedCustomB {
+    input := {}
+    output := {}
+}


### PR DESCRIPTION
This updates the IDL serializer to be able to optionally determine if the operations in a given file all have inputs / outputs that share suffixes, and then use that to enable inlining operation IO during serialization.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
