### PR TITLE
Split sparse collection tests to new operations

### DIFF
--- a/smithy-aws-protocol-tests/model/awsJson1_1/main.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/main.smithy
@@ -27,6 +27,7 @@ service JsonProtocol {
         PutAndGetInlineDocuments,
         JsonEnums,
         NullOperation,
+        SparseNullsOperation,
         GreetingWithErrors,
         JsonUnions,
 

--- a/smithy-aws-protocol-tests/model/awsJson1_1/null.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/null.smithy
@@ -44,52 +44,6 @@ use smithy.test#httpResponseTests
         method: "POST",
         uri: "/",
         appliesTo: "server",
-    },
-    {
-        id: "AwsJson11MapsSerializeNullValues",
-        documentation: "Serializes null values in maps",
-        protocol: awsJson1_1,
-        body: """
-            {
-                "sparseStringMap": {
-                    "foo": null
-                }
-            }""",
-        bodyMediaType: "application/json",
-        headers: {
-            "Content-Type": "application/x-amz-json-1.1",
-            "X-Amz-Target": "JsonProtocol.NullOperation",
-        },
-        params: {
-            "sparseStringMap": {
-                "foo": null
-            }
-        },
-        method: "POST",
-        uri: "/",
-    },
-    {
-        id: "AwsJson11ListsSerializeNull",
-        documentation: "Serializes null values in lists",
-        protocol: awsJson1_1,
-        body: """
-            {
-                "sparseStringList": [
-                    null
-                ]
-            }""",
-        bodyMediaType: "application/json",
-        headers: {
-            "Content-Type": "application/x-amz-json-1.1",
-            "X-Amz-Target": "JsonProtocol.NullOperation",
-        },
-        params: {
-            "sparseStringList": [
-                null
-            ]
-        },
-        method: "POST",
-        uri: "/",
     }
 ])
 @httpResponseTests([
@@ -119,53 +73,111 @@ use smithy.test#httpResponseTests
             string: null
         },
         appliesTo: "server",
-    },
+    }
+])
+operation NullOperation {
+    input: NullOperationInputOutput
+    output: NullOperationInputOutput
+}
+
+structure NullOperationInputOutput {
+    string: String
+}
+
+@httpRequestTests([
     {
-        id: "AwsJson11MapsDeserializeNullValues",
-        documentation: "Deserializes null values in maps",
-        protocol: awsJson1_1,
-        code: 200,
+        id: "AwsJson11SparseMapsSerializeNullValues"
+        documentation: "Serializes null values in maps"
+        protocol: awsJson1_1
         body: """
             {
                 "sparseStringMap": {
                     "foo": null
                 }
-            }""",
-        bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+            }"""
+        bodyMediaType: "application/json"
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1"
+            "X-Amz-Target": "JsonProtocol.SparseNullsOperation"
+        }
         params: {
             "sparseStringMap": {
                 "foo": null
             }
-        },
+        }
+        method: "POST"
+        uri: "/"
     },
     {
-        id: "AwsJson11ListsDeserializeNull",
-        documentation: "Deserializes null values in lists",
-        protocol: awsJson1_1,
-        code: 200,
+        id: "AwsJson11SparseListsSerializeNull"
+        documentation: "Serializes null values in lists"
+        protocol: awsJson1_1
         body: """
             {
                 "sparseStringList": [
                     null
                 ]
-            }""",
-        bodyMediaType: "application/json",
-        headers: {"Content-Type": "application/x-amz-json-1.1"},
+            }"""
+        bodyMediaType: "application/json"
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1"
+            "X-Amz-Target": "JsonProtocol.SparseNullsOperation"
+        }
         params: {
             "sparseStringList": [
                 null
             ]
-        },
+        }
+        method: "POST"
+        uri: "/"
     }
 ])
