### PR TITLE
Use placeholder instead of static gradle plugin version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,5 @@
 from smithy.lexer import SmithyLexer
+import requests
 
 project = u'Smithy'
 copyright = u'2022, Amazon Web Services'
@@ -73,12 +74,25 @@ def __load_version():
 smithy_version = __load_version()
 smithy_version_placeholder = "__smithy_version__"
 
+## Find the latest version of the gradle plugin from github
+def __load_gradle_version():
+    return requests.get('https://api.github.com/repos/smithy-lang/smithy-gradle-plugin/tags').json()[0]['name']
+
+# We use the __smithy_gradle_version__ placeholder in documentation to represent
+# the current gradle plugin version number. This is found and replaced
+# using a source-read pre-processor so that the generated documentation
+# always references the latest release of the gradle plugin
+smithy_gradle_plugin_version = __load_gradle_version()
+smithy_gradle_version_placeholder = "__smithy_gradle_version__"
 
 def setup(sphinx):
     sphinx.add_lexer("smithy", SmithyLexer)
     sphinx.connect('source-read', source_read_handler)
     print("Finding and replacing '" + smithy_version_placeholder + "' with '" + smithy_version + "'")
+    print("Finding and replacing '" + smithy_gradle_version_placeholder + "' with '" + smithy_gradle_plugin_version + "'")
 
-# Rewrites __smithy_version__ to the version found in ../VERSION
+# Rewrites __smithy_version__ to the version found in ../VERSION and
+# rewrites __smithy_gradle_version__ to the latest version found on Github
 def source_read_handler(app, docname, source):
     source[0] = source[0].replace(smithy_version_placeholder, smithy_version)
+    source[0] = source[0].replace(smithy_gradle_version_placeholder, smithy_gradle_plugin_version)

--- a/docs/source-2.0/guides/gradle-plugin/gradle-migration-guide.rst
+++ b/docs/source-2.0/guides/gradle-plugin/gradle-migration-guide.rst
@@ -34,7 +34,7 @@ your project.
         plugins {
         -     id("software.amazon.smithy").version("0.7.0")
         +     `java`
-        +     id("software.amazon.smithy.gradle.smithy-jar").version("0.10.0")
+        +     id("software.amazon.smithy.gradle.smithy-jar").version("__smithy_gradle_version__")
         }
 
 .. tab:: Groovy
@@ -45,7 +45,7 @@ your project.
         plugins {
         -      id 'software.amazon.smithy' version '0.7.0'
         +      id 'java'
-        +      id 'software.amazon.smithy.gradle.smithy-jar' version '0.10.0'
+        +      id 'software.amazon.smithy.gradle.smithy-jar' version '__smithy_gradle_version__'
         }
 
 Remove Buildscript Dependencies

--- a/docs/source-2.0/guides/gradle-plugin/index.rst
+++ b/docs/source-2.0/guides/gradle-plugin/index.rst
@@ -51,7 +51,7 @@ The following example configures a project to use the ``smithy-base`` Gradle plu
         :caption: build.gradle.kts
 
         plugins {
-            id("software.amazon.smithy.gradle.smithy-base").version("0.10.0")
+            id("software.amazon.smithy.gradle.smithy-base").version("__smithy_gradle_version__")
         }
 
 .. tab:: Groovy
@@ -60,7 +60,7 @@ The following example configures a project to use the ``smithy-base`` Gradle plu
         :caption: build.gradle
 
         plugins {
-            id 'software.amazon.smithy.gradle.smithy-base' version '0.10.0'
+            id 'software.amazon.smithy.gradle.smithy-base' version '__smithy_gradle_version__'
         }
 
 
@@ -124,7 +124,7 @@ The following example ``build.gradle.kts`` will build a Smithy model using a
 
         plugins {
             `java-library`
-            id("software.amazon.smithy.gradle.smithy-jar").version("0.10.0")
+            id("software.amazon.smithy.gradle.smithy-jar").version("__smithy_gradle_version__")
         }
 
         // The SmithyExtension is used to customize the build. This example
@@ -152,7 +152,7 @@ The following example ``build.gradle.kts`` will build a Smithy model using a
 
         plugins {
             id 'java-library'
-            'software.amazon.smithy.gradle.smithy-jar' version '0.10.0'
+            'software.amazon.smithy.gradle.smithy-jar' version '__smithy_gradle_version__'
         }
 
         // The SmithyExtension is used to customize the build. This example
