### PR TITLE
Revert EC2 Query Protocol empty list serialization

### DIFF
--- a/smithy-aws-protocol-tests/model/ec2Query/input-lists.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/input-lists.smithy
@@ -42,14 +42,16 @@ apply QueryLists @httpRequestTests([
     },
     {
         id: "Ec2EmptyQueryLists",
-        documentation: "Serializes empty query lists",
+        // Empty lists are NOT serialized for the EC2 query protocol, which differs from the AWS query protocol.
+        // See "EmptyQueryLists" for the AWS query protocol equivalent test case.
+        documentation: "Does not serialize empty query lists.",
         protocol: ec2Query,
         method: "POST",
         uri: "/",
         headers: {
             "Content-Type": "application/x-www-form-urlencoded"
         },
-        body: "Action=QueryLists&Version=2020-01-08&ListArg=",
+        body: "Action=QueryLists&Version=2020-01-08",
         bodyMediaType: "application/x-www-form-urlencoded",
         params: {
             ListArg: []


### PR DESCRIPTION
## Overview

Revert EC2 Query Protocol empty list serialization.

Empty lists are NOT serialized for the EC2 query protocol, which differs from the AWS query protocol.
See "EmptyQueryLists" for the AWS query protocol equivalent test case.

This is needed since SDKs that conform to the broken protocol tests will send invalid requests to EC2.

## Testing

Tested with aws-sdk-js-v3 locally ([smithy-typescript](https://github.com/syall/smithy-typescript/tree/temp-fork), [aws-sdk-js-v3](https://github.com/syall/aws-sdk-js-v3/tree/temp-fork)) sending a previously failing command with the error `InvalidRequest: The request received was invalid.` now with the correct validation error.

```javascript
const { EC2Client: Client, DescribeKeyPairsCommand: Command } = require("@aws-sdk/client-ec2");

(async () => {
    const client = new Client();
    client.middlewareStack.add(next => async (args) => {
        console.info(args.request.body);
        return await next(args);
    }, { step: 'finalizeRequest' });
    try {
        await client.send(new Command({
            Filters: [],
            KeyPairIds: ["key-KEYISNOTREALATALL"],
        }));
    } catch (error) {
        console.error(error);
    }
})();
```

Before:

```log
Filter=&KeyPairId.1=key-KEYISNOTREALATALL&Action=DescribeKeyPairs&Version=2016-11-15
InvalidRequest: The request received was invalid.
```

After:

```log
KeyPairId.1=key-KEYISNOTREALATALL&Action=DescribeKeyPairs&Version=2016-11-15
InvalidParameterValue: Invalid value 'key-KEYISNOTREALATALL' for keyPairId.
```

The `Filter=` empty list serialization is removed.

```diff
- Filter=&KeyPairId.1=key-KEYISNOTREALATALL&Action=DescribeKeyPairs&Version=2016-11-15
+ KeyPairId.1=key-KEYISNOTREALATALL&Action=DescribeKeyPairs&Version=2016-11-15
```

## Links

* AWS EC2 Query Protocol: https://smithy.io/2.0/aws/protocols/aws-ec2-query-protocol.html
* Original empty list serialization PR: #1444
* Customer reports from AWS SDK for Go v2: aws/aws-sdk-go-v2#2624 aws/aws-sdk-go-v2#2559
* Botocore AWS EC2 Query Protocol List serialization: https://github.com/boto/botocore/blob/develop/botocore/serialize.py#L337
* Botocore AWS Query Protocol List serialization: https://github.com/boto/botocore/blob/develop/botocore/serialize.py#L259

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
