### PR TITLE
Protocol test for `: null` values in unions

### DIFF
--- a/smithy-aws-protocol-tests/model/awsJson1_0/unions.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/unions.smithy
@@ -556,8 +556,7 @@ apply JsonUnions @httpResponseTests([
                   "mapValue": null,
                   "structureValue": {
                       "hi": "hello"
-                  },
-                  "unitValue": null
+                  }
                 }
             }"""
         bodyMediaType: "application/json"

--- a/smithy-aws-protocol-tests/model/awsJson1_0/unions.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/unions.smithy
@@ -43,6 +43,7 @@ union MyUnion {
     listValue: StringList,
     mapValue: StringMap,
     structureValue: GreetingStruct,
+    unitValue: Unit,
 }
 
 apply JsonUnions @httpRequestTests([
@@ -522,6 +523,42 @@ apply JsonUnions @httpResponseTests([
                     "structureValue": {
                         "hi": "hello"
                     }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: {
+            "Content-Type": "application/x-amz-json-1.0"
+        },
+        params: {
+            contents: {
+                structureValue: {
+                    hi: "hello"
+                }
+            }
+        }
+    },
+    {
+        id: "AwsJson10DeserializeAllowNulls"
+        appliesTo: "client"
+        documentation: "Allows for `: null` to be set for all unset fields"
+        protocol: awsJson1_0
+        code: 200
+        body: """
+            {
+                "contents": {
+                  "stringValue": null,
+                  "booleanValue": null,
+                  "numberValue": null,
+                  "blobValue": null,
+                  "timestampValue": null,
+                  "enumValue": null,
+                  "intEnumValue": null,
+                  "listValue": null,
+                  "mapValue": null,
+                  "structureValue": {
+                      "hi": "hello"
+                  },
+                  "unitValue": null
                 }
             }"""
         bodyMediaType: "application/json"

--- a/smithy-aws-protocol-tests/model/awsJson1_0/unions.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/unions.smithy
@@ -43,7 +43,6 @@ union MyUnion {
     listValue: StringList,
     mapValue: StringMap,
     structureValue: GreetingStruct,
-    unitValue: Unit,
 }
 
 apply JsonUnions @httpRequestTests([


### PR DESCRIPTION
#### Background
Servers are allowed (but not recommended) to send `"key": null` for unset fields in unions. However, this behavior was not covered by protocol tests.

#### Testing
These tests were dry-run on the Rust SDK.

#### Links
* https://github.com/awslabs/aws-sdk-rust/issues/1095

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
