### PR TITLE
Downgrade shadow dependency to fix staging command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
     id "com.github.spotbugs" version "6.0.8"
     id "io.codearte.nexus-staging" version "0.30.0"
     id "me.champeau.jmh" version "0.7.2"
-    id "com.github.johnrengelman.shadow" version "8.1.1"
+    id "com.github.johnrengelman.shadow" version "7.1.2"
     id "org.jreleaser" version "1.11.0"
 }
 


### PR DESCRIPTION
#### Background
* While executing 1.46.0 release, issues were encountered when staging JARS:
```
Execution failed for task ':smithy-cli:publishMavenJavaPublicationToMavenLocal'.
> Failed to publish publication 'mavenJava' to repository 'mavenLocal'
   > Invalid publication 'mavenJava': artifact file does not exist: '/Users/sugmanue/Sources/smithy/smithy-cli/build/libs/smithy-cli-1.46.0-all.jar'
```
* Tracked it down to bug fixes in latest version of `shadow`, where `-all` is the expected suffix

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
