### PR TITLE
Update gradle quickstart example to include empty smithy-build.json

### DIFF
--- a/docs/source-2.0/quickstart.rst
+++ b/docs/source-2.0/quickstart.rst
@@ -537,8 +537,18 @@ generate artifacts, and runs validation.
                 mavenCentral()
             }
 
+    Next, create a :ref:`smithy-build.json <smithy-build-json>` file in the
+    ``smithy-quickstart`` directory:
 
-    Next, run ``gradle build``. That's it! We just created a simple, read-only, ``Weather`` service.
+    .. code-block:: json
+        :caption: smithy-build.json
+
+        {
+            // Version of the smithy-build.json file specification
+            "version": "1.0"
+        }
+
+    Finally, run ``gradle build``. That's it! We just created a simple, read-only, ``Weather`` service.
 
 
 Next steps
@@ -604,6 +614,7 @@ If you followed all the steps in this guide, your working directory should be la
 
         .
         ├── build.gradle.kts
+        ├── smithy-build.json
         └── model
             └── weather.smithy
 


### PR DESCRIPTION
#### Background
Updates quickstart example to include an empty smithy-build.json.

#### Testing
N/A

#### Links
* The following Gradle plugin update will require either an empty build config or an explicit opt-out: https://github.com/smithy-lang/smithy-gradle-plugin/pull/123

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
