### PR TITLE
Add typed properties for TypedPropertiesBag

### DIFF
--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/Property.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/Property.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.codegen.core;
+
+import java.util.Objects;
+
+/**
+ * A {@code Property} provides an identity-based, immutable token for a property.
+ *
+ * <p>The token also contains a name used to describe the value.
+ */
+public final class Property<T> {
+
+    private final String name;
+
+    /**
+     * @param name Name of the value.
+     */
+    public Property(String name) {
+        this.name = Objects.requireNonNull(name);
+    }
+
+    /**
+     * Create a new identity-based property key.
+     *
+     * @param name Name of the property.
+     * @param <T> value type associated with the property.
+     * @return the created property.
+     */
+    public static <T> Property<T> named(String name) {
+        return new Property<>(name);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/TypedPropertiesBag.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/TypedPropertiesBag.java
@@ -62,6 +62,7 @@ class TypedPropertiesBag {
      * Get a typed property if present.
      *
      * @param property   property key to get by exact reference identity.
+     * @param <T> value type of the property
      * @return Returns the optionally found property.
      */
     @SuppressWarnings("unchecked")
@@ -123,8 +124,8 @@ class TypedPropertiesBag {
      * Get a property and throw if it isn't present.
      *
      * @param property property key to get by exact reference identity.
-     * @param <T> Returns the value.
-     * @throws NullPointerException if the property isn't found.
+     * @param <T> value type of the property.
+     * @throws IllegalArgumentException if the property isn't found.
      */
     <T> T expectProperty(Property<T> property) {
         return getProperty(property).orElseThrow(() -> new IllegalArgumentException(String.format(

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/TypedPropertiesBag.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/TypedPropertiesBag.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.codegen.core;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -44,8 +45,8 @@ class TypedPropertiesBag {
      *
      * @return Returns a map of additional typed properties.
      */
-    public Map<Property<?>, Object> getTypedProperties() {
-        return typedProperties;
+    public Iterator<Property<?>> getTypedProperties() {
+        return typedProperties.keySet().iterator();
     }
 
     /**

--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/SymbolTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/SymbolTest.java
@@ -19,10 +19,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
 
+import java.util.Map;
+import java.util.Properties;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.utils.MapUtils;
 
 public class SymbolTest {
     @Test
@@ -38,7 +42,7 @@ public class SymbolTest {
     }
 
     @Test
-    public void getsTypedProperties() {
+    public void getsPropertiesFromClass() {
         Symbol symbol = Symbol.builder()
                 .name("foo")
                 .putProperty("baz", "bar")
@@ -50,11 +54,36 @@ public class SymbolTest {
     }
 
     @Test
+    public void getsTypedProperties() {
+        Property<String> stringProperty = Property.named("string");
+        Property<Integer> integerProperty = Property.named("int");
+
+        Symbol symbol = Symbol.builder()
+                .name("foo")
+                .putProperty(stringProperty, "foo")
+                .putProperty(integerProperty, 100)
+                .build();
+
+        assertThat(symbol.expectProperty(stringProperty), equalTo("foo"));
+        assertThat(symbol.expectProperty(integerProperty), equalTo(100));
+    }
+
+    @Test
     public void throwsIfExpectedPropertyIsNotPresent() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             Symbol symbol = Symbol.builder().name("foo").build();
 
             symbol.expectProperty("baz");
+        });
+    }
+
+    @Test
+    public void throwsIfExpectedTypedPropertyIsNotPresent() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            Property<String> prop = Property.named("prop");
+            Symbol symbol = Symbol.builder().name("foo").build();
+
+            symbol.expectProperty(prop);
         });
     }
 


### PR DESCRIPTION
#### Background
Adds a strongly typed Key to the typed properties bag used by Symbols in codegen. These changes are intended to improve the experience of using Symbol properties in code generators. Usage of these new typed properties would look like: 

```java
Property<String> myStringProperty = Property.named("string property"); 

Symbol symbol = Symbol.builder()
                .name("foo")
                .putProperty(myStringProperty, "foo")
                .build()
                
String result = symbol.expectProperty(myStringProperty);
```

#### Testing
Added new unit tests

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
