### PR TITLE
Fix issues with RPCv2 CBOR protocol tests

### DIFF
--- a/smithy-protocol-tests/model/rpcv2Cbor/cbor-lists.smithy
+++ b/smithy-protocol-tests/model/rpcv2Cbor/cbor-lists.smithy
@@ -45,9 +45,11 @@ apply RpcV2CborLists @httpRequestTests([
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             "stringList": [
                 "foo",
@@ -114,9 +116,11 @@ apply RpcV2CborLists @httpRequestTests([
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             stringList: []
         }
@@ -132,9 +136,11 @@ apply RpcV2CborLists @httpRequestTests([
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             stringList: []
         }
@@ -149,9 +155,11 @@ apply RpcV2CborLists @httpRequestTests([
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             stringList: ["An example indefinite string, which will be chunked, on each comma", "Another example indefinite string with only one chunk", "This is a plain string"]
         }
@@ -167,9 +175,11 @@ apply RpcV2CborLists @httpRequestTests([
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             stringList: ["An example indefinite string, which will be chunked, on each comma", "Another example indefinite string with only one chunk", "This is a plain string"]
         },
@@ -333,9 +343,11 @@ structure StructureListMember {
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: "v29zcGFyc2VTdHJpbmdNYXC/Y2Zvb/b//w=="
         params: {
             "sparseStringMap": {
@@ -352,9 +364,11 @@ structure StructureListMember {
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: "v3BzcGFyc2VTdHJpbmdMaXN0n/b//w=="
         params: {
             "sparseStringList": [

--- a/smithy-protocol-tests/model/rpcv2Cbor/cbor-maps.smithy
+++ b/smithy-protocol-tests/model/rpcv2Cbor/cbor-maps.smithy
@@ -29,9 +29,11 @@ apply RpcV2CborDenseMaps @httpRequestTests([
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             "denseStructMap": {
                 "foo": {
@@ -53,9 +55,11 @@ apply RpcV2CborDenseMaps @httpRequestTests([
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             "denseNumberMap": {
                 "x": 0
@@ -75,9 +79,11 @@ apply RpcV2CborDenseMaps @httpRequestTests([
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             "denseSetMap": {
                 "x": [],
@@ -217,9 +223,11 @@ apply RpcV2CborSparseMaps @httpRequestTests([
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             "sparseStructMap": {
                 "foo": {
@@ -241,9 +249,11 @@ apply RpcV2CborSparseMaps @httpRequestTests([
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             "sparseBooleanMap": {
                 "x": null
@@ -269,9 +279,11 @@ apply RpcV2CborSparseMaps @httpRequestTests([
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             "sparseSetMap": {
                 "x": [],
@@ -289,9 +301,11 @@ apply RpcV2CborSparseMaps @httpRequestTests([
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             "sparseSetMap": {
                 "x": [],
@@ -310,9 +324,11 @@ apply RpcV2CborSparseMaps @httpRequestTests([
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             "sparseNumberMap": {
                 "x": 0

--- a/smithy-protocol-tests/model/rpcv2Cbor/cbor-structs.smithy
+++ b/smithy-protocol-tests/model/rpcv2Cbor/cbor-structs.smithy
@@ -13,9 +13,11 @@ use smithy.test#httpResponseTests
         documentation: "Serializes simple scalar properties",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         }
+        requireHeaders: [
+            "Content-Length"
+        ],
         method: "POST",
         bodyMediaType: "application/cbor",
         uri: "/service/RpcV2Protocol/operation/SimpleScalarProperties",
@@ -42,9 +44,11 @@ use smithy.test#httpResponseTests
             a key encoded using an indefinite length string.""",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         }
+        requireHeaders: [
+            "Content-Length"
+        ],
         method: "POST",
         bodyMediaType: "application/cbor",
         uri: "/service/RpcV2Protocol/operation/SimpleScalarProperties",
@@ -73,9 +77,11 @@ use smithy.test#httpResponseTests
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         }
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             stringValue: null
         },
@@ -91,9 +97,11 @@ use smithy.test#httpResponseTests
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         }
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {},
         appliesTo: "server"
     },
@@ -103,9 +111,11 @@ use smithy.test#httpResponseTests
         documentation: "Supports handling NaN float values.",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         }
+        requireHeaders: [
+            "Content-Length"
+        ],
         method: "POST",
         bodyMediaType: "application/cbor",
         uri: "/service/RpcV2Protocol/operation/SimpleScalarProperties",
@@ -121,9 +131,11 @@ use smithy.test#httpResponseTests
         documentation: "Supports handling Infinity float values.",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         }
+        requireHeaders: [
+            "Content-Length"
+        ],
         method: "POST",
         bodyMediaType: "application/cbor",
         uri: "/service/RpcV2Protocol/operation/SimpleScalarProperties",
@@ -139,9 +151,11 @@ use smithy.test#httpResponseTests
         documentation: "Supports handling Infinity float values.",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         }
+        requireHeaders: [
+            "Content-Length"
+        ],
         method: "POST",
         bodyMediaType: "application/cbor",
         uri: "/service/RpcV2Protocol/operation/SimpleScalarProperties",
@@ -157,9 +171,11 @@ use smithy.test#httpResponseTests
         documentation: "The server should be capable of deserializing indefinite length text strings.",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         }
+        requireHeaders: [
+            "Content-Length"
+        ],
         method: "POST",
         bodyMediaType: "application/cbor",
         uri: "/service/RpcV2Protocol/operation/SimpleScalarProperties",
@@ -175,9 +191,11 @@ use smithy.test#httpResponseTests
         documentation: "The server should be capable of deserializing indefinite length byte strings.",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         }
+        requireHeaders: [
+            "Content-Length"
+        ],
         method: "POST",
         bodyMediaType: "application/cbor",
         uri: "/service/RpcV2Protocol/operation/SimpleScalarProperties",
@@ -193,9 +211,11 @@ use smithy.test#httpResponseTests
         documentation: "Supports upcasting from a smaller byte representation of the same data type.",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         }
+        requireHeaders: [
+            "Content-Length"
+        ],
         method: "POST",
         bodyMediaType: "application/cbor",
         uri: "/service/RpcV2Protocol/operation/SimpleScalarProperties",
@@ -218,9 +238,11 @@ use smithy.test#httpResponseTests
             generated against an older Smithy model.""",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         }
+        requireHeaders: [
+            "Content-Length"
+        ],
         method: "POST",
         bodyMediaType: "application/cbor",
         uri: "/service/RpcV2Protocol/operation/SimpleScalarProperties",
@@ -431,9 +453,11 @@ apply RecursiveShapes @httpRequestTests([
         bodyMediaType: "application/cbor",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         params: {
             nested: {
                 foo: "Foo1",

--- a/smithy-protocol-tests/model/rpcv2Cbor/defaults.smithy
+++ b/smithy-protocol-tests/model/rpcv2Cbor/defaults.smithy
@@ -18,9 +18,11 @@ apply OperationWithDefaults @httpRequestTests([
         uri: "/service/RpcV2Protocol/operation/OperationWithDefaults",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         bodyMediaType: "application/cbor"
         body: "v21kZWZhdWx0U3RyaW5nYmhpbmRlZmF1bHRCb29sZWFu9WtkZWZhdWx0TGlzdIBwZGVmYXVsdFRpbWVzdGFtcMH7AAAAAAAAAABrZGVmYXVsdEJsb2JDYWJja2RlZmF1bHRCeXRlAWxkZWZhdWx0U2hvcnQBbmRlZmF1bHRJbnRlZ2VyCmtkZWZhdWx0TG9uZxhkbGRlZmF1bHRGbG9hdPo/gAAAbWRlZmF1bHREb3VibGX7P/AAAAAAAABqZGVmYXVsdE1hcKBrZGVmYXVsdEVudW1jRk9PbmRlZmF1bHRJbnRFbnVtAWtlbXB0eVN0cmluZ2BsZmFsc2VCb29sZWFu9GllbXB0eUJsb2JAaHplcm9CeXRlAGl6ZXJvU2hvcnQAa3plcm9JbnRlZ2VyAGh6ZXJvTG9uZwBpemVyb0Zsb2F0+gAAAABqemVyb0RvdWJsZfsAAAAAAAAAAP8="
         params: {
@@ -38,9 +40,11 @@ apply OperationWithDefaults @httpRequestTests([
         uri: "/service/RpcV2Protocol/operation/OperationWithDefaults",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: "v/8="
         params: {
         }
@@ -56,9 +60,11 @@ apply OperationWithDefaults @httpRequestTests([
         uri: "/service/RpcV2Protocol/operation/OperationWithDefaults",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: "v2hkZWZhdWx0c7dtZGVmYXVsdFN0cmluZ2NieWVuZGVmYXVsdEJvb2xlYW71a2RlZmF1bHRMaXN0gWFhcGRlZmF1bHRUaW1lc3RhbXDB+z/wAAAAAAAAa2RlZmF1bHRCbG9iQmhpa2RlZmF1bHRCeXRlAmxkZWZhdWx0U2hvcnQCbmRlZmF1bHRJbnRlZ2VyFGtkZWZhdWx0TG9uZxjIbGRlZmF1bHRGbG9hdPpAAAAAbWRlZmF1bHREb3VibGX7QAAAAAAAAABqZGVmYXVsdE1hcKFkbmFtZWRKYWNra2RlZmF1bHRFbnVtY0JBUm5kZWZhdWx0SW50RW51bQJrZW1wdHlTdHJpbmdjZm9vbGZhbHNlQm9vbGVhbvVpZW1wdHlCbG9iQmhpaHplcm9CeXRlAWl6ZXJvU2hvcnQBa3plcm9JbnRlZ2VyAWh6ZXJvTG9uZwFpemVyb0Zsb2F0+j+AAABqemVyb0RvdWJsZfs/8AAAAAAAAP8="
         params: {
             defaults: {
@@ -99,9 +105,11 @@ apply OperationWithDefaults @httpRequestTests([
         uri: "/service/RpcV2Protocol/operation/OperationWithDefaults",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: "v2hkZWZhdWx0c6D/"
         params: {
             defaults: {
@@ -144,9 +152,11 @@ apply OperationWithDefaults @httpRequestTests([
         uri: "/service/RpcV2Protocol/operation/OperationWithDefaults",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: "v290b3BMZXZlbERlZmF1bHRiaGl0b3RoZXJUb3BMZXZlbERlZmF1bHQA/w=="
         params: {
             topLevelDefault: "hi",
@@ -164,9 +174,11 @@ apply OperationWithDefaults @httpRequestTests([
         uri: "/service/RpcV2Protocol/operation/OperationWithDefaults",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         body: "v3ZjbGllbnRPcHRpb25hbERlZmF1bHRzoP8="
         params: {
             clientOptionalDefaults: {}

--- a/smithy-protocol-tests/model/rpcv2Cbor/empty-input-output.smithy
+++ b/smithy-protocol-tests/model/rpcv2Cbor/empty-input-output.smithy
@@ -14,7 +14,6 @@ use smithy.test#httpResponseTests
         documentation: "Body is empty and no Content-Type header if no input",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
         },
         forbidHeaders: [
             "Content-Type",
@@ -109,9 +108,11 @@ operation NoInputOutput {}
         documentation: "When Input structure is empty we write CBOR equivalent of {}",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
+        requireHeaders: [
+            "Content-Length"
+        ],
         forbidHeaders: [
             "X-Amz-Target"
         ]
@@ -124,6 +125,22 @@ operation NoInputOutput {}
         id: "empty_input_no_body",
         protocol: rpcv2Cbor,
         documentation: "When Input structure is empty the server should accept an empty body",
+        headers: {
+            "smithy-protocol": "rpc-v2-cbor",
+            "Content-Type": "application/cbor"
+        },
+        method: "POST",
+        uri: "/service/RpcV2Protocol/operation/EmptyInputOutput",
+        bodyMediaType: "application/cbor",
+        body: "",
+        appliesTo: "server"
+    },
+    {
+        id: "empty_input_no_body_has_accept",
+        protocol: rpcv2Cbor,
+        documentation: """
+            When input structure, is empty the server should accept an empty body
+            even if the Accept header is set.""",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
             "Accept": "application/cbor",
@@ -175,7 +192,6 @@ operation EmptyInputOutput {
         documentation: "When input is empty we write CBOR equivalent of {}",
         headers: {
             "smithy-protocol": "rpc-v2-cbor",
-            "Accept": "application/cbor",
             "Content-Type": "application/cbor"
         },
         forbidHeaders: [


### PR DESCRIPTION
1. Add Content-Length expectation for requests with bodies
2. Remove Accept headers from authoritative tests

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
