### PR TITLE
Add survey banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # <img alt="Smithy" src="docs/_static/favicon.png" width="28"> Smithy
 [![Build Status](https://github.com/smithy-lang/smithy/workflows/ci/badge.svg)](https://github.com/smithy-lang/smithy/actions/workflows/ci.yml)
 
+<strong> We want your feedback on Smithy.</strong>
+Please consider taking our brief <a href="https://amazonmr.au1.qualtrics.com/jfe/form/SV_9Rfqo2wizSpnZPM">survey</a>
+to share your feedback.
+
+---
+
 Smithy defines and generates clients, services, and documentation for
 any protocol.
 

--- a/docs/source-2.0/conf.py
+++ b/docs/source-2.0/conf.py
@@ -12,3 +12,7 @@ release = u'2.0'
 version = release
 
 html_theme_options['source_directory'] = "docs/source-2.0"
+html_theme_options['announcement'] = '''<strong> We want your feedback on Smithy.</strong>
+Please consider taking our brief <a href="https://amazonmr.au1.qualtrics.com/jfe/form/SV_9Rfqo2wizSpnZPM">survey</a>
+ to share your feedback.
+'''


### PR DESCRIPTION
#### Background
* Adds a banner to smithy Docs site with a link to a customer survey for smithy 
* Adds a link to the survey to the README.md

NOTE: We plan to keep this banner up for one month and after that period, revert this commit to remove the banner.

#### Testing
[Document Artifact link](https://github.com/smithy-lang/smithy/actions/runs/7980085314/artifacts/1260924812)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
