### PR TITLE
Fix gradle dependency error for publishing to maven local

### DIFF
--- a/smithy-aws-protocol-tests/build.gradle
+++ b/smithy-aws-protocol-tests/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     api project(":smithy-validation-model")
 }
 
-tasks["sourcesJar"].dependsOn("smithyBuild")
+tasks["sourcesJar"].dependsOn("smithyJarStaging")
 
 smithy {
     format.set(false)

--- a/smithy-validation-model/build.gradle
+++ b/smithy-validation-model/build.gradle
@@ -28,4 +28,4 @@ dependencies {
     implementation project(path: ":smithy-cli", configuration: "shadow")
 }
 
-tasks["sourcesJar"].dependsOn("smithyBuild")
+tasks["sourcesJar"].dependsOn("smithyJarStaging")


### PR DESCRIPTION
#### Background
* Corrects an issue introduced in PR: https://github.com/smithy-lang/smithy/pull/2176

* Gradle requires an explicit dependency on `smithyJarStaging` for the publish task. Before this commit the following error was encountered when running `./gradlew publishToMavenLocal`:
```
* What went wrong:
A problem was found with the configuration of task ':smithy-aws-protocol-tests:sourcesJar' (type 'Jar').
  - Gradle detected a problem with the following location: '/Users/example/code/smithy/smithy-aws-protocol-tests/build/tmp/staging-smithyJarStaging'.
    
    Reason: Task ':smithy-aws-protocol-tests:sourcesJar' uses this output of task ':smithy-aws-protocol-tests:smithyJarStaging' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':smithy-aws-protocol-tests:smithyJarStaging' as an input of ':smithy-aws-protocol-tests:sourcesJar'.
      2. Declare an explicit dependency on ':smithy-aws-protocol-tests:smithyJarStaging' from ':smithy-aws-protocol-tests:sourcesJar' using Task#dependsOn.
      3. Declare an explicit dependency on ':smithy-aws-protocol-tests:smithyJarStaging' from ':smithy-aws-protocol-tests:sourcesJar' using Task#mustRunAfter.
```

#### Testing
* Successfully ran `./gradlew publishToMavenLocal`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
