### PR TITLE
Add ValidationException to RpcV2CborSparseMaps

### DIFF
--- a/smithy-aws-protocol-tests/model/rpcV2/cbor-maps.smithy
+++ b/smithy-aws-protocol-tests/model/rpcV2/cbor-maps.smithy
@@ -435,6 +435,7 @@ apply RpcV2CborSparseMaps @httpResponseTests([
 operation RpcV2CborSparseMaps {
     input: RpcV2CborSparseMapsInputOutput
     output: RpcV2CborSparseMapsInputOutput
+    errors: [ValidationException]
 }
 
 structure RpcV2CborSparseMapsInputOutput {


### PR DESCRIPTION
#### Background
* What do these changes do? 
. Adds `ValidationException` to `RpcV2CborSparseMaps` because of member shape `SparseSetMap`
* Why are they important?
. `smithy-rs` raises an error otherwise.

#### Testing
* How did you test these changes?
- Local test using `smithy-rs` implementation.