### PR TITLE
[docs] Update caption for gradle migration guide to 0.10.0

### DIFF
--- a/docs/source-2.0/guides/gradle-plugin/index.rst
+++ b/docs/source-2.0/guides/gradle-plugin/index.rst
@@ -10,7 +10,7 @@ build artifacts from Smithy models, and generate JARs for Smithy models and mode
 
 .. toctree::
     :maxdepth: 1
-    :caption: Migrate to version 0.8.0+
+    :caption: Migrate to version 0.10.0+
 
     gradle-migration-guide
 


### PR DESCRIPTION
#### Background
Guide is now for 0.10.0, so caption needs update to match

#### Testing
```
make install
make html
open build/html/2.0/index.html
```
to see the expected output

#### Links

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
