### PR TITLE
Nested xml map with xml name

### DIFF
--- a/smithy-aws-protocol-tests/model/restXml/document-maps.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-maps.smithy
@@ -658,10 +658,10 @@ operation NestedXmlMapWithXmlName {
 }
 
 structure NestedXmlMapWithXmlNameInputOutput {
-    nestedXmlMapWithXmlName: NestedXmlMapWithXmlName
+    nestedXmlMapWithXmlNameMap: NestedXmlMapWithXmlNameMap
 }
 
-map NestedXmlMapWithXmlName{
+map NestedXmlMapWithXmlNameMap{
     @xmlName("OuterKey")
     key: String
     
@@ -684,7 +684,7 @@ apply NestedXmlMapWithXmlName @httpResponseTests([
         code: 200,
         body: """
             <NestedXmlMapWithXmlNameResponse>
-                <nestedXmlMapWithXmlName>
+                <nestedXmlMapWithXmlNameMap>
                     <entry>
                         <OuterKey>foo</OuterKey>
                         <value>
@@ -711,15 +711,15 @@ apply NestedXmlMapWithXmlName @httpResponseTests([
                             </entry>
                         </value>
                     </entry>
-                </nestedXmlMapWithXmlName>
-            <NestedXmlMapWithXmlNameResponse>
+                </nestedXmlMapWithXmlNameMap>
+            </NestedXmlMapWithXmlNameResponse>
         """
         bodyMediaType: "application/xml",
         headers: {
             "Content-Type": "application/xml"
         }
         params: {
-            nestedXmlMapWithXmlName: {
+            nestedXmlMapWithXmlNameMap: {
                 foo: {
                     bar: "Baz",
                     fizz: "Buzz"

--- a/smithy-aws-protocol-tests/model/restXml/document-maps.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-maps.smithy
@@ -682,7 +682,7 @@ apply NestedXmlMapWithXmlName @httpResponseTests([
         documentation: "Serializes nested XML maps in responses that have xmlName on members"
         protocol: restXml,
         code: 200,
-        body:"""
+        body: """
             <NestedXmlMapWithXmlNameResponse>
                 <nestedXmlMapWithXmlName>
                     <entry>

--- a/smithy-aws-protocol-tests/model/restXml/document-maps.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-maps.smithy
@@ -650,6 +650,89 @@ apply NestedXmlMaps @httpResponseTests([
     },
 ])
 
+/// Nested Xml Maps with key/values with @xmlName
+@http(uri: "/NestedXmlMapWithXmlName", method: "POST")
+operation NestedXmlMapWithXmlName {
+    input: NestedXmlMapWithXmlNameInputOutput
+    output: NestedXmlMapWithXmlNameInputOutput
+}
+
+structure NestedXmlMapWithXmlNameInputOutput {
+    nestedXmlMapWithXmlName: NestedXmlMapWithXmlName
+}
+
+map NestedXmlMapWithXmlName{
+    @xmlName("OuterKey")
+    key: String
+    
+    value: NestedXmlMapWithXmlNameInnerMap
+}
+
+map NestedXmlMapWithXmlNameInnerMap{
+    @xmlName("InnerKey")
+    key: String
+    
+    @xmlName("InnerValue")
+    value: String
+}
+
+apply NestedXmlMapWithXmlName @httpResponseTests([
+    {
+        id: "NestedXmlMapWithXmlName"
+        documentation: "Serializes nested XML maps in responses that have xmlName on members"
+        protocol: restXml,
+        code: 200,
+        body:"""
+            <NestedXmlMapWithXmlNameResponse>
+                <nestedXmlMapWithXmlName>
+                    <entry>
+                        <OuterKey>foo</OuterKey>
+                        <value>
+                            <entry>
+                                <InnerKey>bar</InnerKey>
+                                <InnerValue>Baz</InnerValue>
+                            </entry>
+                            <entry>
+                                <InnerKey>fizz</InnerKey>
+                                <InnerValue>Buzz</InnerValue>
+                            </entry>
+                        </value>
+                    </entry>
+                    <entry>
+                        <OuterKey>qux</OuterKey>
+                        <value>
+                            <entry>
+                                <InnerKey>foobar</InnerKey>
+                                <InnerValue>Bar</InnerValue>
+                            </entry>
+                            <entry>
+                                <InnerKey>fizzbuzz</InnerKey>
+                                <InnerValue>Buzz</InnerValue>
+                            </entry>
+                        </value>
+                    </entry>
+                </nestedXmlMapWithXmlName>
+            <NestedXmlMapWithXmlNameResponse>
+        """
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml"
+        }
+        params: {
+            nestedXmlMapWithXmlName: {
+                foo: {
+                    bar: "Baz",
+                    fizz: "Buzz"
+                },
+                qux: {
+                    foobar: "Bar",
+                    fizzbuzz: "Buzz"
+                }
+            }
+        }
+    }
+])
+
 /// Maps with @xmlNamespace and @xmlName
 @http(uri: "/XmlMapWithXmlNamespace", method: "POST")
 operation XmlMapWithXmlNamespace {

--- a/smithy-aws-protocol-tests/model/restXml/document-maps.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/document-maps.smithy
@@ -676,10 +676,72 @@ map NestedXmlMapWithXmlNameInnerMap{
     value: String
 }
 
+apply NestedXmlMapWithXmlName @httpRequestTests([
+    {
+        id : "NestedXmlMapWithXmlNameSerializes",
+        documentation : "Serializes nested XML Maps in requests that have xmlName on members",
+        protocol: restXml,
+        method: "POST",
+        uri: "/NestedXmlMapWithXmlName",
+        body: """
+            <NestedXmlMapWithXmlNameRequest>
+                <nestedXmlMapWithXmlNameMap>
+                    <entry>
+                        <OuterKey>foo</OuterKey>
+                        <value>
+                            <entry>
+                                <InnerKey>bar</InnerKey>
+                                <InnerValue>Baz</InnerValue>
+                            </entry>
+                            <entry>
+                                <InnerKey>fizz</InnerKey>
+                                <InnerValue>Buzz</InnerValue>
+                            </entry>
+                        </value>
+                    </entry>
+                    <entry>
+                        <OuterKey>qux</OuterKey>
+                        <value>
+                            <entry>
+                                <InnerKey>foobar</InnerKey>
+                                <InnerValue>Bar</InnerValue>
+                            </entry>
+                            <entry>
+                                <InnerKey>fizzbuzz</InnerKey>
+                                <InnerValue>Buzz</InnerValue>
+                            </entry>
+                        </value>
+                    </entry>
+                </nestedXmlMapWithXmlNameMap>
+            </NestedXmlMapWithXmlNameRequest>
+        """,
+        bodyMediaType: "application/xml",
+        headers: {
+            "Content-Type": "application/xml",
+        },
+        params: {
+            nestedXmlMapWithXmlNameMap: {
+                foo: {
+                    bar: "Baz",
+                    fizz: "Buzz"
+                },
+                qux: {
+                    foobar: "Bar",
+                    fizzbuzz: "Buzz"
+                }
+            }
+        }
+    }
+
+
+
+
+])
+
 apply NestedXmlMapWithXmlName @httpResponseTests([
     {
-        id: "NestedXmlMapWithXmlName"
-        documentation: "Serializes nested XML maps in responses that have xmlName on members"
+        id: "NestedXmlMapWithXmlNameDeserializes",
+        documentation: "Serializes nested XML maps in responses that have xmlName on members",
         protocol: restXml,
         code: 200,
         body: """


### PR DESCRIPTION
#### Background
* What do these changes do? 
Adds a protocol test for the restXml protocol for unmarshalling a response that contains a nested xml map with the `@xmlName `trait applied to both key and value pairs

* Why are they important?
While implementing other protocol tests we realized that this was a gap in our generator, but it was hard to fix without an existing protocol test. This drives TDD for us.


#### Testing
* How did you test these changes?
```
./gradlew :smithy-aws-protocol-tests:build 
PS C:\Dev\Repos\smithy-fork> ./gradlew :smithy-aws-protocol-tests:build
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true

> Configure project :
Smithy version: '1.47.0'

> Task :smithy-validation-model:smithyFormat
Running smithy format

> Task :smithy-aws-protocol-tests:smithyBuild
Running smithy build
SUCCESS: Validated 2831 shapes

Validated model, now starting projections...

ΓöÇΓöÇ  source  ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
Completed projection source (2831): C:\Dev\Repos\smithy-fork\smithy-aws-protocol-tests\build\smithyprojections\smithy-aws-protocol-tests\source

Summary: Smithy built 1 projection(s), 3 plugin(s), and 134 artifacts

> Task :smithy-aws-protocol-tests:smithyJarValidate
Running smithy validate
SUCCESS: Validated 2831 shapes


Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.6/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 4s
36 actionable tasks: 8 executed, 28 up-to-date
```
#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
