### PR TITLE
Fix member mixin lists

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ApplyMixin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ApplyMixin.java
@@ -99,22 +99,25 @@ final class ApplyMixin implements ShapeModifier {
                     }
                 }
             }
-            if (introducedMember == null && memberBuilders.containsKey(member.getMemberName())) {
-                MemberShape.Builder original = memberBuilders.get(member.getMemberName());
-                introducedMember = original.addMixin(member).build();
-                if (!introducedMember.getTarget().equals(member.getTarget())) {
-                    mixinMemberConflict(original, member);
+
+            if (introducedMember == null) {
+                if (memberBuilders.containsKey(member.getMemberName())) {
+                    MemberShape.Builder original = memberBuilders.get(member.getMemberName());
+                    introducedMember = original.addMixin(member).build();
+                    if (!introducedMember.getTarget().equals(member.getTarget())) {
+                        mixinMemberConflict(original, member);
+                    }
+                } else if (!introducedTraits.isEmpty()) {
+                    // Build local member copies before adding mixins if traits
+                    // were introduced to inherited mixin members.
+                    introducedMember = MemberShape.builder()
+                            .id(targetId)
+                            .target(member.getTarget())
+                            .source(member.getSourceLocation())
+                            .addTraits(introducedTraits.values())
+                            .addMixin(member)
+                            .build();
                 }
-            } else if (!introducedTraits.isEmpty()) {
-                // Build local member copies before adding mixins if traits
-                // were introduced to inherited mixin members.
-                introducedMember = MemberShape.builder()
-                        .id(targetId)
-                        .target(member.getTarget())
-                        .source(member.getSourceLocation())
-                        .addTraits(introducedTraits.values())
-                        .addMixin(member)
-                        .build();
             }
 
             if (introducedMember != null) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/NamedMemberUtils.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/NamedMemberUtils.java
@@ -48,11 +48,11 @@ final class NamedMemberUtils {
                 String name = member.getMemberName();
                 if (members.get().containsKey(name)) {
                     MemberShape localMember = members.get().get(name);
-                    // Rebuild the member with the proper inherited mixin if needed.
+                    // Rebuild the member with the proper inherited mixins if needed.
                     // This catches errant cases where a member is added to a structure/union
                     // but omits the mixin members of parent shapes. Arguably, that's way too
                     // nuanced and error-prone to _not_ try to smooth over.
-                    if (localMember.getMixins().isEmpty() || !mixins.containsKey(member.getId())) {
+                    if (localMember.getMixins().isEmpty() || !localMember.getMixins().contains(member.getId())) {
                         localMember = localMember.toBuilder().clearMixins().addMixin(member).build();
                     }
                     computedMembers.put(name, localMember);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/NamedMemberUtils.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/NamedMemberUtils.java
@@ -53,7 +53,7 @@ final class NamedMemberUtils {
                     // but omits the mixin members of parent shapes. Arguably, that's way too
                     // nuanced and error-prone to _not_ try to smooth over.
                     if (localMember.getMixins().isEmpty() || !localMember.getMixins().contains(member.getId())) {
-                        localMember = localMember.toBuilder().clearMixins().addMixin(member).build();
+                        localMember = rebuildMemberMixins(localMember, mixins.values());
                     }
                     computedMembers.put(name, localMember);
                 } else {
@@ -85,6 +85,14 @@ final class NamedMemberUtils {
             }
         }
         return Collections.unmodifiableMap(computedMembers);
+    }
+
+    private static MemberShape rebuildMemberMixins(MemberShape member, Collection<Shape> mixins) {
+        MemberShape.Builder builder = member.toBuilder().clearMixins();
+        for (Shape mixin : mixins) {
+            mixin.getMember(member.getMemberName()).ifPresent(builder::addMixin);
+        }
+        return builder.build();
     }
 
     static Set<MemberShape> flattenMixins(

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
@@ -491,4 +491,11 @@ public class IdlModelLoaderTest {
         assertThat(e.getMessage(),
                    startsWith("Syntax error at line 1, column 1: Parser exceeded maximum allowed depth of 64"));
     }
+
+    @Test
+    public void handlesMultipleMemberInheritance() {
+        ValidatedResult<Model> result = Model.assembler()
+                .addImport(getClass().getResource("error-recovery/to-dollar.smithy"))
+                .assemble();
+    }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/StructureShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/StructureShapeTest.java
@@ -310,4 +310,30 @@ public class StructureShapeTest {
 
         assertThat(concrete.getMemberNames(), contains("a", "b", "c", "d"));
     }
+
+    @Test
+    public void fixesMissingMemberMixins() {
+        StringShape string = StringShape.builder().id("smithy.example#String").build();
+        StructureShape mixin1 = StructureShape.builder()
+                .id("smithy.example#Mixin1")
+                .addTrait(MixinTrait.builder().build())
+                .addMember("a", string.getId())
+                .build();
+        StructureShape mixin2 = StructureShape.builder()
+                .id("smithy.example#Mixin2")
+                .addTrait(MixinTrait.builder().build())
+                .addMember("a", string.getId())
+                .build();
+        StructureShape concrete = StructureShape.builder()
+                .id("smithy.example#Concrete")
+                .addMember("a", string.getId())
+                .addMixin(mixin1)
+                .addMixin(mixin2)
+                .build();
+
+        assertThat(concrete.getMember("a").get().getMixins(), contains(
+                ShapeId.from("smithy.example#Mixin1$a"),
+                ShapeId.from("smithy.example#Mixin2$a")
+        ));
+    }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/multiple-inheritance-with-introduction.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/mixins/multiple-inheritance-with-introduction.smithy
@@ -1,0 +1,22 @@
+$version: "2"
+
+namespace com.example
+
+@mixin
+structure MixinA {
+    @pattern("foo")
+    @required
+    member: String
+}
+
+@mixin
+structure MixinB {
+    @pattern("bar")
+    @internal
+    member: String
+}
+
+structure FinalStructure with [MixinA, MixinB] {
+    @pattern("baz")
+    member: String
+}


### PR DESCRIPTION
#### Background
* What do these changes do? 

  Fixes two bugs regarding member shapes that have multiple mixins:

    1. Fixes a bug where mixed members that also applied local traits would drop all but the last mixin from their list of mixins.
    2. Fixes a bug where shape constructors attempting to fix missing mixins from member mixin lists would drop all but the last mixin from the list.

* Why are they important?

  Correctness is a virtue.

#### Testing
* How did you test these changes?

  The specific customer case was tested manually, unit tests derived from that were added.

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

  Fixes #2150

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
