### PR TITLE
Remove no-cone on add in init command

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/InitCommand.java
@@ -274,7 +274,7 @@ final class InitCommand implements Command {
         exec(ListUtils.of("git", "sparse-checkout", "set", "--no-cone", templatePath), stagingPath);
         // add any additional files that should be included
         for (String includedFile : includedFiles) {
-            exec(ListUtils.of("git", "sparse-checkout", "add", "--no-cone", includedFile), stagingPath);
+            exec(ListUtils.of("git", "sparse-checkout", "add", includedFile), stagingPath);
         }
         exec(ListUtils.of("git", "checkout"), stagingPath);
 


### PR DESCRIPTION
#### Background
* Trying to fix issue with windows CI.

#### Testing
* See integ tests

#### Links
* Previous failure: https://github.com/smithy-lang/smithy/actions/runs/8084081393/job/22090560577?pr=2168
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
