### PR TITLE
Add data-shape-only visitor class

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/ShapeVisitor.java
@@ -199,4 +199,30 @@ public interface ShapeVisitor<R> {
             return getDefault(shape);
         }
     }
+
+    /**
+     * Creates {@link ShapeVisitor} that only requires implementation of
+     * all data shape branches, but does not support service shapes.
+     *
+     * @param <R> Return type.
+     */
+    abstract class DataShapeVisitor<R> implements ShapeVisitor<R> {
+        @Override
+        public R operationShape(OperationShape shape) {
+            throw new IllegalArgumentException("DataShapeVisitor cannot be use to visit "
+                    + "Operation Shapes. Attempted to visit: " + shape);
+        }
+
+        @Override
+        public R resourceShape(ResourceShape shape) {
+            throw new IllegalArgumentException("DataShapeVisitor cannot be use to visit "
+                    + "Resource Shapes. Attempted to visit: " + shape);
+        }
+
+        @Override
+        public R serviceShape(ServiceShape shape) {
+            throw new IllegalArgumentException("DataShapeVisitor cannot be use to visit "
+                + "Service Shapes. Attempted to visit: " + shape);
+        }
+    }
 }


### PR DESCRIPTION
#### Background
* While working on trait codegen (see: https://github.com/smithy-lang/smithy/pull/2074) I have encountered quite a few cases where generators need to visit all data shapes types, but should fail on service shapes (resource, operation, service). This PR adds a new abstract class to provide this behavior as a common abstract class. 

#### Testing
* N/A 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
