### PR TITLE
Fix creating @standardRegionalEndpoints nodes

### DIFF
--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/PartitionSpecialCase.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/PartitionSpecialCase.java
@@ -6,6 +6,7 @@
 package software.amazon.smithy.rulesengine.aws.traits;
 
 import java.util.Objects;
+import java.util.Optional;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.Node;
@@ -64,10 +65,10 @@ public final class PartitionSpecialCase implements FromSourceLocation, ToNode, T
     @Override
     public Node toNode() {
         return Node.objectNodeBuilder()
-            .withMember(ENDPOINT, endpoint)
-            .withMember(DUAL_STACK, dualStack.toString())
-            .withMember(FIPS, fips.toString())
-            .build();
+                .withMember(ENDPOINT, endpoint)
+                .withOptionalMember(DUAL_STACK, Optional.ofNullable(dualStack).map(Node::from))
+                .withOptionalMember(FIPS, Optional.ofNullable(fips).map(Node::from))
+                .build();
     }
 
     @Override

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/StandardRegionalEndpointsTrait.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/StandardRegionalEndpointsTrait.java
@@ -79,7 +79,7 @@ public final class StandardRegionalEndpointsTrait extends AbstractTrait
         return ObjectNode.objectNodeBuilder()
                 .sourceLocation(getSourceLocation())
                 .withMember(PARTITION_SPECIAL_CASES, partitionSpecialCasesNodeBuilder.build())
-                .withMember(REGION_SPECIAL_CASES, partitionSpecialCasesNodeBuilder.build())
+                .withMember(REGION_SPECIAL_CASES, regionSpecialCasesNodeBuilder.build())
                 .build();
     }
 

--- a/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/traits/StandardRegionalEndpointsTraitTest.java
+++ b/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/traits/StandardRegionalEndpointsTraitTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
 
 class StandardRegionalEndpointsTraitTest {
@@ -25,12 +26,12 @@ class StandardRegionalEndpointsTraitTest {
 
         trait = getTraitFromService(model, "ns.foo#Service2");
 
-        assertEquals(trait.getRegionSpecialCases().size(), 0);
+        assertEquals(trait.getPartitionSpecialCases().size(), 0);
         assertEquals(trait.getRegionSpecialCases().size(), 0);
 
         trait = getTraitFromService(model, "ns.foo#Service3");
 
-        assertEquals(trait.getRegionSpecialCases().size(), 1);
+        assertEquals(trait.getPartitionSpecialCases().size(), 1);
         assertEquals(trait.getRegionSpecialCases().size(), 1);
         List<PartitionSpecialCase> partitionSpecialCases = trait.getPartitionSpecialCases().get("aws-us-gov");
 
@@ -46,6 +47,8 @@ class StandardRegionalEndpointsTraitTest {
 
         List<RegionSpecialCase> regionSpecialCases = trait.getRegionSpecialCases().get("us-east-1");
         assertEquals(regionSpecialCases.size(), 0);
+
+        Node.assertEquals(trait.toNode(), trait.toBuilder().build().toNode());
     }
 
     private StandardRegionalEndpointsTrait getTraitFromService(Model model, String service) {


### PR DESCRIPTION
#### Background
* What do these changes do? 
Fixes multiple issues serializing the `@standardRegionalEndpoints` trait.
* Why are they important?
If not fixed, serializing this trait may include incorrect values.

#### Testing
* How did you test these changes?
Added a test case.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