@@ -198,7 +198,7 @@ build using the "external" projection.
 
             plugins {
                 `java-library`
-                id("software.amazon.smithy.gradle.smithy-jar").version("0.10.0")
+                id("software.amazon.smithy.gradle.smithy-jar").version("__smithy_gradle_version__")
             }
 
             repositories {
@@ -231,7 +231,7 @@ build using the "external" projection.
 
             plugins {
                 id 'java-library'
-                id 'software.amazon.smithy.gradle.smithy-jar' version '0.10.0'
+                id 'software.amazon.smithy.gradle.smithy-jar' version '__smithy_gradle_version__'
             }
 
             repositories {

--- a/docs/source-2.0/guides/model-translations/converting-to-openapi.rst
+++ b/docs/source-2.0/guides/model-translations/converting-to-openapi.rst
@@ -165,7 +165,7 @@ OpenAPI specifications from Smithy models.
                 java
                 // Use the `smithy-jar` plugin if you also want to package
                 // smithy models into the JAR created by the `java` plugin.
-                id("software.amazon.smithy-base").version("0.10.0")
+                id("software.amazon.smithy-base").version("__smithy_gradle_version__")
             }
 
             dependencies {
@@ -184,7 +184,7 @@ OpenAPI specifications from Smithy models.
                 id 'java'
                 // Use the `smithy-jar` plugin if you also want to package
                 // smithy models into the JAR created by the `java` plugin.
-                id 'software.amazon.smithy-base' version '0.10.0'
+                id 'software.amazon.smithy-base' version '__smithy_gradle_version__'
             }
 
             dependencies {
@@ -1245,7 +1245,7 @@ of a Smithy model into an OpenAPI specification.
 
             plugins {
                 java
-                id("software.amazon.smithy.gradle.smithy-base").version("0.10.0")
+                id("software.amazon.smithy.gradle.smithy-base").version("__smithy_gradle_version__")
             }
 
             dependencies {
@@ -1263,7 +1263,7 @@ of a Smithy model into an OpenAPI specification.
 
             plugins {
                 id 'java'
-                id 'software.amazon.smithy.gradle.smithy-base' version '0.10.0'
+                id 'software.amazon.smithy.gradle.smithy-base' version '__smithy_gradle_version__'
             }
 
             dependencies {

--- a/docs/source-2.0/guides/model-translations/generating-cloudformation-resources.rst
+++ b/docs/source-2.0/guides/model-translations/generating-cloudformation-resources.rst
@@ -91,7 +91,7 @@ generate CloudFormation Resource Schemas from Smithy models.
 
             plugins {
                 java
-                id("software.amazon.smithy.gradle.smithy-jar").version("0.10.0")
+                id("software.amazon.smithy.gradle.smithy-jar").version("__smithy_gradle_version__")
             }
 
             dependencies {
@@ -108,7 +108,7 @@ generate CloudFormation Resource Schemas from Smithy models.
 
             plugins {
                 id 'java'
-                id 'software.amazon.smithy.gradle.smithy-jar' version '0.10.0'
+                id 'software.amazon.smithy.gradle.smithy-jar' version '__smithy_gradle_version__'
             }
 
             dependencies {

--- a/docs/source-2.0/quickstart.rst
+++ b/docs/source-2.0/quickstart.rst
@@ -512,7 +512,7 @@ generate artifacts, and runs validation.
 
             plugins {
                 `java-library`
-                id("software.amazon.smithy.gradle.smithy-jar").version("0.10.0")
+                id("software.amazon.smithy.gradle.smithy-jar").version("__smithy_gradle_version__")
             }
 
             repositories {
@@ -527,7 +527,7 @@ generate artifacts, and runs validation.
 
             plugins {
                 id 'java-library'
-                id 'software.amazon.smithy.gradle.smithy-jar' version '0.10.0'
+                id 'software.amazon.smithy.gradle.smithy-jar' version '__smithy_gradle_version__'
             }
 
             repositories {


### PR DESCRIPTION
#### Background
* Uses a placeholder, `__smithy_gradle_version__`, in docs instead of a static value so the docs stay up to date with the latest gradle plugin releases.
* The placeholder is replaced with the latest tagged version in the gradle plugin repo.

#### Testing
* Built docs locally with `make html`
* [Docs build link](https://github.com/smithy-lang/smithy/actions/runs/8055439080/artifacts/1276630495)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
