### PR TITLE
Correct typo in @pattern validation example

### DIFF
--- a/docs/source-2.0/guides/model-validation-examples.rst
+++ b/docs/source-2.0/guides/model-validation-examples.rst
@@ -314,7 +314,7 @@ linters to have clear, actionable error messages.
 Require strings to have a ``@pattern`` constraint
 =================================================
 
-This example shows how to require all integers used in an operation input to
+This example shows how to require all strings used in an operation input to
 have a ``@pattern`` constraint trait.
 
 .. code-block:: smithy


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* There is a typo in one of the examples for model validation. In the text, it should say `strings` instead of `integers` since the example refers to requiring the use of the `@pattern` trait for all strings.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
