### PR TITLE
Fix the `RestJsonZeroAndFalseQueryValues` protocol test for servers

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -232,6 +232,10 @@ apply AllQueryStringTypes @httpRequestTests([
         params: {
             queryInteger: 0
             queryBoolean: false
+            queryParamsMapOfStringList: {
+                queryInteger: ["0"]
+                queryBoolean: ["false"]
+            }
         }
     }
 ])


### PR DESCRIPTION
The new RestJsonZeroAndFalseQueryValues test that was released in Smithy 1.44 has incorrect parameters for servers. Other protocol tests that use `@httpQueryParams` explicitly set a `params` value for the member(s) with that trait, but this [new test is not](https://github.com/smithy-lang/smithy/blob/1.44.0/smithy-aws-protocol-tests/model/restJson1/http-query.smithy#L221-L236). This causes the smithy-rs server protocol tests to fail upon upgrading despite code generating the correct behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
