### PR TITLE
Fix a timing issue in the waiters retry delay calculation

### DIFF
--- a/docs/source-1.0/spec/waiters.rst
+++ b/docs/source-1.0/spec/waiters.rst
@@ -190,12 +190,12 @@ exponential backoff with jitter through the following algorithm:
     delay = random(minDelay, delay)
 
     if remainingTime - delay <= minDelay:
-        delay = remainingTime - minDelay
+        delay = remainingTime
 
 If the computed ``delay`` subtracted from ``remainingTime`` is less than
-or equal to ``minDelay``, then set ``delay`` to ``remainingTime`` minus
-``minDelay`` and perform one last retry. This prevents a waiter from waiting
-needlessly only to exceed ``maxWaitTime`` before issuing a final request.
+or equal to ``minDelay``, then set ``delay`` to ``remainingTime`` and
+perform one last retry. This prevents a waiter from waiting needlessly
+only to exceed ``maxWaitTime`` before issuing a final request.
 
 Using the default ``minDelay`` of 2, the default ``maxDelay`` of 120, a caller
 provided ``maxWaitTime`` of 300 (5 minutes), and assuming that requests

--- a/docs/source-2.0/additional-specs/waiters.rst
+++ b/docs/source-2.0/additional-specs/waiters.rst
@@ -191,12 +191,12 @@ exponential backoff with jitter through the following algorithm:
     delay = random(minDelay, delay)
 
     if remainingTime - delay <= minDelay:
-        delay = remainingTime - minDelay
+        delay = remainingTime
 
 If the computed ``delay`` subtracted from ``remainingTime`` is less than
-or equal to ``minDelay``, then set ``delay`` to ``remainingTime`` minus
-``minDelay`` and perform one last retry. This prevents a waiter from waiting
-needlessly only to exceed ``maxWaitTime`` before issuing a final request.
+or equal to ``minDelay``, then set ``delay`` to ``remainingTime`` and
+perform one last retry. This prevents a waiter from waiting needlessly
+only to exceed ``maxWaitTime`` before issuing a final request.
 
 Using the default ``minDelay`` of 2, the default ``maxDelay`` of 120, a caller
 provided ``maxWaitTime`` of 300 (5 minutes), and assuming that requests
@@ -259,8 +259,8 @@ follows:
       - 296
       - 4
     * - 13 (last attempt)
-      - 2
-      - 298
+      - 4
+      - 300
       - N/A
 
 .. note::


### PR DESCRIPTION
#### Background
Subtracting `minDelay` from `remainingTime` results in the waiter exiting before the user's desired max wait time. This is especially apparent in models that use a `minDelay` value that is larger than the default 2 seconds. For example, AWS EC2 uses 15 seconds, so it would exit the waiter a full 15 seconds before the desired max wait time.

#### Testing
Tested these changes in the implementation of waiters for the AWS Rust SDK.

#### Links
* [AWS Rust SDK waiters implementation PR](https://github.com/smithy-lang/smithy-rs/pull/3595)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
