### PR TITLE
Update post-release.yml

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -24,6 +24,7 @@ jobs:
       with:
         workflow: autoupdate
         repo: smithy-lang/homebrew-tap
+        ref: 'main'
         inputs: '{ "version": "${{ env.version }}" }'
         # Required when using the `repo` option
         token: "${{ secrets.PR_TOKEN }}"


### PR DESCRIPTION
#### Background
- When starting the workflow, it uses the ref by default, so when a release triggers it, it would use ref/tags/x.y.z, which won't exist in the downstream-repo (homebrew-tap)

#### Testing
- Tested in personal fork

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
