### PR TITLE
Add docs-publishing workflow

### DIFF
--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -1,0 +1,86 @@
+name: make-docs
+on:
+  release:
+    types: [released]
+  workflow_dispatch: # on button click
+    inputs:
+      javadocs:
+        type: boolean
+        description: 'Build JavaDocs?'
+        required: true
+      release:
+        type: boolean
+        description: 'Release the docs?'
+        required: true
+
+env:
+  ARTIFACTS_DIR: /tmp/artifacts
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo 
+      uses: actions/checkout@v4
+    - name: Setup
+      run: |
+        mkdir -p $ARTIFACTS_DIR
+
+    - name: Build JavaDocs
+      # run if 'javadocs' is not set to false 
+      if: ${{ !contains(inputs.javadocs, 'false') }}
+      run: |
+        VERSION=$(cat VERSION)
+        mkdir -p $ARTIFACTS_DIR/javadoc
+        ./gradlew javadoc
+        cp -R build/docs/javadoc/latest $ARTIFACTS_DIR/javadoc/$VERSION
+        mkdir $ARTIFACTS_DIR/javadoc/latest
+        cat << EOF > $ARTIFACTS_DIR/javadoc/latest/index.html
+        <!DOCTYPE html>
+        <meta charset="utf-8">
+        <title>Redirecting to latest javadocs</title>
+        <meta http-equiv="refresh" content="0; URL=../${VERSION}/">
+        EOF
+
+    - name: Build Smithy docs
+      run: |
+        cd docs
+        pip3 install -r requirements.txt
+        make clean
+        make html
+        cp -R build/html/* $ARTIFACTS_DIR
+        rm $ARTIFACTS_DIR/.buildinfo || true
+        rm $ARTIFACTS_DIR/objects.inv || true
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: smithy-docs
+        path: ${{ env.ARTIFACTS_DIR }}
+        retention-days: 7
+  
+
+  publish-docs:
+    runs-on: ubuntu-latest
+    # run if 'release' is not set to false 
+    if: ${{ !contains(inputs.release, 'false') }}
+    needs: build-docs
+    steps:
+    - name: Checkout GitHub pages branch
+      uses: actions/checkout@v4
+      with:
+        ref: 'gh-pages'
+    - name: Download artifacts
+      id: download
+      uses: actions/download-artifact@v4
+      with:
+        name: smithy-docs
+        path: /tmp/smithy-docs
+    - name: Copy artifacts
+      run: |
+        cp -R /tmp/smithy-docs/* .
+        git config --global user.name "smithy-automation"
+        git config --global user.email "github-smithy-automation@amazon.com"
+        git add -A
+        git commit -m "Update documentation"
+        git push

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -22,7 +22,7 @@ merge-versions:
 	mkdir -p build/html
 	cp -R "build/1.0/html" "build/html/1.0"
 	cp -R "build/2.0/html" "build/html/2.0"
-	cp -R "root/" "build/html"
+	cp -R root/* "build/html"
 
 openhtml:
 	open "build/html/index.html"


### PR DESCRIPTION
#### Background
- To reduce effort in releasing new versions of smithy, we can automate doc-publishing
- The `mkdocs` script is mostly 1-1 with this workflow, but this workflow will also allow us to do off-cycle docs releases without releasing javadocs (which may contain docs for new code not officially release yet)
- There are two flags that can be toggled: `javadocs` and `release`L
  - `javadoc`: whether to build javadocs as part of the workflow
  - `release`: whether to release the artifacts as part of the workflow
- One potential use case of toggling release off is to generate docs for PRs, so that we can see the rendered docs instead of a diff view

#### Testing
- Tested in personal fork of smithy
- Ran workflow by hand with each flag combo (javadoc, release, javadoc + release)
- Triggered workflow by creating a new release



---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
