### PR TITLE
Fix http status code in restXml response protocol test

### DIFF
--- a/smithy-aws-protocol-tests/model/restXml/errors.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/errors.smithy
@@ -103,7 +103,7 @@ apply ComplexError @httpResponseTests([
                 Foo: "bar"
             }
         },
-        code: 400,
+        code: 403,
         headers: {
             "Content-Type": "application/xml",
             "X-Header": "Header",


### PR DESCRIPTION
#### Background
* Change the http status code from 400 to 403 as specified by the [httpError trait on the error shape](https://github.com/smithy-lang/smithy/blob/main/smithy-aws-protocol-tests/model/restXml/errors.smithy#L84).

#### Testing
* Local build

#### Links
* The [smithy docs for restXml](https://smithy.io/2.0/aws/protocols/aws-restxml-protocol.html#supported-traits) includes httpError in the list of supported traits.
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
