### PR TITLE
Fix formatting comments in operation errors list

### DIFF
--- a/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TreeCursor.java
+++ b/smithy-syntax/src/main/java/software/amazon/smithy/syntax/TreeCursor.java
@@ -318,6 +318,19 @@ public final class TreeCursor implements FromSourceLocation {
         }
     }
 
+    /**
+     * @return All siblings after this cursor, in order.
+     */
+    public List<TreeCursor> remainingSiblings() {
+        List<TreeCursor> remaining = new ArrayList<>();
+        TreeCursor nextSibling = getNextSibling();
+        while (nextSibling != null) {
+            remaining.add(nextSibling);
+            nextSibling = nextSibling.getNextSibling();
+        }
+        return remaining;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/operation-errors-comments.formatted.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/operation-errors-comments.formatted.smithy
@@ -1,0 +1,27 @@
+$version: "2.0"
+
+namespace smithy.example
+
+operation Foo {
+    errors: [
+        // a
+        E1
+        // c
+        E2
+        // d
+    ]
+}
+
+operation Bar {
+    // a
+    // b
+    errors: [
+        // c
+    ]
+}
+
+@error("client")
+structure E1 {}
+
+@error("client")
+structure E2 {}

--- a/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/operation-errors-comments.smithy
+++ b/smithy-syntax/src/test/resources/software/amazon/smithy/syntax/formatter/operation-errors-comments.smithy
@@ -1,0 +1,27 @@
+$version: "2.0"
+
+namespace smithy.example
+
+operation Foo {
+    errors: [
+        // a
+        E1
+        // c
+        E2
+        // d
+    ]
+}
+
+operation Bar {
+    errors // a
+    : // b
+    [
+        // c
+    ]
+}
+
+@error("client")
+structure E1 {}
+
+@error("client")
+structure E2 {}


### PR DESCRIPTION
#### Background

For operation errors like:
```
errors // foo
: // bar
[
    // baz
    MyError
]
```
you'd expect formatting of:
```
// foo
// bar
errors: [
    // baz
    MyError
]
```
Prior to this commit, we were handling the cases of `foo` and `bar`, but inadvertently doing the same thing for `baz`. This is because we were looking for comments to pull out to above `errors` in the direct children of OPERATION_ERRORS, which include all WS within the `[]`.

To make it work as expected, we need to only pull out comments in the first two positions (`foo`, `bar`), and leave the rest for BracketFormatter to format. BracketFormatter was expecting to operate on all the children of a given TreeCursor, so I modified it to act on an arbitrary stream of cursors, and added a way to get all remaining siblings after a cursor.

#### Testing
* Added a new test case for this

#### Links
* Fixes #2261
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
