### PR TITLE
Add no document types validation to rpcv2Cbor

### DIFF
--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -309,6 +309,7 @@ structure httpApiKeyAuth {
 ///
 /// `traitValidators` is a map of validation event IDs to validators to apply to a shape.
 /// Selectors are used to identify shapes that are incompatible with a constrained trait.
+/// The shape with the targeted trait applied MUST be a valid entry point for the selector.
 ///
 /// The following example defines a protocol that does not support document types. Each matching member found in the
 /// closure of an attached shape emits a validation event:
@@ -317,7 +318,7 @@ structure httpApiKeyAuth {
 /// @trait(selector: "service")
 /// @traitValidators(
 ///     "myCustomProtocol.NoDocuments": {
-///         selector: "member :test(> document)"
+///         selector: "~> member :test(> document)"
 ///         message: "This protocol does not support document types"
 ///     }
 /// )

--- a/smithy-protocol-traits/src/main/resources/META-INF/smithy/smithy.protocols.rpcv2.smithy
+++ b/smithy-protocol-traits/src/main/resources/META-INF/smithy/smithy.protocols.rpcv2.smithy
@@ -15,6 +15,12 @@ use smithy.api#httpError
     hostLabel
     httpError
 ])
+@traitValidators(
+    "rpcv2Cbor.NoDocuments": {
+         selector: "service ~> member :test(> document)"
+         message: "This protocol does not support document types"
+    }
+)
 structure rpcv2Cbor {
     /// Priority ordered list of supported HTTP protocol versions.
     http: StringList

--- a/smithy-protocol-traits/src/test/resources/software/amazon/smithy/protocol/traits/errorfiles/no-document-support.errors
+++ b/smithy-protocol-traits/src/test/resources/software/amazon/smithy/protocol/traits/errorfiles/no-document-support.errors
@@ -1,0 +1,1 @@
+[ERROR] smithy.example#DocumentOperationInput$document: Found an incompatible shape when validating the constraints of the `smithy.protocols#rpcv2Cbor` trait attached to `smithy.example#DocumentService`: This protocol does not support document types | rpcv2Cbor.NoDocuments

--- a/smithy-protocol-traits/src/test/resources/software/amazon/smithy/protocol/traits/errorfiles/no-document-support.smithy
+++ b/smithy-protocol-traits/src/test/resources/software/amazon/smithy/protocol/traits/errorfiles/no-document-support.smithy
@@ -1,0 +1,19 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use smithy.protocols#rpcv2Cbor
+
+@rpcv2Cbor
+service DocumentService {
+    version: "2023-02-10"
+    operations: [
+        DocumentOperation
+    ]
+}
+
+operation DocumentOperation {
+    input := {
+        document: Document
+    }
+}


### PR DESCRIPTION
#### Background
* What do these changes do? 
Disallow `document` types in RPCv2 services per spec.
* Why are they important?
To enforce the protocol's requirements on services using it.

#### Testing
* How did you test these changes?
New test files.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
