### PR TITLE
Fix mistakenly removed section in smithy-cli gradle build

### DIFF
--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -233,6 +233,26 @@ sourceSets {
     }
 }
 
+task integ(type: Test) {
+    useJUnitPlatform()
+    systemProperty "SMITHY_BINARY", "${smithyBinary}"
+    testClassesDirs = sourceSets["it"].output.classesDirs
+    classpath = sourceSets["it"].runtimeClasspath
+
+    // Configuration parameters to execute top-level classes in parallel but methods in same thread
+    systemProperties["junit.jupiter.execution.parallel.enabled"] = "true"
+    systemProperties["junit.jupiter.execution.parallel.mode.default"] = "same_thread"
+    systemProperties["junit.jupiter.execution.parallel.mode.classes.default"] = "concurrent"
+
+    testLogging {
+        events = ["passed", "skipped", "failed"]
+        exceptionFormat = "full"
+    }
+}
+
+// Runtime images need to be created before integration tests can run.
+tasks["integ"].dependsOn("runtime")
+
 // ------ Setup Jreleaser -------
 tasks.assembleDist.doFirst {
     // This is a workaround for a weird behavior.


### PR DESCRIPTION
#### Background
- gradle file got mangled in the process of #2134 
- adds back the mistakenly removed section for cli integ task
 
#### Testing
- `./gradlew :smithy-cli:integ`


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
