### PR TITLE
Use correct case for aggregate shapes in table

### DIFF
--- a/docs/source-2.0/spec/model.rst
+++ b/docs/source-2.0/spec/model.rst
@@ -423,13 +423,13 @@ Shape types are grouped into three categories:
 
         * - Type
           - Description
-        * - :ref:`list`
+        * - :ref:`list <list>`
           - Ordered collection of homogeneous values
-        * - :ref:`map`
+        * - :ref:`map <map>`
           - Map data structure that maps string keys to homogeneous values
-        * - :ref:`structure`
+        * - :ref:`structure <structure>`
           - Fixed set of named heterogeneous members
-        * - :ref:`union`
+        * - :ref:`union <union>`
           - Tagged union data structure that can take on one of several
             different, but fixed, types
 :ref:`Service types <service-types>`


### PR DESCRIPTION
#### Background
Updates the table in https://smithy.io/2.0/spec/model.html#shape-types for Aggregate types to use the casing of the actual shape names, like `list` instead of `List`. 

Note, this doesn't change the heading on the page https://smithy.io/2.0/spec/aggregate-types.html#list which is still `List`. We could consider changing the headings to match the shape name too, like for [simple types](https://smithy.io/2.0/spec/simple-types.html), though we use uppercase for [service types](https://smithy.io/2.0/spec/service-types.html). Additional to this PR, if we want to change the headings to match the shape name, can do that separately.

#### Testing
```
cd docs
make install
make html
open build/html/2.0/index.html
```
Ran above and verified table has lower case in type column.


#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