-operation NullOperation {
-    input: NullOperationInputOutput,
-    output: NullOperationInputOutput,
+@httpResponseTests([
+    {
+        id: "AwsJson11SparseMapsDeserializeNullValues"
+        documentation: "Deserializes null values in maps"
+        protocol: awsJson1_1
+        code: 200
+        body: """
+            {
+                "sparseStringMap": {
+                    "foo": null
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: {"Content-Type": "application/x-amz-json-1.1"}
+        params: {
+            "sparseStringMap": {
+                "foo": null
+            }
+        }
+    }
+    {
+        id: "AwsJson11SparseListsDeserializeNull"
+        documentation: "Deserializes null values in lists"
+        protocol: awsJson1_1
+        code: 200
+        body: """
+            {
+                "sparseStringList": [
+                    null
+                ]
+            }"""
+        bodyMediaType: "application/json"
+        headers: {"Content-Type": "application/x-amz-json-1.1"}
+        params: {
+            "sparseStringList": [
+                null
+            ]
+        }
+    }
+])
+operation SparseNullsOperation {
+    input: SparseNullsOperationInputOutput
+    output: SparseNullsOperationInputOutput
 }
 
-structure NullOperationInputOutput {
-    string: String,
-    sparseStringList: SparseStringList,
-    sparseStringMap: SparseStringMap,
+structure SparseNullsOperationInputOutput {
+    sparseStringList: SparseStringList
+    sparseStringMap: SparseStringMap
 }

--- a/smithy-aws-protocol-tests/model/restJson1/json-lists.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-lists.smithy
@@ -159,25 +159,6 @@ apply JsonLists @httpRequestTests([
         params: {
             stringList: []
         }
-    },
-    {
-          id: "RestJsonListsSerializeNull",
-          documentation: "Serializes null values in lists",
-          protocol: restJson1,
-          method: "PUT",
-          uri: "/JsonLists",
-          body: """
-                {
-                    "sparseStringList": [
-                        null,
-                        "hi"
-                    ]
-                }""",
-          bodyMediaType: "application/json",
-          headers: {"Content-Type": "application/json"},
-          params: {
-              sparseStringList: [null, "hi"]
-          }
     }
 ])
 
@@ -305,31 +286,11 @@ apply JsonLists @httpResponseTests([
         params: {
             stringList: []
         }
-    },
-    {
-          id: "RestJsonListsSerializeNull",
-          documentation: "Serializes null values in sparse lists",
-          protocol: restJson1,
-          code: 200,
-          body: """
-                {
-                    "sparseStringList": [
-                        null,
-                        "hi"
-                    ]
-                }""",
-          bodyMediaType: "application/json",
-          headers: {"Content-Type": "application/json"},
-          params: {
-              sparseStringList: [null, "hi"]
-          }
     }
 ])
 
 structure JsonListsInputOutput {
     stringList: StringList,
-
-    sparseStringList: SparseStringList,
 
     stringSet: StringSet,
 
@@ -359,4 +320,56 @@ structure StructureListMember {
 
     @jsonName("other")
     b: String,
+}
+
+@httpRequestTests([
+    {
+        id: "RestJsonSparseListsSerializeNull"
+        documentation: "Serializes null values in sparse lists"
+        protocol: restJson1
+        method: "PUT"
+        uri: "/SparseJsonLists"
+        body: """
+                {
+                    "sparseStringList": [
+                        null,
+                        "hi"
+                    ]
+                }"""
+        bodyMediaType: "application/json"
+        headers: {"Content-Type": "application/json"}
+        params: {
+            sparseStringList: [null, "hi"]
+        }
+    }
+])
+@httpResponseTests([
+    {
+        id: "RestJsonSparseListsSerializeNull"
+        documentation: "Serializes null values in sparse lists"
+        protocol: restJson1
+        code: 200
+        body: """
+                {
+                    "sparseStringList": [
+                        null,
+                        "hi"
+                    ]
+                }"""
+        bodyMediaType: "application/json"
+        headers: {"Content-Type": "application/json"}
+        params: {
+            sparseStringList: [null, "hi"]
+        }
+    }
+])
+@idempotent
+@http(uri: "/SparseJsonLists", method: "PUT")
+operation SparseJsonLists {
+    input: SparseJsonListsInputOutput
+    output: SparseJsonListsInputOutput
+}
+
+structure SparseJsonListsInputOutput {
+    sparseStringList: SparseStringList
 }

--- a/smithy-aws-protocol-tests/model/restJson1/json-maps.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-maps.smithy
@@ -35,8 +35,86 @@ apply JsonMaps @httpRequestTests([
                       "baz": {
                           "hi": "bye"
                       }
-                  },
-                  "sparseStructMap": {
+                  }
+              }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            "denseStructMap": {
+                "foo": {
+                    "hi": "there"
+                },
+                "baz": {
+                    "hi": "bye"
+                }
+            }
+        }
+    },
+    {
+        id: "RestJsonSerializesZeroValuesInMaps",
+        documentation: "Ensure that 0 and false are sent over the wire in all maps and lists",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/JsonMaps",
+        body: """
+            {
+                "denseNumberMap": {
+                    "x": 0
+                },
+                "denseBooleanMap": {
+                    "x": false
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            "denseNumberMap": {
+                "x": 0
+            },
+            "denseBooleanMap": {
+                "x": false
+            },
+        }
+    },
+    {
+        id: "RestJsonSerializesDenseSetMap",
+        documentation: "A request that contains a dense map of sets.",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/JsonMaps",
+        body: """
+            {
+                "denseSetMap": {
+                    "x": [],
+                    "y": ["a", "b"]
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            "denseSetMap": {
+                "x": [],
+                "y": ["a", "b"]
+            }
+        }
+    }
+])
+
+apply JsonMaps @httpResponseTests([
+    {
+        id: "RestJsonJsonMaps",
+        documentation: "Deserializes JSON maps",
+        protocol: restJson1,
+        code: 200,
+        body: """
+              {
+                  "denseStructMap": {
                       "foo": {
                           "hi": "there"
                       },
@@ -57,7 +135,151 @@ apply JsonMaps @httpRequestTests([
                 "baz": {
                     "hi": "bye"
                 }
+            }
+        }
+    },
+    {
+        id: "RestJsonDeserializesZeroValuesInMaps",
+        documentation: "Ensure that 0 and false are sent over the wire in all maps and lists",
+        protocol: restJson1,
+        code: 200,
+        body: """
+            {
+                "denseNumberMap": {
+                    "x": 0
+                },
+                "denseBooleanMap": {
+                    "x": false
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            "denseNumberMap": {
+                "x": 0
             },
+            "denseBooleanMap": {
+                "x": false
+            },
+        }
+    },
+    {
+        id: "RestJsonDeserializesDenseSetMap",
+        documentation: "A response that contains a dense map of sets.",
+        protocol: restJson1,
+        code: 200,
+        body: """
+            {
+                "denseSetMap": {
+                    "x": [],
+                    "y": ["a", "b"]
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            "denseSetMap": {
+                "x": [],
+                "y": ["a", "b"]
+            }
+        }
+    },
+    {
+        id: "RestJsonDeserializesDenseSetMapAndSkipsNull",
+        documentation: """
+            Clients SHOULD tolerate seeing a null value in a dense map, and they SHOULD
+            drop the null key-value pair.""",
+        protocol: restJson1,
+        appliesTo: "client",
+        code: 200,
+        body: """
+            {
+                "denseSetMap": {
+                    "x": [],
+                    "y": ["a", "b"],
+                    "z": null
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
+            "denseSetMap": {
+                "x": [],
+                "y": ["a", "b"]
+            }
+        }
+    }
+])
+
+structure JsonMapsInputOutput {
+    denseStructMap: DenseStructMap
+    denseNumberMap: DenseNumberMap
+    denseBooleanMap: DenseBooleanMap
+    denseStringMap: DenseStringMap
+    denseSetMap: DenseSetMap
+}
+
+map DenseStructMap {
+    key: String,
+    value: GreetingStruct
+}
+
+map DenseBooleanMap {
+    key: String,
+    value: Boolean
+}
+
+map DenseNumberMap {
+    key: String,
+    value: Integer
+}
+
+map DenseStringMap {
+    key: String,
+    value: String
+}
+
+map DenseSetMap {
+    key: String,
+    value: StringSet
+}
+
+/// This example tests sparse map serialization.
+@http(uri: "/SparseJsonMaps", method: "POST")
+operation SparseJsonMaps {
+    input: SparseJsonMapsInputOutput
+    output: SparseJsonMapsInputOutput
+}
+
+apply SparseJsonMaps @httpRequestTests([
+    {
+        id: "RestJsonSparseJsonMaps",
+        documentation: "Serializes JSON maps",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/SparseJsonMaps",
+        body: """
+              {
+                  "sparseStructMap": {
+                      "foo": {
+                          "hi": "there"
+                      },
+                      "baz": {
+                          "hi": "bye"
+                      }
+                  }
+              }""",
+        bodyMediaType: "application/json",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        params: {
             "sparseStructMap": {
                 "foo": {
                     "hi": "there"
@@ -69,11 +291,11 @@ apply JsonMaps @httpRequestTests([
         }
     },
     {
-        id: "RestJsonSerializesNullMapValues",
+        id: "RestJsonSerializesSparseNullMapValues",
         documentation: "Serializes JSON map values in sparse maps",
         protocol: restJson1,
         method: "POST",
-        uri: "/JsonMaps",
+        uri: "/SparseJsonMaps",
         body: """
             {
                 "sparseBooleanMap": {
@@ -109,21 +331,15 @@ apply JsonMaps @httpRequestTests([
         }
     },
     {
-        id: "RestJsonSerializesZeroValuesInMaps",
+        id: "RestJsonSerializesZeroValuesInSparseMaps",
         documentation: "Ensure that 0 and false are sent over the wire in all maps and lists",
         protocol: restJson1,
         method: "POST",
-        uri: "/JsonMaps",
+        uri: "/SparseJsonMaps",
         body: """
             {
-                "denseNumberMap": {
-                    "x": 0
-                },
                 "sparseNumberMap": {
                     "x": 0
-                },
-                "denseBooleanMap": {
-                    "x": false
                 },
                 "sparseBooleanMap": {
                     "x": false
@@ -134,14 +350,8 @@ apply JsonMaps @httpRequestTests([
             "Content-Type": "application/json"
         },
         params: {
-            "denseNumberMap": {
-                "x": 0
-            },
             "sparseNumberMap": {
                 "x": 0
-            },
-            "denseBooleanMap": {
-                "x": false
             },
             "sparseBooleanMap": {
                 "x": false
@@ -153,7 +363,7 @@ apply JsonMaps @httpRequestTests([
         documentation: "A request that contains a sparse map of sets",
         protocol: restJson1,
         method: "POST",
-        uri: "/JsonMaps",
+        uri: "/SparseJsonMaps",
         body: """
             {
                 "sparseSetMap": {
@@ -173,35 +383,11 @@ apply JsonMaps @httpRequestTests([
         }
     },
     {
-        id: "RestJsonSerializesDenseSetMap",
-        documentation: "A request that contains a dense map of sets.",
-        protocol: restJson1,
-        method: "POST",
-        uri: "/JsonMaps",
-        body: """
-            {
-                "denseSetMap": {
-                    "x": [],
-                    "y": ["a", "b"]
-                }
-            }""",
-        bodyMediaType: "application/json",
-        headers: {
-            "Content-Type": "application/json"
-        },
-        params: {
-            "denseSetMap": {
-                "x": [],
-                "y": ["a", "b"]
-            }
-        }
-    },
-    {
         id: "RestJsonSerializesSparseSetMapAndRetainsNull",
         documentation: "A request that contains a sparse map of sets.",
         protocol: restJson1,
         method: "POST",
-        uri: "/JsonMaps",
+        uri: "/SparseJsonMaps",
         body: """
             {
                 "sparseSetMap": {
@@ -224,22 +410,14 @@ apply JsonMaps @httpRequestTests([
     }
 ])
 
-apply JsonMaps @httpResponseTests([
+apply SparseJsonMaps @httpResponseTests([
     {
-        id: "RestJsonJsonMaps",
+        id: "RestJsonSparseJsonMaps",
         documentation: "Deserializes JSON maps",
         protocol: restJson1,
         code: 200,
         body: """
               {
-                  "denseStructMap": {
-                      "foo": {
-                          "hi": "there"
-                      },
-                      "baz": {
-                          "hi": "bye"
-                      }
-                  },
                   "sparseStructMap": {
                       "foo": {
                           "hi": "there"
@@ -254,14 +432,6 @@ apply JsonMaps @httpResponseTests([
             "Content-Type": "application/json"
         },
         params: {
-            "denseStructMap": {
-                "foo": {
-                    "hi": "there"
-                },
-                "baz": {
-                    "hi": "bye"
-                }
-            },
             "sparseStructMap": {
                 "foo": {
                     "hi": "there"
@@ -273,7 +443,7 @@ apply JsonMaps @httpResponseTests([
         }
     },
     {
-        id: "RestJsonDeserializesNullMapValues",
+        id: "RestJsonDeserializesSparseNullMapValues",
         documentation: "Deserializes null JSON map values",
         protocol: restJson1,
         code: 200,
@@ -312,20 +482,14 @@ apply JsonMaps @httpResponseTests([
         }
     },
     {
-        id: "RestJsonDeserializesZeroValuesInMaps",
+        id: "RestJsonDeserializesZeroValuesInSparseMaps",
         documentation: "Ensure that 0 and false are sent over the wire in all maps and lists",
         protocol: restJson1,
         code: 200,
         body: """
             {
-                "denseNumberMap": {
-                    "x": 0
-                },
                 "sparseNumberMap": {
                     "x": 0
-                },
-                "denseBooleanMap": {
-                    "x": false
                 },
                 "sparseBooleanMap": {
                     "x": false
@@ -336,14 +500,8 @@ apply JsonMaps @httpResponseTests([
             "Content-Type": "application/json"
         },
         params: {
-            "denseNumberMap": {
-                "x": 0
-            },
             "sparseNumberMap": {
                 "x": 0
-            },
-            "denseBooleanMap": {
-                "x": false
             },
             "sparseBooleanMap": {
                 "x": false
@@ -374,29 +532,6 @@ apply JsonMaps @httpResponseTests([
         }
     },
     {
-        id: "RestJsonDeserializesDenseSetMap",
-        documentation: "A response that contains a dense map of sets.",
-        protocol: restJson1,
-        code: 200,
-        body: """
-            {
-                "denseSetMap": {
-                    "x": [],
-                    "y": ["a", "b"]
-                }
-            }""",
-        bodyMediaType: "application/json",
-        headers: {
-            "Content-Type": "application/json"
-        },
-        params: {
-            "denseSetMap": {
-                "x": [],
-                "y": ["a", "b"]
-            }
-        }
-    },
-    {
         id: "RestJsonDeserializesSparseSetMapAndRetainsNull",
         documentation: "A response that contains a sparse map of sets.",
         protocol: restJson1,
@@ -420,73 +555,21 @@ apply JsonMaps @httpResponseTests([
                 "z": null
             }
         }
-    },
-    {
-        id: "RestJsonDeserializesDenseSetMapAndSkipsNull",
-        documentation: """
-            Clients SHOULD tolerate seeing a null value in a dense map, and they SHOULD
-            drop the null key-value pair.""",
-        protocol: restJson1,
-        appliesTo: "client",
-        code: 200,
-        body: """
-            {
-                "denseSetMap": {
-                    "x": [],
-                    "y": ["a", "b"],
-                    "z": null
-                }
-            }""",
-        bodyMediaType: "application/json",
-        headers: {
-            "Content-Type": "application/json"
-        },
-        params: {
-            "denseSetMap": {
-                "x": [],
-                "y": ["a", "b"]
-            }
-        }
     }
 ])
 
-structure JsonMapsInputOutput {
-    denseStructMap: DenseStructMap,
-    sparseStructMap: SparseStructMap,
-    denseNumberMap: DenseNumberMap,
-    denseBooleanMap: DenseBooleanMap,
-    denseStringMap: DenseStringMap,
-    sparseNumberMap: SparseNumberMap,
-    sparseBooleanMap: SparseBooleanMap,
-    sparseStringMap: SparseStringMap,
-    denseSetMap: DenseSetMap,
-    sparseSetMap: SparseSetMap,
-}
-
-map DenseStructMap {
-    key: String,
-    value: GreetingStruct
+structure SparseJsonMapsInputOutput {
+    sparseStructMap: SparseStructMap
+    sparseNumberMap: SparseNumberMap
+    sparseBooleanMap: SparseBooleanMap
+    sparseStringMap: SparseStringMap
+    sparseSetMap: SparseSetMap
 }
 
 @sparse
 map SparseStructMap {
     key: String,
     value: GreetingStruct
-}
-
-map DenseBooleanMap {
-    key: String,
-    value: Boolean
-}
-
-map DenseNumberMap {
-    key: String,
-    value: Integer
-}
-
-map DenseStringMap {
-    key: String,
-    value: String
 }
 
 @sparse
@@ -499,11 +582,6 @@ map SparseBooleanMap {
 map SparseNumberMap {
     key: String,
     value: Integer
-}
-
-map DenseSetMap {
-    key: String,
-    value: StringSet
 }
 
 @sparse

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -81,7 +81,9 @@ service RestJson {
         JsonIntEnums,
         RecursiveShapes,
         JsonLists,
+        SparseJsonLists,
         JsonMaps,
+        SparseJsonMaps,
         JsonBlobs,
 
         // Documents


### PR DESCRIPTION
#### Background
* What do these changes do? 
Create new operations in protocol tests for sparse tests.
* Why are they important?
Makes it easier to support sparse vs dense collections when working with protocols.

#### Testing
* How did you test these changes?
Ran generated tests in AWS SDK for JSv3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
