### PR TITLE
Add placeholder for typescript versions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,14 +85,29 @@ def __load_gradle_version():
 smithy_gradle_plugin_version = __load_gradle_version()
 smithy_gradle_version_placeholder = "__smithy_gradle_version__"
 
+## Find the latest version of the typescript codegen plugin from maven repo
+def __load_typescript_codegen_version():
+    return requests.get('https://search.maven.org/solrsearch/select?q=g:"software.amazon.smithy.typescript"'
+        + '+AND+a:"smithy-typescript-codegen"&wt=json').json()['response']['docs'][0]['latestVersion']
+
+# We use the __smithy_typescript_version__ placeholder in documentation to represent
+# the current gradle plugin version number. This is found and replaced
+# using a source-read pre-processor so that the generated documentation
+# always references the latest release of the gradle plugin
+smithy_typescript_codegen_version = __load_typescript_codegen_version()
+smithy_typescript_version_placeholder = "__smithy_typescript_version__"
+
 def setup(sphinx):
     sphinx.add_lexer("smithy", SmithyLexer)
     sphinx.connect('source-read', source_read_handler)
     print("Finding and replacing '" + smithy_version_placeholder + "' with '" + smithy_version + "'")
     print("Finding and replacing '" + smithy_gradle_version_placeholder + "' with '" + smithy_gradle_plugin_version + "'")
+    print("Finding and replacing '" + smithy_typescript_version_placeholder + "' with '" + smithy_typescript_codegen_version + "'")
+
 
 # Rewrites __smithy_version__ to the version found in ../VERSION and
 # rewrites __smithy_gradle_version__ to the latest version found on Github
 def source_read_handler(app, docname, source):
     source[0] = source[0].replace(smithy_version_placeholder, smithy_version)
-    source[0] = source[0].replace(smithy_gradle_version_placeholder, smithy_gradle_plugin_version)
+    source[0] = source[0].replace(smithy_gradle_version_placeholder, smithy_typescript_codegen_version)
+    source[0] = source[0].replace(smithy_typescript_version_placeholder, smithy_typescript_codegen_version)

--- a/docs/source-2.0/guides/gradle-plugin/index.rst
+++ b/docs/source-2.0/guides/gradle-plugin/index.rst
@@ -385,7 +385,7 @@ For example, to generate a Typescript client from a Smithy model, add the
 
                 // This dependency is required in order to apply the "typescript-client-codegen"
                 // plugin in smithy-build.json
-                smithyBuild("software.amazon.smithy.typescript:smithy-typescript-codegen:0.19.0")
+                smithyBuild("software.amazon.smithy.typescript:smithy-typescript-codegen:__smithy_typescript_version__")
             }
 
 .. tab:: Groovy
@@ -398,7 +398,7 @@ For example, to generate a Typescript client from a Smithy model, add the
 
                 // This dependency is required in order to apply the "typescript-client-codegen"
                 // plugin in smithy-build.json
-                smithyBuild 'software.amazon.smithy.typescript:smithy-typescript-codegen:0.19.0'
+                smithyBuild 'software.amazon.smithy.typescript:smithy-typescript-codegen:__smithy_typescript_version__'
             }
 
 The plugin can then be configured in the ``smithy-build.json`` to generate a typescript client

--- a/docs/source-2.0/guides/using-code-generation/generating-a-client.rst
+++ b/docs/source-2.0/guides/using-code-generation/generating-a-client.rst
@@ -42,7 +42,7 @@ named ``@weather-service/client`` with version ``0.0.1``.
             "sources": ["model"],
             "maven": {
                 "dependencies": [
-                    "software.amazon.smithy.typescript:smithy-aws-typescript-codegen:0.12.0"
+                    "software.amazon.smithy.typescript:smithy-aws-typescript-codegen:__smithy_typescript_version__"
                 ]
             },
             "...": "..."

--- a/docs/source-2.0/guides/using-code-generation/generating-a-client.rst
+++ b/docs/source-2.0/guides/using-code-generation/generating-a-client.rst
@@ -58,7 +58,7 @@ named ``@weather-service/client`` with version ``0.0.1``.
             :caption: build.gradle.kts
 
             dependencies {
-                smithyBuild("software.amazon.smithy.typescript:smithy-aws-typescript-codegen:0.12.0")
+                smithyBuild("software.amazon.smithy.typescript:smithy-aws-typescript-codegen:__smithy_typescript_version__")
             }
 
     .. tab:: Groovy
@@ -67,7 +67,7 @@ named ``@weather-service/client`` with version ``0.0.1``.
             :caption: build.gradle
 
             dependencies {
-                smithyBuild 'software.amazon.smithy.typescript:smithy-aws-typescript-codegen:0.12.0'
+                smithyBuild 'software.amazon.smithy.typescript:smithy-aws-typescript-codegen:__smithy_typescript_version__'
             }
 
 .. important::


### PR DESCRIPTION
#### Background
* Adds a placeholder, `__smithy_typescript_version__` for the smithy typescript code generator version. 
* The version number is determined by querying the latest version of the `smithy-typescript-codegen` package from Maven.
* This will keep the typescript version up to date without any additional action beyond just releasing the docs.

#### Testing
* local docs build
* [Doc artifact link](https://github.com/smithy-lang/smithy/actions/runs/8206427849/artifacts/1309960389)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
