### PR TITLE
Fix docs for `aws.iam#serviceResolvedConditionKeys` and `aws.iam#conditionKeyValue`

### DIFF
--- a/docs/source-2.0/aws/aws-iam.rst
+++ b/docs/source-2.0/aws/aws-iam.rst
@@ -545,6 +545,10 @@ The following example defines two service-specific condition keys:
 
     namespace smithy.example
 
+    use aws.api#service
+    use aws.iam#defineConditionKeys
+    use aws.iam#serviceResolvedConditionKeys
+
     @defineConditionKeys(
         "myservice:ActionContextKey1": { type: "String" },
         "myservice:ActionContextKey2": { type: "String" }
@@ -583,6 +587,11 @@ explicitly binds ``ActionContextKey1`` to the field ``key``.
 
     namespace smithy.example
 
+    use aws.api#service
+    use aws.iam#conditionKeys
+    use aws.iam#defineConditionKeys
+    use aws.iam#conditionKeyValue
+
     @defineConditionKeys(
         "myservice:ActionContextKey1": { type: "String" }
     )
@@ -595,7 +604,7 @@ explicitly binds ``ActionContextKey1`` to the field ``key``.
     @conditionKeys(["myservice:ActionContextKey1"])
     operation OperationA {
         input := {
-            @conditionKeyValue("ActionContextKey1")
+            @conditionKeyValue("myservice:ActionContextKey1")
             key: String
         }
         output := {


### PR DESCRIPTION
Besides missing imports, `aws.iam#conditionKeyValue` was referring to an
undefined condition key.

Error if you build the current model:

```
Shape: smithy.example#OperationAInput$key
File:  /home/ANT.AMAZON.COM/davidpz/code/smithy-rs-main/codegen-server-test/../codegen-core/common-test-models/simple.smithy:22:9

19| @conditionKeys(["myservice:ActionContextKey1"])
20| operation OperationA {
21|     input := {
22|         @conditionKeyValue("ActionContextKey1")
  |         ^

This operation `smithy.example#OperationA` scoped within the
`smithy.example#MyService` service with member
`smithy.example#OperationAInput$key` refers to an undefined condition key
`ActionContextKey1`. Expected one of the following defined condition keys:
[`myservice:ActionContextKey1`]
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
