### PR TITLE
Ignore private prelude shapes when converting to JSON schema

### DIFF
--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/DeconflictingStrategy.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/DeconflictingStrategy.java
@@ -21,12 +21,14 @@ import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.Prelude;
 import software.amazon.smithy.model.shapes.CollectionShape;
 import software.amazon.smithy.model.shapes.MapShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.SimpleShape;
 import software.amazon.smithy.model.traits.EnumTrait;
+import software.amazon.smithy.model.traits.PrivateTrait;
 import software.amazon.smithy.utils.FunctionalUtils;
 import software.amazon.smithy.utils.StringUtils;
 
@@ -78,7 +80,8 @@ final class DeconflictingStrategy implements RefStrategy {
                || shape.isResourceShape()
                || shape.isServiceShape()
                || shape.isOperationShape()
-               || shape.isMemberShape();
+               || shape.isMemberShape()
+               || (Prelude.isPreludeShape(shape) && shape.hasTrait(PrivateTrait.class));
     }
 
     private String deconflict(Shape shape, String pointer, Map<String, ShapeId> reversePointers) {

--- a/smithy-jsonschema/src/test/java/software/amazon/smithy/jsonschema/DeconflictingStrategyTest.java
+++ b/smithy-jsonschema/src/test/java/software/amazon/smithy/jsonschema/DeconflictingStrategyTest.java
@@ -87,4 +87,14 @@ public class DeconflictingStrategyTest {
                     new JsonSchemaConverter.FilterPreludeUnit(false));
         });
     }
+
+    @Test
+    public void excludesPrivatePreludeShapes() {
+        StructureShape a = StructureShape.builder().id("com.foo#Severity").build();
+        Model model = Model.assembler().addShapes(a).assemble().unwrap();
+        PropertyNamingStrategy propertyNamingStrategy = PropertyNamingStrategy.createDefaultStrategy();
+        RefStrategy strategy = RefStrategy
+            .createDefaultStrategy(model, new JsonSchemaConfig(), propertyNamingStrategy, alwaysTrue());
+        assertThat(strategy.toPointer(a.getId()), equalTo("#/definitions/Severity"));
+    }
 }


### PR DESCRIPTION
#### Background

Exclude private prelude shapes to avoid name conflicts. Without this change a model including a shape, say, `Severity` will raise a name conflict with `smithy.api#Severity`.

#### Testing

Added unit tests.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
