### PR TITLE
Fix `RestJsonZeroAndFalseQueryValues` protocol test

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -233,8 +233,8 @@ apply AllQueryStringTypes @httpRequestTests([
             queryInteger: 0
             queryBoolean: false
             queryParamsMapOfStringList: {
-                queryInteger: ["0"]
-                queryBoolean: ["false"]
+                "Integer": ["0"]
+                "Boolean": ["false"]
             }
         }
     }


### PR DESCRIPTION
#### Background
Intially added in https://github.com/smithy-lang/smithy/pull/2070, `RestJsonZeroAndFalseQueryValues` didn't include the correct params that would be deserialized by a server. Specifically it omitted the `@httpQueryParams` member `queryParamsMapOfStringList`. This member was added back in https://github.com/smithy-lang/smithy/pull/2132, but the map keys corresponded to member names in the input struct, rather than the literal query parameter keys. This meant that _clients_ running this protocol test would actually have a query string of
```
?Integer=0&Boolean=false&queryInteger=0&queryBoolean=false
```
instead of the intended
```
?Integer=0&Boolean=false
```
(`forbidQueryParams` wasn't set in the protocol test, so clients wouldn't fail here).
_servers_ would fail this test because they'd be expecting to get
```
{
    queryInteger: 0,
    queryBoolean: false,
    queryParamsMapOfStringList: {
        queryInteger: ["0"],
        queryBoolean: ["false"]
    }
}
```
from a query string of
```
?Integer=0&Boolean=false
```
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
