### PR TITLE
Update make-docs to pull before pushing

### DIFF
--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -78,6 +78,7 @@ jobs:
         path: /tmp/smithy-docs
     - name: Copy artifacts
       run: |
+        git pull
         cp -R /tmp/smithy-docs/* .
         git config --global user.name "smithy-automation"
         git config --global user.email "github-smithy-automation@amazon.com"


### PR DESCRIPTION




#### Background
The latest automated release run of this workflow failed because a few off-cycle docs updates were done: https://github.com/smithy-lang/smithy/actions/runs/8394668276

We should pull the changes, copy the docs, and then push.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
