### PR TITLE
Fix @externalDocumentation rendering

### DIFF
--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/javadoc/ExternalDocsInterceptor.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/javadoc/ExternalDocsInterceptor.java
@@ -23,7 +23,7 @@ final class ExternalDocsInterceptor implements CodeInterceptor.Appender<JavaDocS
         // Add a space to make it easier to read
         writer.writeDocStringContents("");
         for (Map.Entry<String, String> entry : trait.getUrls().entrySet()) {
-            writer.writeDocStringContents("@see <a href=$S>$L</a>", entry.getKey(), entry.getValue());
+            writer.writeDocStringContents("@see <a href=$S>$L</a>", entry.getValue(), entry.getKey());
         }
     }
 

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/structures/structure-trait.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/structures/structure-trait.smithy
@@ -2,8 +2,16 @@ $version: "2.0"
 
 namespace test.smithy.traitcodegen.structures
 
+/// structureTrait docs
+@externalDocumentation(
+    "External docs": "https://external.docs/structureTrait"
+)
 @trait
 structure structureTrait {
+
+    @externalDocumentation(
+        "External docs": "https://external.docs/structureTrait#fieldA"
+    )
     @required
     @pattern("^[^#+]+$")
     fieldA: String


### PR DESCRIPTION
#### Background

Currently the `key` and `value` from the `@externalDocumentation` trait is taken in the wrong order, leading to rendering of the following:

```
<a href="External docs">https://external.docs/structureTrait</a>
```



* What do these changes do? 
* Why are they important?

#### Testing
* How did you test these changes? Added unit test

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
