### PR TITLE
Use `@deprecated` info when building OpenAPI description

### DIFF
--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/simple-service-aws.cfn.json
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/simple-service-aws.cfn.json
@@ -19,7 +19,8 @@
   },
   "properties": {
     "FooDeprecatedMutableProperty": {
-      "type": "string"
+      "type": "string",
+      "description": "This shape is deprecated: Use the `fooValidFullyMutableProperty` property."
     },
     "FooId": {
       "type": "string"

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
@@ -333,11 +333,10 @@ final class JsonSchemaShapeVisitor extends ShapeVisitor.Default<Schema> {
     }
 
     private Optional<String> descriptionMessage(Shape shape) {
-        String deprecatedMessageSuffix = shape.getTrait(DeprecatedTrait.class)
-                .map(deprecatedTrait -> deprecatedTrait.getDeprecatedDescription(shape.getType()))
-                .map(message -> "\n" + message).orElse("");
-        return shape.getTrait(DocumentationTrait.class).map(DocumentationTrait::getValue)
-                .map(documentation -> documentation + deprecatedMessageSuffix);
+        StringBuilder builder = new StringBuilder();
+        shape.getTrait(DocumentationTrait.class).ifPresent(trait -> builder.append(trait.getValue());
+        shape.getTrait(DeprecatedTrait.class).ifPresent(trait -> builder.append("\n").append(trait.getValue());
+        return builder.toString().trim();
     }
 
     /**

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
@@ -334,9 +334,19 @@ final class JsonSchemaShapeVisitor extends ShapeVisitor.Default<Schema> {
 
     private Optional<String> descriptionMessage(Shape shape) {
         StringBuilder builder = new StringBuilder();
-        shape.getTrait(DocumentationTrait.class).ifPresent(trait -> builder.append(trait.getValue());
-        shape.getTrait(DeprecatedTrait.class).ifPresent(trait -> builder.append("\n").append(trait.getValue());
-        return builder.toString().trim();
+        shape
+            .getTrait(DocumentationTrait.class)
+            .ifPresent(trait ->
+                builder.append(trait.getValue())
+            );
+        shape
+            .getTrait(DeprecatedTrait.class)
+            .ifPresent(trait ->
+                builder
+                    .append("\n")
+                    .append(trait.getDeprecatedDescription(shape.getType()))
+            );
+        return builder.isEmpty() ? Optional.empty() : Optional.of(builder.toString().trim());
     }
 
     /**

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
@@ -346,7 +346,8 @@ final class JsonSchemaShapeVisitor extends ShapeVisitor.Default<Schema> {
                     .append("\n")
                     .append(trait.getDeprecatedDescription(shape.getType()))
             );
-        return builder.isEmpty() ? Optional.empty() : Optional.of(builder.toString().trim());
+        String description = builder.toString().trim();
+        return description.isEmpty() ? Optional.empty() : Optional.of(description);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/DeprecatedTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/DeprecatedTrait.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -70,6 +71,17 @@ public final class DeprecatedTrait extends AbstractTrait implements ToSmithyBuil
      */
     public Optional<String> getMessage() {
         return Optional.ofNullable(message);
+    }
+
+    public String getDeprecatedDescription(ShapeType shapeType) {
+        String shapeTypeString = shapeType == ShapeType.OPERATION ? "operation" : "shape";
+        if (getSince().isEmpty()) {
+            return getMessage().orElse("This " + shapeTypeString + " is deprecated.");
+        } else if (getMessage().isEmpty()) {
+            return "This " + shapeTypeString + " is deprecated since " + getSince().get();
+        } else {
+            return "This " + shapeTypeString + " is deprecated since " + getSince().get() + ": " + getMessage().get();
+        }
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/DeprecatedTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/DeprecatedTrait.java
@@ -75,14 +75,17 @@ public final class DeprecatedTrait extends AbstractTrait implements ToSmithyBuil
     }
 
     public String getDeprecatedDescription(ShapeType shapeType) {
-        String shapeTypeString = shapeType == ShapeType.OPERATION ? "operation" : "shape";
-        if (Objects.isNull(this.since)) {
-            return this.message != null ? this.message : "This " + shapeTypeString + " is deprecated.";
-        } else if (Objects.isNull(this.message)) {
-            return "This " + shapeTypeString + " is deprecated since " + this.since;
-        } else {
-            return "This " + shapeTypeString + " is deprecated since " + this.since + ": " + this.message;
+        StringBuilder builder = new StringBuilder("This ");
+        builder.append(shapeType == ShapeType.OPERATION ? "operation" : "shape").append(" is deprecated");
+        if (since != null) {
+            builder.append(" since ").append(since);
         }
+        if (message != null) {
+            builder.append(": ").append(message);
+        } else {
+            builder.append(".");
+        }
+        return builder.toString();
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/DeprecatedTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/DeprecatedTrait.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.model.traits;
 
+import java.util.Objects;
 import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
@@ -75,12 +76,12 @@ public final class DeprecatedTrait extends AbstractTrait implements ToSmithyBuil
 
     public String getDeprecatedDescription(ShapeType shapeType) {
         String shapeTypeString = shapeType == ShapeType.OPERATION ? "operation" : "shape";
-        if (getSince().isEmpty()) {
-            return getMessage().orElse("This " + shapeTypeString + " is deprecated.");
-        } else if (getMessage().isEmpty()) {
-            return "This " + shapeTypeString + " is deprecated since " + getSince().get();
+        if (Objects.isNull(this.since)) {
+            return this.message != null ? this.message : "This " + shapeTypeString + " is deprecated.";
+        } else if (Objects.isNull(this.message)) {
+            return "This " + shapeTypeString + " is deprecated since " + this.since;
         } else {
-            return "This " + shapeTypeString + " is deprecated since " + getSince().get() + ": " + getMessage().get();
+            return "This " + shapeTypeString + " is deprecated since " + this.since + ": " + this.message;
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/DeprecatedTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/DeprecatedTrait.java
@@ -15,7 +15,6 @@
 
 package software.amazon.smithy.model.traits;
 
-import java.util.Objects;
 import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/DeprecatedTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/DeprecatedTraitTest.java
@@ -60,13 +60,13 @@ public class DeprecatedTraitTest {
     @Test
     public void returnDescriptionWhenMessageSet() {
         DeprecatedTrait deprecatedTrait = DeprecatedTrait.builder().message("Use X shape instead.").build();
-        assertThat(deprecatedTrait.getDeprecatedDescription(ShapeType.STRING), equalTo("Use X shape instead."));
+        assertThat(deprecatedTrait.getDeprecatedDescription(ShapeType.STRING), equalTo("This shape is deprecated: Use X shape instead."));
     }
 
     @Test
     public void returnDescriptionWhenSinceSet() {
         DeprecatedTrait deprecatedTrait = DeprecatedTrait.builder().since("2020-01-01").build();
-        assertThat(deprecatedTrait.getDeprecatedDescription(ShapeType.STRING), equalTo("This shape is deprecated since 2020-01-01"));
+        assertThat(deprecatedTrait.getDeprecatedDescription(ShapeType.STRING), equalTo("This shape is deprecated since 2020-01-01."));
     }
 
     @Test

--- a/smithy-model/src/test/java/software/amazon/smithy/model/traits/DeprecatedTraitTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/traits/DeprecatedTraitTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.SourceException;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeType;
 
 public class DeprecatedTraitTest {
     @Test
@@ -47,5 +48,30 @@ public class DeprecatedTraitTest {
             TraitFactory provider = TraitFactory.createServiceFactory();
             provider.createTrait(ShapeId.from("smithy.api#deprecated"), ShapeId.from("ns.qux#foo"), Node.from("abc"));
         });
+    }
+
+    @Test
+    public void returnDefaultDescription() {
+        DeprecatedTrait deprecatedTrait = DeprecatedTrait.builder().build();
+        assertThat(deprecatedTrait.getDeprecatedDescription(ShapeType.OPERATION), equalTo("This operation is deprecated."));
+        assertThat(deprecatedTrait.getDeprecatedDescription(ShapeType.STRING), equalTo("This shape is deprecated."));
+    }
+
+    @Test
+    public void returnDescriptionWhenMessageSet() {
+        DeprecatedTrait deprecatedTrait = DeprecatedTrait.builder().message("Use X shape instead.").build();
+        assertThat(deprecatedTrait.getDeprecatedDescription(ShapeType.STRING), equalTo("Use X shape instead."));
+    }
+
+    @Test
+    public void returnDescriptionWhenSinceSet() {
+        DeprecatedTrait deprecatedTrait = DeprecatedTrait.builder().since("2020-01-01").build();
+        assertThat(deprecatedTrait.getDeprecatedDescription(ShapeType.STRING), equalTo("This shape is deprecated since 2020-01-01"));
+    }
+
+    @Test
+    public void returnDescriptionWhenBothSinceAndMessageSet() {
+        DeprecatedTrait deprecatedTrait = DeprecatedTrait.builder().since("2020-01-01").message("Use X shape instead.").build();
+        assertThat(deprecatedTrait.getDeprecatedDescription(ShapeType.STRING), equalTo("This shape is deprecated since 2020-01-01: Use X shape instead."));
     }
 }


### PR DESCRIPTION

#### Background
The objective is to add `@deprecated` to the description of the definition in OpenAPI.

Let me know if this makes sense or if the way the description is built makes sense.

#### Testing

Added a couple of tests.
