### PR TITLE
Add default test, fix missing headers and body/params conflict

### DIFF
--- a/smithy-aws-protocol-tests/model/rpcV2/cbor-lists.smithy
+++ b/smithy-aws-protocol-tests/model/rpcV2/cbor-lists.smithy
@@ -16,6 +16,7 @@ use aws.protocoltests.shared#TimestampList
 use smithy.protocols#rpcv2Cbor
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
+use smithy.framework#ValidationException
 
 /// This test case serializes JSON lists for the following cases for both
 /// input and output:
@@ -27,7 +28,8 @@ use smithy.test#httpResponseTests
 @idempotent
 operation RpcV2CborLists {
     input: RpcV2CborListInputOutput,
-    output: RpcV2CborListInputOutput
+    output: RpcV2CborListInputOutput,
+    errors: [ValidationException]
 }
 
 apply RpcV2CborLists @httpRequestTests([
@@ -113,6 +115,23 @@ apply RpcV2CborLists @httpRequestTests([
         }
     },
     {
+        id: "RpcV2CborListsEmptyUsingDefiniteLength",
+        documentation: "Serializes empty JSON definite length lists",
+        protocol: rpcv2Cbor,
+        method: "POST",
+        uri: "/service/RpcV2Protocol/operation/RpcV2CborLists",
+        body: "oWpzdHJpbmdMaXN0gA=="
+        bodyMediaType: "application/cbor",
+        headers: {
+            "smithy-protocol": "rpc-v2-cbor",
+            "Accept": "application/cbor",
+            "Content-Type": "application/cbor"
+        },
+        params: {
+            stringList: []
+        }
+    },
+    {
         id: "RpcV2CborListsSerializeNull",
         documentation: "Serializes null values in lists",
         protocol: rpcv2Cbor,
@@ -127,6 +146,40 @@ apply RpcV2CborLists @httpRequestTests([
         },
         params: {
             sparseStringList: [null, "hi"]
+        }
+    },
+    {
+        id: "RpcV2CborSparseListWithIndefiniteString",
+        documentation: "Serializes indefinite length text strings inside an indefinite length list",
+        protocol: rpcv2Cbor,
+        method: "POST",
+        uri: "/service/RpcV2Protocol/operation/RpcV2CborLists",
+        body: "v3BzcGFyc2VTdHJpbmdMaXN0n394HUFuIGV4YW1wbGUgaW5kZWZpbml0ZSBzdHJpbmcsdyB3aGljaCB3aWxsIGJlIGNodW5rZWQsbiBvbiBlYWNoIGNvbW1h/394NUFub3RoZXIgZXhhbXBsZSBpbmRlZmluaXRlIHN0cmluZyB3aXRoIG9ubHkgb25lIGNodW5r/3ZUaGlzIGlzIGEgcGxhaW4gc3RyaW5n//8="
+        bodyMediaType: "application/cbor",
+        headers: {
+            "smithy-protocol": "rpc-v2-cbor",
+            "Accept": "application/cbor",
+            "Content-Type": "application/cbor"
+        },
+        params: {
+            sparseStringList: ["An example indefinite string, which will be chunked, on each comma", "Another example indefinite string with only one chunk", "This is a plain string"]
+        }
+    },
+    {
+        id: "RpcV2CborListWithIndefiniteString",
+        documentation: "Serializes indefinite length text strings inside a definite length list",
+        protocol: rpcv2Cbor,
+        method: "POST",
+        uri: "/service/RpcV2Protocol/operation/RpcV2CborLists",
+        body: "oWpzdHJpbmdMaXN0g394HUFuIGV4YW1wbGUgaW5kZWZpbml0ZSBzdHJpbmcsdyB3aGljaCB3aWxsIGJlIGNodW5rZWQsbiBvbiBlYWNoIGNvbW1h/394NUFub3RoZXIgZXhhbXBsZSBpbmRlZmluaXRlIHN0cmluZyB3aXRoIG9ubHkgb25lIGNodW5r/3ZUaGlzIGlzIGEgcGxhaW4gc3RyaW5n"
+        bodyMediaType: "application/cbor",
+        headers: {
+            "smithy-protocol": "rpc-v2-cbor",
+            "Accept": "application/cbor",
+            "Content-Type": "application/cbor"
+        },
+        params: {
+            stringList: ["An example indefinite string, which will be chunked, on each comma", "Another example indefinite string with only one chunk", "This is a plain string"]
         }
     }
 ])

--- a/smithy-aws-protocol-tests/model/rpcV2/cbor-maps.smithy
+++ b/smithy-aws-protocol-tests/model/rpcV2/cbor-maps.smithy
@@ -9,11 +9,13 @@ use aws.protocoltests.shared#StringSet
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 use smithy.protocols#rpcv2Cbor
+use smithy.framework#ValidationException
 
 /// The example tests basic map serialization.
 operation RpcV2CborMaps {
     input: RpcV2CborMapsInputOutput,
-    output: RpcV2CborMapsInputOutput
+    output: RpcV2CborMapsInputOutput,
+    errors: [ValidationException]
 }
 
 apply RpcV2CborMaps @httpRequestTests([
@@ -23,7 +25,7 @@ apply RpcV2CborMaps @httpRequestTests([
         protocol: rpcv2Cbor,
         method: "POST",
         uri: "/service/RpcV2Protocol/operation/RpcV2CborMaps",
-        body: "v25kZW5zZVN0cnVjdE1hcL9jYmF6v2JoaWNieWX/Y2Zvb79iaGlldGhlcmX//29zcGFyc2VTdHJ1Y3RNYXC/Y2Jher9iaGljYnll/2Nmb2+/YmhpZXRoZXJl////",
+        body: "v25kZW5zZVN0cnVjdE1hcKJjZm9voWJoaWV0aGVyZWNiYXqhYmhpY2J5ZW9zcGFyc2VTdHJ1Y3RNYXC/Y2Zvb6FiaGlldGhlcmVjYmF6oWJoaWNieWX//w=="
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
@@ -55,7 +57,7 @@ apply RpcV2CborMaps @httpRequestTests([
         protocol: rpcv2Cbor,
         method: "POST",
         uri: "/service/RpcV2Protocol/operation/RpcV2CborMaps",
-        body: "v3BzcGFyc2VCb29sZWFuTWFwv2F49v9vc3BhcnNlTnVtYmVyTWFwv2F49v9vc3BhcnNlU3RydWN0TWFwv2F49v//",
+        body: "v3BzcGFyc2VCb29sZWFuTWFwv2F49v9vc3BhcnNlTnVtYmVyTWFwv2F49v9vc3BhcnNlU3RyaW5nTWFwv2F49v9vc3BhcnNlU3RydWN0TWFwv2F49v//"
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
@@ -83,7 +85,7 @@ apply RpcV2CborMaps @httpRequestTests([
         protocol: rpcv2Cbor,
         method: "POST",
         uri: "/service/RpcV2Protocol/operation/RpcV2CborMaps",
-        body: "v29kZW5zZUJvb2xlYW5NYXC/YXj0/25kZW5zZU51bWJlck1hcL9heAD/cHNwYXJzZUJvb2xlYW5NYXC/YXj0/29zcGFyc2VOdW1iZXJNYXC/YXgA//8=",
+        body: "v25kZW5zZU51bWJlck1hcKFheABvc3BhcnNlTnVtYmVyTWFwv2F4AP9vZGVuc2VCb29sZWFuTWFwoWF49HBzcGFyc2VCb29sZWFuTWFwv2F49P//"
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
@@ -111,7 +113,7 @@ apply RpcV2CborMaps @httpRequestTests([
         protocol: rpcv2Cbor,
         method: "POST",
         uri: "/service/RpcV2Protocol/operation/RpcV2CborMaps",
-        body: "v2xzcGFyc2VTZXRNYXC/YXmfYWFhYv9heJ////8=",
+        body: "v2xzcGFyc2VTZXRNYXC/YXiAYXmCYWFhYv//"
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
@@ -131,7 +133,7 @@ apply RpcV2CborMaps @httpRequestTests([
         protocol: rpcv2Cbor,
         method: "POST",
         uri: "/service/RpcV2Protocol/operation/RpcV2CborMaps",
-        body: "v2xzcGFyc2VTZXRNYXC/YXmfYWFhYv9heJ////8=",
+        body: "oWtkZW5zZVNldE1hcKJheIBheYJhYWFi"
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
@@ -174,7 +176,7 @@ apply RpcV2CborMaps @httpResponseTests([
         documentation: "Deserializes maps",
         protocol: rpcv2Cbor,
         code: 200,
-        body: "v25kZW5zZVN0cnVjdE1hcL9jYmF6v2JoaWNieWX/Y2Zvb79iaGlldGhlcmX//29zcGFyc2VTdHJ1Y3RNYXC/Y2Jher9iaGljYnll/2Nmb2+/YmhpZXRoZXJl////",
+        body: "v25kZW5zZVN0cnVjdE1hcKJjZm9voWJoaWV0aGVyZWNiYXqhYmhpY2J5ZW9zcGFyc2VTdHJ1Y3RNYXC/Y2Zvb6FiaGlldGhlcmVjYmF6oWJoaWNieWX//w=="
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
@@ -204,7 +206,7 @@ apply RpcV2CborMaps @httpResponseTests([
         documentation: "Deserializes null map values",
         protocol: rpcv2Cbor,
         code: 200,
-        body: "v3BzcGFyc2VCb29sZWFuTWFwv2F49v9vc3BhcnNlTnVtYmVyTWFwv2F49v9vc3BhcnNlU3RydWN0TWFwv2F49v//",
+        body: "v3BzcGFyc2VCb29sZWFuTWFwv2F49v9vc3BhcnNlTnVtYmVyTWFwv2F49v9vc3BhcnNlU3RyaW5nTWFwv2F49v9vc3BhcnNlU3RydWN0TWFwv2F49v//"
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
@@ -230,7 +232,7 @@ apply RpcV2CborMaps @httpResponseTests([
         documentation: "Ensure that 0 and false are sent over the wire in all maps and lists",
         protocol: rpcv2Cbor,
         code: 200,
-        body: "v29kZW5zZUJvb2xlYW5NYXC/YXj0/25kZW5zZU51bWJlck1hcL9heAD/cHNwYXJzZUJvb2xlYW5NYXC/YXj0/29zcGFyc2VOdW1iZXJNYXC/YXgA//8=",
+        body: "v25kZW5zZU51bWJlck1hcKFheABvc3BhcnNlTnVtYmVyTWFwv2F4AP9vZGVuc2VCb29sZWFuTWFwoWF49HBzcGFyc2VCb29sZWFuTWFwv2F49P//"
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
@@ -274,7 +276,7 @@ apply RpcV2CborMaps @httpResponseTests([
         documentation: "A response that contains a dense map of sets.",
         protocol: rpcv2Cbor,
         code: 200,
-        body: "v2xzcGFyc2VTZXRNYXC/YXmfYWFhYv9heJ////8=",
+        body: "oWtkZW5zZVNldE1hcKJheIBheYJhYWFi"
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
@@ -314,7 +316,7 @@ apply RpcV2CborMaps @httpResponseTests([
         protocol: rpcv2Cbor,
         appliesTo: "client",
         code: 200,
-        body: "v2xzcGFyc2VTZXRNYXC/YXif/2F5n2FhYWL/YXr2//8=",
+        body: "oWtkZW5zZVNldE1hcKNheIBheYJhYWFiYXr2"
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
@@ -323,7 +325,8 @@ apply RpcV2CborMaps @httpResponseTests([
         params: {
             "denseSetMap": {
                 "x": [],
-                "y": ["a", "b"]
+                "y": ["a", "b"],
+                "z": null
             }
         }
     }

--- a/smithy-aws-protocol-tests/model/rpcV2/cbor-structs.smithy
+++ b/smithy-aws-protocol-tests/model/rpcV2/cbor-structs.smithy
@@ -6,7 +6,6 @@ use smithy.protocols#rpcv2Cbor
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
-
 @httpRequestTests([
     {
         id: "RpcV2CborSimpleScalarProperties",
@@ -19,26 +18,56 @@ use smithy.test#httpResponseTests
         }
         method: "POST",
         bodyMediaType: "application/cbor",
-        uri: "/service/aws.protocoltests.rpcv2Cbor.RpcV2Protocol/operation/SimpleScalarProperties",
-        body: "v2lieXRlVmFsdWUFa2RvdWJsZVZhbHVl+z/+OVgQYk3TcWZhbHNlQm9vbGVhblZhbHVl9GpmbG9hdFZhbHVl+kDz989saW50ZWdlclZhbHVlGQEAaWxvbmdWYWx1ZRkmkWpzaG9ydFZhbHVlGSaqa3N0cmluZ1ZhbHVlZnNpbXBsZXB0cnVlQm9vbGVhblZhbHVl9f8="
+        uri: "/service/RpcV2Protocol/operation/SimpleScalarProperties",
+        body: "v2lieXRlVmFsdWUFa2RvdWJsZVZhbHVl+z/+OVgQYk3TcWZhbHNlQm9vbGVhblZhbHVl9GpmbG9hdFZhbHVl+kDz989saW50ZWdlclZhbHVlGQEAaWxvbmdWYWx1ZRkmkWpzaG9ydFZhbHVlGSaqa3N0cmluZ1ZhbHVlZnNpbXBsZXB0cnVlQm9vbGVhblZhbHVl9WlibG9iVmFsdWVDZm9v/w=="
         params: {
-            trueBooleanValue: true,
-            falseBooleanValue: false,
             byteValue: 5,
             doubleValue: 1.889,
+            falseBooleanValue: false,
             floatValue: 7.624,
             integerValue: 256,
-            shortValue: 9898,
             longValue: 9873,
-            stringValue: "simple"
+            shortValue: 9898,
+            stringValue: "simple",
+            trueBooleanValue: true,
+            blobValue: "foo"
         }
+    },
+    {
+        id: "RpcV2CborSimpleScalarPropertiesUsingIndefiniteLength",
+        protocol: rpcv2Cbor,
+        documentation: """
+            The server should be capable of deserializing simple scalar properties
+            encoded using a map with a definite length.""",
+        headers: {
+            "smithy-protocol": "rpc-v2-cbor",
+            "Accept": "application/cbor",
+            "Content-Type": "application/cbor"
+        }
+        method: "POST",
+        bodyMediaType: "application/cbor",
+        uri: "/service/RpcV2Protocol/operation/SimpleScalarProperties",
+        body: "qmlieXRlVmFsdWUFa2RvdWJsZVZhbHVl+z/+OVgQYk3TcWZhbHNlQm9vbGVhblZhbHVl9GpmbG9hdFZhbHVl+kDz989saW50ZWdlclZhbHVlGQEAaWxvbmdWYWx1ZRkmkWpzaG9ydFZhbHVlGSaqa3N0cmluZ1ZhbHVlZnNpbXBsZXB0cnVlQm9vbGVhblZhbHVl9WlibG9iVmFsdWVDZm9v"
+        params: {
+            byteValue: 5,
+            doubleValue: 1.889,
+            falseBooleanValue: false,
+            floatValue: 7.624,
+            integerValue: 256,
+            longValue: 9873,
+            shortValue: 9898,
+            stringValue: "simple",
+            trueBooleanValue: true,
+            blobValue: "foo"
+        },
+        appliesTo: "server"
     },
     {
         id: "RpcV2CborClientDoesntSerializeNullStructureValues",
         documentation: "RpcV2 Cbor should not serialize null structure values",
         protocol: rpcv2Cbor,
         method: "POST",
-        uri: "/service/aws.protocoltests.rpcv2Cbor.RpcV2Protocol/operation/SimpleScalarProperties",
+        uri: "/service/RpcV2Protocol/operation/SimpleScalarProperties",
         body: "v/8=",
         bodyMediaType: "application/cbor",
         headers: {
@@ -56,7 +85,7 @@ use smithy.test#httpResponseTests
         documentation: "RpcV2 Cbor should not deserialize null structure values",
         protocol: rpcv2Cbor,
         method: "POST",
-        uri: "/service/aws.protocoltests.rpcv2Cbor.RpcV2Protocol/operation/SimpleScalarProperties",
+        uri: "/service/RpcV2Protocol/operation/SimpleScalarProperties",
         body: "v2tzdHJpbmdWYWx1Zfb/",
         bodyMediaType: "application/cbor",
         headers: {
@@ -120,7 +149,65 @@ use smithy.test#httpResponseTests
             doubleValue: "-Infinity",
             floatValue: "-Infinity"
         }
-    }
+    },
+    {
+        id: "RpcV2CborIndefiniteLengthStringsCanBeDeserialized",
+        protocol: rpcv2Cbor,
+        documentation: "The server should be capable of deserializing indefinite length text strings.",
+        headers: {
+            "smithy-protocol": "rpc-v2-cbor",
+            "Accept": "application/cbor",
+            "Content-Type": "application/cbor"
+        }
+        method: "POST",
+        bodyMediaType: "application/cbor",
+        uri: "/service/RpcV2Protocol/operation/SimpleScalarProperties",
+        body: "oWtzdHJpbmdWYWx1ZX94HUFuIGV4YW1wbGUgaW5kZWZpbml0ZSBzdHJpbmcscSBjaHVua2VkIG9uIGNvbW1h/w=="
+        params: {
+            stringValue: "An example indefinite string, chunked on comma"
+        },
+        appliesTo: "server"
+    },
+    {
+        id: "RpcV2CborIndefiniteLengthByteStringsCanBeDeserialized",
+        protocol: rpcv2Cbor,
+        documentation: "The server should be capable of deserializing indefinite length byte strings.",
+        headers: {
+            "smithy-protocol": "rpc-v2-cbor",
+            "Accept": "application/cbor",
+            "Content-Type": "application/cbor"
+        }
+        method: "POST",
+        bodyMediaType: "application/cbor",
+        uri: "/service/RpcV2Protocol/operation/SimpleScalarProperties",
+        body: "oWlibG9iVmFsdWVfWCJBbiBleGFtcGxlIGluZGVmaW5pdGUtYnl0ZSBzdHJpbmcsUSBjaHVua2VkIG9uIGNvbW1h/w=="
+        params: {
+            blobValue: "An example indefinite-byte string, chunked on comma"
+        },
+        appliesTo: "server"
+    },
+    {
+        id: "RpcV2CborSupportsUpcastingData",
+        protocol: rpcv2Cbor,
+        documentation: "Supports upcasting from a smaller byte representation of the same date type.",
+        headers: {
+            "smithy-protocol": "rpc-v2-cbor",
+            "Accept": "application/cbor",
+            "Content-Type": "application/cbor"
+        }
+        method: "POST",
+        bodyMediaType: "application/cbor",
+        uri: "/service/RpcV2Protocol/operation/SimpleScalarProperties",
+        body: "v2tkb3VibGVWYWx1Zfk+AGpmbG9hdFZhbHVl+UegbGludGVnZXJWYWx1ZRg4aWxvbmdWYWx1ZRkBAGpzaG9ydFZhbHVlCv8="
+        params: {
+            doubleValue: 1.5,
+            floatValue: 7.625,
+            integerValue: 56,
+            longValue: 256,
+            shortValue: 10
+        },
+        appliesTo: "server"
+    },
 ])
 @httpResponseTests([
     {
@@ -132,7 +219,7 @@ use smithy.test#httpResponseTests
             "Content-Type": "application/cbor"
         }
         bodyMediaType: "application/cbor",
-        body: "v2lieXRlVmFsdWUFa2RvdWJsZVZhbHVl+z/+OVgQYk3TcWZhbHNlQm9vbGVhblZhbHVl9GpmbG9hdFZhbHVl+kDz989saW50ZWdlclZhbHVlGQEAaWxvbmdWYWx1ZRkmkWpzaG9ydFZhbHVlGSaqa3N0cmluZ1ZhbHVlZnNpbXBsZXB0cnVlQm9vbGVhblZhbHVl9f8=",
+        body: "v3B0cnVlQm9vbGVhblZhbHVl9XFmYWxzZUJvb2xlYW5WYWx1ZfRpYnl0ZVZhbHVlBWtkb3VibGVWYWx1Zfs//jlYEGJN02pmbG9hdFZhbHVl+kDz989saW50ZWdlclZhbHVlGQEAanNob3J0VmFsdWUZJqprc3RyaW5nVmFsdWVmc2ltcGxlaWJsb2JWYWx1ZUNmb2//"
         code: 200,
         params: {
             trueBooleanValue: true,
@@ -142,8 +229,33 @@ use smithy.test#httpResponseTests
             floatValue: 7.624,
             integerValue: 256,
             shortValue: 9898,
-            stringValue: "simple"
+            stringValue: "simple",
+            blobValue: "foo"
         }
+    },
+    {
+        id: "RpcV2CborSimpleScalarPropertiesUsingDefiniteLength",
+        protocol: rpcv2Cbor,
+        documentation: "Deserializes simple scalar properties encoded using a map with definite length",
+        headers: {
+            "smithy-protocol": "rpc-v2-cbor",
+            "Content-Type": "application/cbor"
+        }
+        bodyMediaType: "application/cbor",
+        body: "qXB0cnVlQm9vbGVhblZhbHVl9XFmYWxzZUJvb2xlYW5WYWx1ZfRpYnl0ZVZhbHVlBWtkb3VibGVWYWx1Zfs//jlYEGJN02pmbG9hdFZhbHVl+kDz989saW50ZWdlclZhbHVlGQEAanNob3J0VmFsdWUZJqprc3RyaW5nVmFsdWVmc2ltcGxlaWJsb2JWYWx1ZUNmb28="
+        code: 200,
+        params: {
+            trueBooleanValue: true,
+            falseBooleanValue: false,
+            byteValue: 5,
+            doubleValue: 1.889,
+            floatValue: 7.624,
+            integerValue: 256,
+            shortValue: 9898,
+            stringValue: "simple",
+            blobValue: "foo"
+        },
+        appliesTo: "client"
     },
     {
         id: "RpcV2CborClientDoesntDeSerializeNullStructureValues",
@@ -286,6 +398,33 @@ apply RecursiveShapes @httpResponseTests([
                 }
             }
         }
+    },
+    {
+        id: "RpcV2CborRecursiveShapesUsingDefiniteLength",
+        documentation: "Deserializes recursive structures encoded using a map with definite length",
+        protocol: rpcv2Cbor,
+        code: 200,
+        body: "oWZuZXN0ZWSiY2Zvb2RGb28xZm5lc3RlZKJjYmFyZEJhcjFvcmVjdXJzaXZlTWVtYmVyomNmb29kRm9vMmZuZXN0ZWShY2JhcmRCYXIy"
+        bodyMediaType: "application/cbor",
+        headers: {
+            "smithy-protocol": "rpc-v2-cbor",
+            "Content-Type": "application/cbor"
+        },
+        params: {
+            nested: {
+                foo: "Foo1",
+                nested: {
+                    bar: "Bar1",
+                    recursiveMember: {
+                        foo: "Foo2",
+                        nested: {
+                            bar: "Bar2"
+                        }
+                    }
+                }
+            }
+        },
+        appliesTo: "client"
     }
 ])
 
@@ -308,7 +447,6 @@ structure RecursiveShapesInputOutputNested2 {
     recursiveMember: RecursiveShapesInputOutputNested1,
 }
 
-
 structure SimpleScalarStructure {
     trueBooleanValue: Boolean,
     falseBooleanValue: Boolean,
@@ -319,4 +457,5 @@ structure SimpleScalarStructure {
     longValue: Long,
     shortValue: Short,
     stringValue: String,
+    blobValue: Blob
 }

--- a/smithy-aws-protocol-tests/model/rpcV2/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/rpcV2/empty-input-output.smithy
@@ -21,7 +21,7 @@ use smithy.test#httpResponseTests
             "X-Amz-Target"
         ]
         method: "POST",
-        uri: "/service/aws.protocoltests.rpcv2Cbor.RpcV2Protocol/operation/NoInputOutput",
+        uri: "/service/RpcV2Protocol/operation/NoInputOutput",
         body: ""
     },
     {
@@ -34,7 +34,7 @@ use smithy.test#httpResponseTests
             "Content-Type": "application/cbor"
         }
         method: "POST",
-        uri: "/service/aws.protocoltests.rpcv2Cbor.RpcV2Protocol/operation/NoInputOutput",
+        uri: "/service/RpcV2Protocol/operation/NoInputOutput",
         body: "",
         appliesTo: "server"
     },
@@ -48,7 +48,7 @@ use smithy.test#httpResponseTests
             "Content-Type": "application/cbor"
         }
         method: "POST",
-        uri: "/service/aws.protocoltests.rpcv2Cbor.RpcV2Protocol/operation/NoInputOutput",
+        uri: "/service/RpcV2Protocol/operation/NoInputOutput",
         body: "v/8=",
         appliesTo: "server"
     },
@@ -62,7 +62,7 @@ use smithy.test#httpResponseTests
             "Content-Type": "application/cbor"
         }
         method: "POST",
-        uri: "/service/aws.protocoltests.rpcv2Cbor.RpcV2Protocol/operation/NoInputOutput",
+        uri: "/service/RpcV2Protocol/operation/NoInputOutput",
         body: "v/8=",
         appliesTo: "server"
     }
@@ -126,7 +126,8 @@ operation NoInputOutput {}
             "X-Amz-Target"
         ]
         method: "POST",
-        uri: "/service/aws.protocoltests.rpcv2Cbor.RpcV2Protocol/operation/EmptyInputOutput",
+        uri: "/service/RpcV2Protocol/operation/EmptyInputOutput",
+        bodyMediaType: "application/cbor",
         body: "v/8=",
     },
 ])
@@ -163,7 +164,8 @@ operation EmptyInputOutput {
             "X-Amz-Target"
         ]
         method: "POST",
-        uri: "/service/aws.protocoltests.rpcv2Cbor.RpcV2Protocol/operation/OptionalInputOutput",
+        uri: "/service/RpcV2Protocol/operation/OptionalInputOutput",
+        bodyMediaType: "application/cbor",
         body: "v/8=",
     },
 ])

--- a/smithy-aws-protocol-tests/model/rpcV2/errors.smithy
+++ b/smithy-aws-protocol-tests/model/rpcV2/errors.smithy
@@ -43,7 +43,7 @@ apply InvalidGreeting @httpResponseTests([
             "smithy-protocol": "rpc-v2-cbor",
             "Content-Type": "application/cbor"
         },
-        body: "v2ZfX3R5cGV4J2F3cy5wcm90b2NvbHRlc3RzLnJwY3YyI0ludmFsaWRHcmVldGluZ2dNZXNzYWdlYkhp/w==",
+        body: "v2ZfX3R5cGV4K2F3cy5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNJbnZhbGlkR3JlZXRpbmdnTWVzc2FnZWJIaf8=",
         bodyMediaType: "application/cbor",
     },
 ])
@@ -75,7 +75,7 @@ apply ComplexError @httpResponseTests([
             "smithy-protocol": "rpc-v2-cbor",
             "Content-Type": "application/cbor"
         },
-        body: "v2ZfX3R5cGV4JGF3cy5wcm90b2NvbHRlc3RzLnJwY3YyI0NvbXBsZXhFcnJvcmZOZXN0ZWS/Y0Zvb2NiYXL/aFRvcExldmVsaVRvcCBsZXZlbP8=",
+        body: "v2ZfX3R5cGV4KGF3cy5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNDb21wbGV4RXJyb3JoVG9wTGV2ZWxpVG9wIGxldmVsZk5lc3RlZL9jRm9vY2Jhcv//",
         bodyMediaType: "application/cbor"
     },
     {
@@ -83,11 +83,10 @@ apply ComplexError @httpResponseTests([
         protocol: rpcv2Cbor,
         code: 400,
         headers: {
-            "Content-Type": "application/x-amz-json-1.1"
+            "smithy-protocol": "rpc-v2-cbor",
+            "Content-Type": "application/cbor"
         },
-        body: "v2ZfX3R5cGV4JGF3cy5wcm90b2NvbHRlc3RzLnJwY3YyI0NvbXBsZXhFcnJvcv8=",
+        body: "v2ZfX3R5cGV4KGF3cy5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNDb21wbGV4RXJyb3L/",
         bodyMediaType: "application/cbor"
     },
 ])
-
-

--- a/smithy-aws-protocol-tests/model/rpcV2/fractional-seconds.smithy
+++ b/smithy-aws-protocol-tests/model/rpcV2/fractional-seconds.smithy
@@ -19,6 +19,10 @@ apply FractionalSeconds @httpResponseTests([
         protocol: rpcv2Cbor,
         code: 200,
         body: "v2hkYXRldGltZcH7Qcw32zgPvnf/",
+        headers: {
+            "smithy-protocol": "rpc-v2-cbor",
+            "Content-Type": "application/cbor"
+        },
         params: { datetime: 946845296.123 }
         bodyMediaType: "application/cbor",
         appliesTo: "client"

--- a/smithy-aws-protocol-tests/model/rpcV2/main.smithy
+++ b/smithy-aws-protocol-tests/model/rpcV2/main.smithy
@@ -20,7 +20,8 @@ service RpcV2Protocol {
         RpcV2CborMaps,
         RecursiveShapes,
         GreetingWithErrors,
-        FractionalSeconds
+        FractionalSeconds,
+        OperationWithDefaults
     ]
 }
 


### PR DESCRIPTION
1. Fix tests where the CBOR-encoded body doesn't match the JSON 'params' key.  
2. Add tests for default values.  
3. Add missing headers in tests.  
4. Add tests for indefinite-length text and byte strings.  
5. Add tests for structures encoded with definite-length maps.