### PR TITLE
Fix typos in RPCv2 CBOR spec

### DIFF
--- a/docs/source-2.0/additional-specs/protocols/smithy-rpc-v2.rst
+++ b/docs/source-2.0/additional-specs/protocols/smithy-rpc-v2.rst
@@ -298,8 +298,8 @@ headers for responses:
       - Required
       - The value of ``rpc-v2-cbor``.
     * - ``Content-Type``
-      - Required with request bodies
-      - The value of ``application/cbor``. For event streaming requests, this
+      - Required with response bodies
+      - The value of ``application/cbor``. For event streaming responses, this
         is ``application/vnd.amazon.eventstream``.
     * - ``Content-Length``
       - Conditional


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
