### PR TITLE
Update smithy-cli jreleaser distribution to depend on runtimeZip

### DIFF
--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -254,6 +254,7 @@ task integ(type: Test) {
 tasks["integ"].dependsOn("runtime")
 
 // ------ Setup Jreleaser -------
+tasks["assembleDist"].dependsOn("runtimeZip")
 tasks.assembleDist.doFirst {
     // This is a workaround for a weird behavior.
     // https://github.com/jreleaser/jreleaser/issues/1292
@@ -262,7 +263,6 @@ tasks.assembleDist.doFirst {
 
 jreleaser {
     gitRootSearch = true
-
 
     project {
         website = 'https://smithy.io'


### PR DESCRIPTION
#### Background
- For the next release (1.47.0), we should set dry-run to be enabled for the cli config, so that it does not try to do an actual release
- The other change is needed so that JReleaser runs _after_ the image zips are created

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
