### PR TITLE
Remove incorrect jsonName protocol info

### DIFF
--- a/docs/source-2.0/aws/protocols/aws-json.rst.template
+++ b/docs/source-2.0/aws/protocols/aws-json.rst.template
@@ -127,8 +127,7 @@ to convert each shape type:
     * - ``structure``
       - JSON object. Each member value provided for the structure is
         serialized as a JSON property where the property name is the same
-        as the member name. The :ref:`jsonName-trait` can be used to serialize
-        a property using a custom name.
+        as the member name.
     * - ``union``
       - JSON object. A union is serialized identically as a ``structure``
         shape, but only a single member can be set to a non-null value.


### PR DESCRIPTION
#### Background
* What do these changes do? 
Remove an incorrect line about `@jsonName` support in `awsJson` protocols.
* Why are they important?
Consistency of specification

#### Testing
* How did you test these changes?
Built docs locally.

#### Links
#1026 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
