### PR TITLE
Update Generating a Client guide  yarn workspaces

### DIFF
--- a/docs/source-2.0/guides/using-code-generation/generating-a-client.rst
+++ b/docs/source-2.0/guides/using-code-generation/generating-a-client.rst
@@ -186,35 +186,84 @@ The generated ``package.json`` contains scripts to do so:
 This example creates a mono-repo using `Yarn Workspaces`_ that
 integrates building the Smithy model and generating the code into the
 development workflow. First, move the Smithy project into its own
-directory named ``smithy/``::
+directory named ``smithy/``:
 
-    .
-    └── smithy
-        ├── build
-        ├── build.gradle.kts
-        ├── model
-        └── smithy-build.json
+.. tab:: Smithy CLI
+
+    .. code-block::
+
+        .
+        └── smithy
+            ├── build
+            ├── model
+            └── smithy-build.json
+
+.. tab:: Gradle
+
+    .. tab:: Kotlin
+
+        .. code-block::
+
+            .
+            └── smithy
+                ├── build
+                ├── build.gradle.kts
+                ├── model
+                └── smithy-build.json
+
+    .. tab:: Groovy
+
+        .. code-block::
+
+            .
+            └── smithy
+                ├── build
+                ├── build.gradle
+                ├── model
+                └── smithy-build.json
 
 Next, create a ``package.json`` in the root of the project with the following
 contents:
 
-.. code-block:: json
-    :caption: package.json
+.. tab:: Smithy CLI
 
-    {
-      "name": "weather-service",
-      "scripts": {
-        "generate": "cd smithy && gradle clean build",
-        "build": "yarn workspace @weather-service/client build",
-      },
-      "dependencies": {
-        "@weather-service/client": "0.0.1"
-      },
-      "private": true,
-      "workspaces": [
-        "smithy/build/smithyprojections/smithy/client/typescript-codegen"
-      ]
-    }
+    .. code-block:: json
+        :caption: package.json
+
+        {
+          "name": "weather-service",
+          "scripts": {
+            "generate": "cd smithy && gradle clean build",
+            "build": "yarn workspace @weather-service/client build",
+          },
+          "dependencies": {
+            "@weather-service/client": "0.0.1"
+          },
+          "private": true,
+          "workspaces": [
+            "smithy/build/smithy/source/typescript-codegen"
+          ]
+        }
+
+.. tab:: Gradle
+
+    .. code-block:: json
+        :caption: package.json
+
+        {
+          "name": "weather-service",
+          "scripts": {
+            "generate": "cd smithy && gradle clean build",
+            "build": "yarn workspace @weather-service/client build",
+          },
+          "dependencies": {
+            "@weather-service/client": "0.0.1"
+          },
+          "private": true,
+          "workspaces": [
+            "smithy/build/smithyprojections/smithy/source/typescript-codegen"
+          ]
+        }
 
 A few things to note:
 


### PR DESCRIPTION
closes: https://github.com/smithy-lang/smithy/pull/2193

#### Background
* The `Generating a Client` only has yarn workspacees set up assuming the reader is using Gradle, but the rest of the guide uses both CLI and Gradle
* This PR updates the guide to include versions for both Gradle and CLI.

#### Testing
* Built and viewed documentation site changes locally.

[Built artifact link](https://github.com/smithy-lang/smithy/actions/runs/8365028445/artifacts/1343964141)

### Links
Issue first brought up here: https://github.com/smithy-lang/smithy/pull/2193

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
