### PR TITLE
Add gradle plugin migration guide

### DIFF
--- a/docs/source-2.0/guides/gradle-plugin/gradle-migration-guide.rst
+++ b/docs/source-2.0/guides/gradle-plugin/gradle-migration-guide.rst
@@ -1,0 +1,186 @@
+.. _gradle_migration_guide:
+
+==========================================
+Migrating to Gradle plugin version 0.10.0+
+==========================================
+
+This guide describes how to migrate your Gradle build files
+to use the `Smithy Gradle plugins`_ v0.10.0+ without breaking
+your existing Gradle projects.
+
+.. warning::
+    Versions 0.10.0+ of the Smithy Gradle plugins will automatically apply
+    the Smithy formatter to your Smithy source files. This can result in a
+    large number of formatting changes the first time you apply these plugins
+    to your project. For instructions on how to disable automatic formatting
+    see :ref:`Disabling the Smithy formatter <disable-smithy-formatter>`.
+
+Update plugin artifact
+======================
+
+The Smithy Gradle plugin has been broken up into separate capability
+(``smithy-jar``) and convention (``smithy-base``) plugins. The
+``smithy-jar`` plugin operates similarly to the previous ``smithy`` plugin,
+but no longer applies the ``java`` plugin automatically. To migrate to the
+new plugin, change the artifact id in the ``plugins`` block and apply the
+``java`` (or ``java-library``) plugin if it is not already applied to
+your project.
+
+.. tab:: Kotlin
+
+    .. code-block:: diff
+        :caption: build.gradle.kts
+
+        plugins {
+        -     id("software.amazon.smithy").version("0.7.0")
+        +     `java`
+        +     id("software.amazon.smithy.gradle.smithy-jar").version("0.10.0")
+        }
+
+.. tab:: Groovy
+
+    .. code-block:: diff
+        :caption: build.gradle
+
+        plugins {
+        -      id 'software.amazon.smithy' version '0.7.0'
+        +      id 'java'
+        +      id 'software.amazon.smithy.gradle.smithy-jar' version '0.10.0'
+        }
+
+Remove Buildscript Dependencies
+===============================
+
+Pre-0.10.0 versions of the Smithy Gradle plugins use the buildscript block
+for build-only dependencies such as Smithy build plugins. The 0.10.0+
+Gradle plugins create a new Gradle `Configuration`_ ``smithyBuild``
+for these build-only dependencies.
+
+.. tab:: Kotlin
+
+    .. code-block:: diff
+        :caption: build.gradle.kts
+
+        -buildscript {
+        -       repositories {
+        -           mavenLocal()
+        -           mavenCentral()
+        -       }
+        -
+        -       dependencies {
+        -           // Dependency repeated here and below because model discovery previously
+        -           // only ran on buildscript classpath for projections
+        -           classpath("software.amazon.smithy:smithy-aws-traits:__smithy_version__")
+        -           // Take a dependency on the internal model package. This
+        -           // dependency *must* be a buildscript only dependency to ensure
+        -           // that is does not appear in the generated JAR.
+        -           classpath("com.foo.baz:foo-internal-model:1.0.0")
+        -       }
+        -}
+
+        dependencies {
+            implementation("software.amazon.smithy:smithy-model:__smithy_version__")
+
+            implementation("software.amazon.smithy:smithy-aws-traits:__smithy_version__")
+        +   smithyBuild("com.foo.baz:foo-internal-model:1.0.0")
+        }
+
+.. tab:: Groovy
+
+    .. code-block:: diff
+        :caption: build.gradle
+
+        -buildscript {
+        -       repositories {
+        -           mavenLocal()
+        -           mavenCentral()
+        -       }
+        -
+        -       dependencies {
+        -           // Dependency repeated here and below because model discovery previously
+        -           // only ran on buildscript classpath for projections
+        -           classpath 'software.amazon.smithy:smithy-aws-traits:__smithy_version__'
+        -           // Take a dependency on the internal model package. This
+        -           // dependency *must* be a buildscript only dependency to ensure
+        -           // that is does not appear in the generated JAR.
+        -           classpath 'com.foo.baz:foo-internal-model:1.0.0'
+        -       }
+        -}
+
+        dependencies {
+            implementation 'software.amazon.smithy:smithy-model:__smithy_version__'
+
+            implementation 'software.amazon.smithy:smithy-aws-traits:__smithy_version__'
+        +   smithyBuild 'com.foo.baz:foo-internal-model:1.0.0'
+        }
+
+Chang ``projection`` property name
+===================================
+
+The property ``projection`` has also been updated to ``sourceProjection``.
+
+.. tab:: Kotlin
+
+        .. code-block:: diff
+                :caption: build.gradle.kts
+
+                -configure<software.amazon.smithy.gradle.SmithyExtension> {
+                +smithy {
+                -    projection = "foo"
+                +    sourceProjection.set("foo")
+                }
+
+.. tab:: Groovy
+
+        .. code-block:: diff
+                :caption: build.gradle
+
+                -configure<software.amazon.smithy.gradle.SmithyExtension> {
+                +smithy {
+                -    projection = "foo"
+                +    sourceProjection = "foo"
+                }
+
+Change ``smithyBuildJar`` task name
+===================================
+
+The ``smithyBuildJar`` task has been removed. Instead, the plugin now
+executes separate ``smithyBuild`` and ``smithyJarStaging`` tasks. If
+your project previously configured the ``smithyBuildJar``,
+configure the ``smithyBuild`` task instead. Tasks that depended on
+``smithyBuildJar`` should now depend on the ``jar`` task.
+
+.. tab:: Kotlin
+
+        .. code-block:: diff
+                :caption: build.gradle.kts
+
+                tasks {
+                -   smithyBuildJar {
+	            +   smithyBuild {
+                        smithyBuildConfigs = files("smithy-build.json", other)
+                    }
+                    // ..
+                }
+
+                -tasks["smithyBuildJar"].dependsOn("otherTask")
+                +tasks["jar"].dependsOn("otherTask")
+
+.. tab:: Groovy
+
+        .. code-block:: diff
+                :caption: build.gradle
+
+                tasks {
+                -   smithyBuildJar {
+	            +   smithyBuild {
+                        smithyBuildConfigs = files("smithy-build.json", other)
+                    }
+                    // ..
+                }
+
+                -tasks["smithyBuildJar"].dependsOn("otherTask")
+                +tasks["jar"].dependsOn("otherTask")
+
+.. _Smithy Gradle plugins: https://github.com/awslabs/smithy-gradle-plugin/
+.. _Configuration: https://docs.gradle.org/current/dsl/org.gradle.api.artifacts.Configuration.html

--- a/docs/source-2.0/guides/gradle-plugin/gradle-migration-guide.rst
+++ b/docs/source-2.0/guides/gradle-plugin/gradle-migration-guide.rst
@@ -114,7 +114,7 @@ for these build-only dependencies.
         +   smithyBuild 'com.foo.baz:foo-internal-model:1.0.0'
         }
 
-Chang ``projection`` property name
+Change ``projection`` property name
 ===================================
 
 The property ``projection`` has also been updated to ``sourceProjection``.
@@ -122,24 +122,24 @@ The property ``projection`` has also been updated to ``sourceProjection``.
 .. tab:: Kotlin
 
         .. code-block:: diff
-                :caption: build.gradle.kts
+            :caption: build.gradle.kts
 
-                -configure<software.amazon.smithy.gradle.SmithyExtension> {
-                +smithy {
-                -    projection = "foo"
-                +    sourceProjection.set("foo")
-                }
+            -configure<software.amazon.smithy.gradle.SmithyExtension> {
+            +smithy {
+            -    projection = "foo"
+            +    sourceProjection.set("foo")
+            }
 
 .. tab:: Groovy
 
         .. code-block:: diff
-                :caption: build.gradle
+            :caption: build.gradle
 
-                -configure<software.amazon.smithy.gradle.SmithyExtension> {
-                +smithy {
-                -    projection = "foo"
-                +    sourceProjection = "foo"
-                }
+            -configure<software.amazon.smithy.gradle.SmithyExtension> {
+            +smithy {
+            -    projection = "foo"
+            +    sourceProjection = "foo"
+            }
 
 Change ``smithyBuildJar`` task name
 ===================================
@@ -153,34 +153,34 @@ configure the ``smithyBuild`` task instead. Tasks that depended on
 .. tab:: Kotlin
 
         .. code-block:: diff
-                :caption: build.gradle.kts
+            :caption: build.gradle.kts
 
-                tasks {
-                -   smithyBuildJar {
-	            +   smithyBuild {
-                        smithyBuildConfigs = files("smithy-build.json", other)
-                    }
-                    // ..
+            tasks {
+            -   smithyBuildJar {
+            +   smithyBuild {
+                    smithyBuildConfigs.set(files("smithy-build.json", other))
                 }
+                // ..
+            }
 
-                -tasks["smithyBuildJar"].dependsOn("otherTask")
-                +tasks["jar"].dependsOn("otherTask")
+            -tasks["smithyBuildJar"].dependsOn("otherTask")
+            +tasks["jar"].dependsOn("otherTask")
 
 .. tab:: Groovy
 
         .. code-block:: diff
-                :caption: build.gradle
+            :caption: build.gradle
 
-                tasks {
-                -   smithyBuildJar {
-	            +   smithyBuild {
-                        smithyBuildConfigs = files("smithy-build.json", other)
-                    }
-                    // ..
+            tasks {
+            -   smithyBuildJar {
+            +   smithyBuild {
+                    smithyBuildConfigs = files("smithy-build.json", other)
                 }
+                // ..
+            }
 
-                -tasks["smithyBuildJar"].dependsOn("otherTask")
-                +tasks["jar"].dependsOn("otherTask")
+            -tasks["smithyBuildJar"].dependsOn("otherTask")
+            +tasks["jar"].dependsOn("otherTask")
 
 .. _Smithy Gradle plugins: https://github.com/awslabs/smithy-gradle-plugin/
 .. _Configuration: https://docs.gradle.org/current/dsl/org.gradle.api.artifacts.Configuration.html

--- a/docs/source-2.0/guides/gradle-plugin/index.rst
+++ b/docs/source-2.0/guides/gradle-plugin/index.rst
@@ -8,6 +8,12 @@ The `Smithy Gradle plugins`_ integrate Smithy with the `Gradle`_ build system. T
 build artifacts from Smithy models, and generate JARs for Smithy models and model
 :ref:`projections <projections>`.
 
+.. toctree::
+    :maxdepth: 1
+    :caption: Migrate to version 0.8.0+
+
+    gradle-migration-guide
+
 Plugins
 =======
 
@@ -151,6 +157,8 @@ Runtime dependencies can be added directly to the ``runtimeClasspath`` configura
 or to a configuration that extends ``runtimeClasspath``, such as the ``implementation``
 configuration added by the ``java-library`` plugin.
 
+.. _dependencies:
+
 Build Dependencies
 ^^^^^^^^^^^^^^^^^^
 
@@ -255,8 +263,6 @@ This extension supports the following properties:
     * - outputDirectory
       - ``Directory``
       - Defines where Smithy build artifacts are written.
-
-.. _dependencies:
 
 
 Customize output directory
@@ -381,6 +387,8 @@ process if necessary. To run Smithy CLI commands in a process set the
         smithy {
             fork = true
         }
+
+.. _disable-smithy-formatter:
 
 Disable Smithy Formatter
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
#### Background
* Adds a migration guide to help users move from the old version of the Smithy gradle plugin to the newer versions without breaking their existing projects.

#### Testing
Built locally with `make html`

[Built artifacts link](https://github.com/smithy-lang/smithy/actions/runs/7934810756/artifacts/1252081313)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
