### PR TITLE
Fix gradle plugin version in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,5 +109,5 @@ def setup(sphinx):
 # rewrites __smithy_gradle_version__ to the latest version found on Github
 def source_read_handler(app, docname, source):
     source[0] = source[0].replace(smithy_version_placeholder, smithy_version)
-    source[0] = source[0].replace(smithy_gradle_version_placeholder, smithy_typescript_codegen_version)
+    source[0] = source[0].replace(smithy_gradle_version_placeholder, smithy_gradle_plugin_version)
     source[0] = source[0].replace(smithy_typescript_version_placeholder, smithy_typescript_codegen_version)


### PR DESCRIPTION
#### Background
Noticed on https://smithy.io/2.0/guides/gradle-plugin/index.html that the version of gradle plugin is `0.20.0`. Was expecting to see the new `1.0.0` or even the older `0.10.0` but `0.20.0` meant something is quite wrong. Found that we had a typo in the docs/conf.py

#### Testing
```
make install
make html
open build/html/2.0/index.html
```
to see the new expected output.

#### Links

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
