### PR TITLE
Turn on closing and releasing of repository with jreleaser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -326,8 +326,8 @@ if (useJreleaser) {
                         active = "ALWAYS"
                         url = "https://aws.oss.sonatype.org/service/local"
                         snapshotUrl = "https://aws.oss.sonatype.org/content/repositories/snapshots"
-                        closeRepository = false
-                        releaseRepository = false
+                        closeRepository = true
+                        releaseRepository = true
                         stagingRepository(stagingDirectory.get().toString())
                     }
                 }


### PR DESCRIPTION
#### Background
* Updates the gradle build to enable the use of Jreleaser for closing and releasing the repository

#### Testing
* The past 2 releases have used jreleaser for staging with nexus. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
