### PR TITLE
Clarify HTTP compliance test params field

### DIFF
--- a/docs/source-1.0/spec/http-protocol-compliance-tests.rst
+++ b/docs/source-1.0/spec/http-protocol-compliance-tests.rst
@@ -207,8 +207,10 @@ that support the following members:
         to parse and validate the expected data against generated data.
     * - params
       - ``document``
-      - Defines the input parameters used to generate the HTTP request. These
-        parameters MUST be compatible with the input of the operation.
+      - For clients, defines the input parameters used to generate the HTTP
+        request. For servers, defines the input parameters extracted from the
+        HTTP request. These parameters MUST be compatible with the input of the
+        operation.
 
         Parameter values that contain binary data MUST be defined using
         values that can be represented in plain text (for example, use "foo"
@@ -391,9 +393,10 @@ structures that support the following members:
         base64 encoded.
     * - params
       - ``document``
-      - Defines the output or error parameters used to generate the HTTP
-        response. These parameters MUST be compatible with the targeted
-        operation's output or the targeted error structure.
+      - For clients, defines the output or error parameters extracted from the
+        HTTP response. For servers, defines the output or error parameters used
+        to generate the HTTP response. These parameters MUST be compatible with
+        the targeted operation's output or the targeted error structure.
 
         Parameter values that contain binary data MUST be defined using
         values that can be represented in plain text (for example, use "foo"

--- a/docs/source-2.0/additional-specs/http-protocol-compliance-tests.rst
+++ b/docs/source-2.0/additional-specs/http-protocol-compliance-tests.rst
@@ -208,8 +208,10 @@ that support the following members:
         to parse and validate the expected data against generated data.
     * - params
       - ``document``
-      - Defines the input parameters used to generate the HTTP request. These
-        parameters MUST be compatible with the input of the operation.
+      - For clients, defines the input parameters used to generate the HTTP
+        request. For servers, defines the input parameters extracted from the
+        HTTP request. These parameters MUST be compatible with the input of the
+        operation.
 
         Parameter values that contain binary data MUST be defined using
         values that can be represented in plain text (for example, use "foo"
@@ -393,9 +395,10 @@ structures that support the following members:
         base64 encoded.
     * - params
       - ``document``
-      - Defines the output or error parameters used to generate the HTTP
-        response. These parameters MUST be compatible with the targeted
-        operation's output or the targeted error structure.
+      - For clients, defines the output or error parameters extracted from the
+        HTTP response. For servers, defines the output or error parameters used
+        to generate the HTTP response. These parameters MUST be compatible with
+        the targeted operation's output or the targeted error structure.
 
         Parameter values that contain binary data MUST be defined using
         values that can be represented in plain text (for example, use "foo"


### PR DESCRIPTION
#### Background
* What do these changes do? 
Update docs for the usage of the `params` member in HTTP compliance test traits.
* Why are they important?
To clarify usage for clients and servers.

#### Testing
* How did you test these changes?
Build and review docs.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
