### PR TITLE
Add JSON protocol tests for document-valued maps

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/documents.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/documents.smithy
@@ -327,13 +327,13 @@ apply DocumentTypeAsPayload @httpResponseTests([
 
 /// This example serializes documents as the value of maps.
 @idempotent
-@http(uri: "/DocumentTypeAsMapKey", method: "PUT")
-operation DocumentTypeAsMapKey {
-    input: DocumentTypeAsMapKeyInputOutput,
-    output: DocumentTypeAsMapKeyInputOutput,
+@http(uri: "/DocumentTypeAsMapValue", method: "PUT")
+operation DocumentTypeAsMapValue {
+    input: DocumentTypeAsMapValueInputOutput,
+    output: DocumentTypeAsMapValueInputOutput,
 }
 
-structure DocumentTypeAsMapKeyInputOutput {
+structure DocumentTypeAsMapValueInputOutput {
     docValuedMap: DocumentValuedMap,
 }
 
@@ -342,13 +342,13 @@ map DocumentValuedMap {
     value: Document,
 }
 
-apply DocumentTypeAsMapKey @httpRequestTests([
+apply DocumentTypeAsMapValue @httpRequestTests([
     {
-        id: "DocumentTypeAsMapKeyInput",
+        id: "DocumentTypeAsMapValueInput",
         documentation: "Serializes a map that uses documents as the value.",
         protocol: restJson1,
         method: "PUT",
-        uri: "/DocumentTypeAsMapKey",
+        uri: "/DocumentTypeAsMapValue",
         body: """
             {
                 "docValuedMap": {
@@ -369,10 +369,10 @@ apply DocumentTypeAsMapKey @httpRequestTests([
     },
 ])
 
-apply DocumentTypeAsMapKey @httpResponseTests([
+apply DocumentTypeAsMapValue @httpResponseTests([
     {
-        id: "DocumentTypeAsMapKeyOutput",
-        documentation: "Deserializes a map that uses documents as the value.",
+        id: "DocumentTypeAsMapValueOutput",
+        documentation: "Serializes a map that uses documents as the value.",
         protocol: restJson1,
         code: 200,
         body: """

--- a/smithy-aws-protocol-tests/model/restJson1/documents.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/documents.smithy
@@ -324,3 +324,73 @@ apply DocumentTypeAsPayload @httpResponseTests([
         }
     }
 ])
+
+/// This example serializes documents as the value of maps.
+@idempotent
+@http(uri: "/DocumentTypeAsMapKey", method: "PUT")
+operation DocumentTypeAsMapKey {
+    input: DocumentTypeAsMapKeyInputOutput,
+    output: DocumentTypeAsMapKeyInputOutput,
+}
+
+structure DocumentTypeAsMapKeyInputOutput {
+    docValuedMap: DocumentValuedMap,
+}
+
+map DocumentValuedMap {
+    key: String,
+    value: Document,
+}
+
+apply DocumentTypeAsMapKey @httpRequestTests([
+    {
+        id: "DocumentTypeAsMapKeyInput",
+        documentation: "Serializes a map that uses documents as the value.",
+        protocol: restJson1,
+        method: "PUT",
+        uri: "/DocumentTypeAsMapKey",
+        body: """
+            {
+                "docValuedMap": {
+                    "foo": { "f": 1, "o": 2 },
+                    "bar": [ "b", "a", "r" ],
+                    "baz": "BAZ"
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {"Content-Type": "application/json"},
+        params: {
+            docValuedMap: {
+                "foo": { "f": 1, "o": 2 },
+                "bar": [ "b", "a", "r" ],
+                "baz": "BAZ",
+            },
+        },
+    },
+])
+
+apply DocumentTypeAsMapKey @httpResponseTests([
+    {
+        id: "DocumentTypeAsMapKeyOutput",
+        documentation: "Deserializes a map that uses documents as the value.",
+        protocol: restJson1,
+        code: 200,
+        body: """
+            {
+                "docValuedMap": {
+                    "foo": { "f": 1, "o": 2 },
+                    "bar": [ "b", "a", "r" ],
+                    "baz": "BAZ"
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {"Content-Type": "application/json"},
+        params: {
+            docValuedMap: {
+                "foo": { "f": 1, "o": 2 },
+                "bar": [ "b", "a", "r" ],
+                "baz": "BAZ",
+            },
+        },
+    },
+])

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -87,7 +87,7 @@ service RestJson {
         // Documents
         DocumentType,
         DocumentTypeAsPayload,
-        DocumentTypeAsMapKey,
+        DocumentTypeAsMapValue,
 
         // Unions
         JsonUnions,

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -87,6 +87,7 @@ service RestJson {
         // Documents
         DocumentType,
         DocumentTypeAsPayload,
+        DocumentTypeAsMapKey,
 
         // Unions
         JsonUnions,


### PR DESCRIPTION
*Issue #, if available:*

(none)

*Description of changes:*

This change adds tests for serializing/deserializing maps which use the document shape as a value. The AWS SDK for Kotlin previously did not handle these correctly, leading to a customer contact.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
