### PR TITLE
Fix formatter to correctly convert invalid doc comments

### DIFF
--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FixBadDocComments.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FixBadDocComments.java
@@ -67,6 +67,11 @@ final class FixBadDocComments implements Function<TokenTree, TokenTree> {
             updateNestedChildren(cursor);
         }
 
+        // Doc comments should not appear in TRAIT_STATEMENTS.
+        for (TreeCursor cursor : shapeSection.findChildrenByType(TreeType.TRAIT_STATEMENTS)) {
+            updateNestedChildren(cursor);
+        }
+
         // Fix doc comments that come before apply statements.
         TreeCursor shapeStatements = shapeSection.getFirstChild(TreeType.SHAPE_STATEMENTS);
         if (shapeStatements != null) {
@@ -76,12 +81,6 @@ final class FixBadDocComments implements Function<TokenTree, TokenTree> {
                 if (nextSibling == null || nextSibling.getFirstChild(TreeType.APPLY_STATEMENT) != null) {
                     updateNestedChildren(br);
                 }
-            }
-
-            // Remove trailing doc comments in member bodies.
-            for (TreeCursor members : shapeStatements.findChildrenByType(TreeType.SHAPE_MEMBERS)) {
-                TreeCursor ws = members.getLastChild(TreeType.WS);
-                updateDirectChildren(ws);
             }
         }
 

--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FixBadDocComments.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/FixBadDocComments.java
@@ -82,6 +82,16 @@ final class FixBadDocComments implements Function<TokenTree, TokenTree> {
                     updateNestedChildren(br);
                 }
             }
+            // Fix any trailing doc comments in shape bodies
+            for (TreeCursor members : shapeStatements.findChildrenByType(TreeType.SHAPE_MEMBERS)) {
+                TreeCursor closeBrace = members.getLastChild();
+                if (closeBrace != null) {
+                    TreeCursor possibleTrailingWs = closeBrace.getPreviousSibling();
+                    if (possibleTrailingWs != null && possibleTrailingWs.getTree().getType() == TreeType.WS) {
+                        updateDirectChildren(possibleTrailingWs);
+                    }
+                }
+            }
         }
 
         return tree;

--- a/smithy-syntax/src/test/java/software/amazon/smithy/syntax/ParseAndFormatTest.java
+++ b/smithy-syntax/src/test/java/software/amazon/smithy/syntax/ParseAndFormatTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.syntax;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -54,7 +53,7 @@ public class ParseAndFormatTest {
         String formatted = Formatter.format(tree, 120);
         String expected = IoUtils.readUtf8File(formattedFile);
 
-        assertThat(formatted, equalTo(expected));
+        assertEquals(expected, formatted);
     }
 
     public static List<Path> tests() throws Exception {

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/fixes-invalid-doc-comments.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/fixes-invalid-doc-comments.formatted.smithy
@@ -23,19 +23,19 @@ use smithy.api#String
 
 /// 12 (keep)
 @deprecated
-/// 13 (change)
+// 13 (change)
 structure Foo {
     /// 14 (keep)
     @length(
         // 15 (change)
         min: 1
     )
-    /// 16 (change)
+    // 16 (change)
     @since("1.x")
-    /// 17 (TODO: change)
+    // 17 (change)
     bar: String
 
-    // 18 (change)
+    /// 18 (TODO: handle this case somehow)
 }
 
 // 19 (change)

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/fixes-invalid-doc-comments.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/fixes-invalid-doc-comments.formatted.smithy
@@ -35,7 +35,12 @@ structure Foo {
     // 17 (change)
     bar: String
 
-    /// 18 (TODO: handle this case somehow)
+    /// 17a (keep)
+    @length(min: 1)
+    baz: String = ""
+
+    /// 18 (TODO: Fix trailing comment after VALUE_ASSIGNMENT)
+
 }
 
 // 19 (change)
@@ -45,4 +50,10 @@ apply Foo @tags(["a"])
 list Baz {
     member: Integer
 }
-// 21 (change)
+
+structure Foo2 {
+    foo2: String
+
+    // 21 (change)
+}
+// 22 (change)

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/fixes-invalid-doc-comments.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/fixes-invalid-doc-comments.smithy
@@ -35,7 +35,11 @@ structure Foo {
     /// 17 (change)
     bar: String
 
-    /// 18 (TODO: handle this case somehow)
+    /// 17a (keep)
+    @length(min: 1)
+    baz: String = ""
+
+    /// 18 (TODO: Fix trailing comment after VALUE_ASSIGNMENT)
 }
 
 /// 19 (change)
@@ -46,4 +50,10 @@ list Baz {
     member: Integer
 }
 
-/// 21 (change)
+structure Foo2 {
+    foo2: String
+
+    /// 21 (change)
+}
+
+/// 22 (change)

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/fixes-invalid-doc-comments.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/fixes-invalid-doc-comments.smithy
@@ -32,9 +32,10 @@ structure Foo {
     )
     /// 16 (change)
     @since("1.x")
-    /// 17 (TODO: change)
+    /// 17 (change)
     bar: String
-    /// 18 (change)
+
+    /// 18 (TODO: handle this case somehow)
 }
 
 /// 19 (change)


### PR DESCRIPTION
#### Background
- Fixes an issue where a doc-comment above a trait-statement and member may get converted to a line-comment
- Updates the expected formatting of test case file (`.formatted.smithy`)
- Updates tests to use `assertEquals`, since it provides diff functionality in IDEs
- Caveat:
  - A trailing doc-comment won't get converted to a line-comment
    - TODO was added to handle this case, if it is possible 


#### Testing
- Ran the tests, no failures

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
