### PR TITLE
Fix `TraitValidator` scope, it should be `@private` not `@internal`

### DIFF
--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -334,7 +334,7 @@ map traitValidators {
     value: TraitValidator
 }
 
-@internal
+@private
 structure TraitValidator {
     /// A Smithy selector that receives only the shape to which the `traitValidators` trait is applied.
     /// Any shape yielded by the selector is considered incompatible with the trait.


### PR DESCRIPTION
#### Background

The structure `TraitValidator` was added in #2156 was marked as `@internal` but it needs to be marked as `@private` otherwise it gets included in some projections.

#### Testing

Tested locally by verifying this the structure is not longer included in my projections.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
