### PR TITLE
Use new gradle plugins for validation model and protocol tests

### DIFF
--- a/.github/workflows/update-gradle-plugin.yml
+++ b/.github/workflows/update-gradle-plugin.yml
@@ -1,0 +1,56 @@
+name: Get latest smithy gradle plugin version
+on:
+  workflow_dispatch: # on button click
+  # Uncomment once permissions to create PRs has been added.
+  schedule:
+    # Runs every wednesday at 11
+    - cron:  '0 11 * * WED'
+
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Fetch latest smithy-gradle-plugin version
+        id: fetch-latest
+        run: |
+          echo "latestSmithyGradle=$( \
+           curl -sL https://api.github.com/repos/smithy-lang/smithy-gradle-plugin/tags | \
+           jq -r '.[0].name')" >> $GITHUB_OUTPUT
+      - name: Get current version
+        id: get-current
+        run: |
+          cat gradle.properties >> $GITHUB_OUTPUT
+      - name: Check if the current version of smithy-gradle-plugin should be updated
+        id: update-check
+        run: |
+          echo update-required=$( \
+          [ "${{ steps.get-current.outputs.smithyGradleVersion }}" = "${{ steps.fetch-latest.outputs.latestSmithyGradle }}" ] \
+          && echo "false" || echo "true") >> $GITHUB_OUTPUT
+      - name: Set up new git branch for version bump
+        id: git-setup
+        if: steps.update-check.outputs.update-required == 'true'
+        run: |
+          git checkout -b "automation/bump-smithy-gradle-version/${{ steps.fetch-latest.outputs.latestSmithyGradle }}"
+          git config --global user.email "github-aws-smithy-automation@amazon.com"
+          git config --global user.name "Smithy Automation"
+      - name: Find and replace gradle version in properties files
+        id: replace-current-version-properties
+        if: steps.update-check.outputs.update-required == 'true'
+        run: |
+          find . -type f -name 'gradle.properties' \
+          -exec sed -i "s|smithyGradleVersion=${{ steps.get-current.outputs.smithyGradleVersion }}|smithyGradleVersion=${{ steps.fetch-latest.outputs.latestSmithyGradle }}|g" {} \;
+      - name: Create PR
+        if: steps.update-check.outputs.update-required == 'true'
+        run: |
+          git add .
+          git commit -m 'Update smithy-gradle-plugin Version'
+          git push --set-upstream origin "automation/bump-smithy-gradle-version/${{ steps.fetch-latest.outputs.latestSmithyGradle }}"
+          gh pr create \
+            --title "[Automation] smithy-gradle-plugin Version Bump - \`${{ steps.fetch-latest.outputs.latestSmithyGradle }}\`" \
+            --body "Automated pull request to bump smithy gradle plugin version from ${{ steps.get-current.outputs.smithyGradleVersion }} to ${{ steps.fetch-latest.outputs.latestSmithyGradle }}" \
+            --base main
+          echo "PR Created for version bump to ${{ steps.fetch-latest.outputs.latestSmithyGradle }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PR_TOKEN }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.parallel=true
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
+smithyGradleVersion=0.10.0

--- a/smithy-aws-protocol-tests/build.gradle
+++ b/smithy-aws-protocol-tests/build.gradle
@@ -14,7 +14,7 @@
  */
 
 plugins {
-    id "software.amazon.smithy" version "0.6.0"
+    id "software.amazon.smithy.gradle.smithy-jar" version "$smithyGradleVersion"
 }
 
 description = "Defines protocol tests for AWS HTTP protocols."
@@ -31,4 +31,8 @@ dependencies {
     api project(":smithy-validation-model")
 }
 
-tasks["sourcesJar"].dependsOn("smithyBuildJar")
+tasks["sourcesJar"].dependsOn("smithyBuild")
+
+smithy {
+    format.set(false)
+}

--- a/smithy-validation-model/build.gradle
+++ b/smithy-validation-model/build.gradle
@@ -14,7 +14,7 @@
  */
 
 plugins {
-    id "software.amazon.smithy" version "0.6.0"
+    id "software.amazon.smithy.gradle.smithy-jar" version "$smithyGradleVersion"
 }
 
 description = "This module provides support for validation in Smithy server SDKs"
@@ -28,4 +28,4 @@ dependencies {
     implementation project(path: ":smithy-cli", configuration: "shadow")
 }
 
-tasks["sourcesJar"].dependsOn("smithyBuildJar")
+tasks["sourcesJar"].dependsOn("smithyBuild")

--- a/smithy-validation-model/model/smithy.framework.validation.smithy
+++ b/smithy-validation-model/model/smithy.framework.validation.smithy
@@ -7,10 +7,9 @@ namespace smithy.framework
 /// falls outside of the modeled or documented constraints.
 @error("client")
 structure ValidationException {
-
     /// A summary of the validation failure.
     @required
-    message: String,
+    message: String
 
     /// A list of specific failures encountered while validating the input.
     /// A member can appear in this list more than once if it failed to satisfy multiple constraints.
@@ -21,7 +20,7 @@ structure ValidationException {
 structure ValidationExceptionField {
     /// A JSONPointer expression to the structure member whose value failed to satisfy the modeled constraints.
     @required
-    path: String,
+    path: String
 
     /// A detailed description of the validation failure.
     @required


### PR DESCRIPTION
#### Background
* Updates the protocol test and validation model packages to use the updated gradle plugins. 
* Adds a new workflow to automatically check for updates to the gradle plugin and update the plugin if the main repo is behind.
* Commits the formatter changes applied by the plugin to the validation model.

#### Testing
* N/A

#### Links
* The periodic auto-update workflow is copied from the workflow used in the examples repo: https://github.com/smithy-lang/smithy-examples/blob/main/.github/workflows/update-smithy-gradle-plugin-version.yml

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
