### PR TITLE
Add protocol tests for Content-Type params

### DIFF
--- a/smithy-aws-protocol-tests/model/awsJson1_0/content-type.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/content-type.smithy
@@ -1,0 +1,44 @@
+// This file defines test cases that test Content-Type headers.
+
+$version: "2.0"
+
+namespace aws.protocoltests.json10
+
+use aws.protocols#awsJson1_0
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+/// The example tests how servers must support requests
+/// containing a `Content-Type` header with parameters.
+operation ContentTypeParameters {
+    input: ContentTypeParametersInput,
+    output: ContentTypeParametersOutput
+}
+
+apply ContentTypeParameters @httpRequestTests([
+    {
+        id: "AwsJson10MustSupportParametersInContentType",
+        documentation: "A server should ignore parameters added to the content type",
+        protocol: awsJson1_0,
+        method: "POST",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.0; charset=utf-8",
+            "X-Amz-Target": "JsonRpc10.ContentTypeParameters",
+        },
+        uri: "/",
+        body: "{\"value\":5}",
+        bodyMediaType: "application/json",
+        params: {
+            value: 5,
+        },
+        appliesTo: "server"
+    }
+])
+
+@input
+structure ContentTypeParametersInput {
+    value: Integer,
+}
+
+@output
+structure ContentTypeParametersOutput {}

--- a/smithy-aws-protocol-tests/model/awsJson1_0/main.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/main.smithy
@@ -35,6 +35,9 @@ service JsonRpc10 {
         // requestCompression trait tests
         PutWithContentEncoding,
 
+        // Content-Type header tests
+        ContentTypeParameters,
+
         OperationWithDefaults,
         OperationWithRequiredMembers,
         OperationWithNestedStructure

--- a/smithy-aws-protocol-tests/model/awsJson1_1/content-type.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/content-type.smithy
@@ -1,0 +1,44 @@
+// This file defines test cases that test Content-Type headers.
+
+$version: "2.0"
+
+namespace aws.protocoltests.json
+
+use aws.protocols#awsJson1_1
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+/// The example tests how servers must support requests
+/// containing a `Content-Type` header with parameters.
+operation ContentTypeParameters {
+    input: ContentTypeParametersInput,
+    output: ContentTypeParametersOutput
+}
+
+apply ContentTypeParameters @httpRequestTests([
+    {
+        id: "AwsJson11MustSupportParametersInContentType",
+        documentation: "A server should ignore parameters added to the content type",
+        protocol: awsJson1_1,
+        method: "POST",
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1; charset=utf-8",
+            "X-Amz-Target": "JsonProtocol.ContentTypeParameters",
+        },
+        uri: "/",
+        body: "{\"value\":5}",
+        bodyMediaType: "application/json",
+        params: {
+            value: 5,
+        },
+        appliesTo: "server"
+    }
+])
+
+@input
+structure ContentTypeParametersInput {
+    value: Integer,
+}
+
+@output
+structure ContentTypeParametersOutput {}

--- a/smithy-aws-protocol-tests/model/awsJson1_1/main.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/main.smithy
@@ -44,6 +44,9 @@ service JsonProtocol {
 
         // requestCompression trait tests
         PutWithContentEncoding
+
+        // Content-Type header tests
+        ContentTypeParameters,
     ],
 }
 

--- a/smithy-aws-protocol-tests/model/restJson1/content-type.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/content-type.smithy
@@ -1,0 +1,41 @@
+// This file defines test cases that test Content-Type headers.
+
+$version: "2.0"
+
+namespace aws.protocoltests.restjson
+
+use aws.protocols#restJson1
+use aws.protocoltests.shared#DateTime
+use smithy.test#httpRequestTests
+
+/// The example tests how servers must support requests
+/// containing a `Content-Type` header with parameters.
+@http(uri: "/ContentTypeParameters", method: "POST")
+operation ContentTypeParameters {
+    input: ContentTypeParametersInput,
+    output: ContentTypeParametersOutput,
+}
+
+apply ContentTypeParameters @httpRequestTests([
+    {
+        id: "RestJsonMustSupportParametersInContentType",
+        documentation: "A server should ignore parameters added to the content type",
+        uri: "/ContentTypeParameters",
+        method: "POST",
+        protocol: "aws.protocols#restJson1",
+        body: "{\"value\":5}",
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+        params: {
+            value: 5,
+        },
+        appliesTo: "server",
+    },
+])
+
+@input
+structure ContentTypeParametersInput {
+    value: Integer,
+}
+
+@output
+structure ContentTypeParametersOutput {}

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -151,6 +151,9 @@ service RestJson {
         FractionalSeconds,
 
         // requestCompression trait tests
-        PutWithContentEncoding
+        PutWithContentEncoding,
+
+        // Content-Type header tests
+        ContentTypeParameters,
     ]
 }

--- a/smithy-aws-protocol-tests/model/restXml/content-type.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/content-type.smithy
@@ -1,0 +1,44 @@
+// This file defines test cases that test Content-Type headers.
+
+$version: "2.0"
+
+namespace aws.protocoltests.restxml
+
+use aws.protocols#restXml
+use aws.protocoltests.shared#DateTime
+use smithy.test#httpRequestTests
+
+/// The example tests how servers must support requests
+/// containing a `Content-Type` header with parameters.
+@http(uri: "/ContentTypeParameters", method: "PUT")
+operation ContentTypeParameters {
+    input: ContentTypeParametersInput,
+    output: ContentTypeParametersOutput
+}
+
+apply ContentTypeParameters @httpRequestTests([
+    {
+        id: "RestXmlMustSupportParametersInContentType",
+        documentation: "A server should ignore parameters added to the content type",
+        protocol: restXml,
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/xml; charset=utf-8"
+        },
+        uri: "/ContentTypeParameters",
+        body: "<ContentTypeParametersInput><value>5</value></ContentTypeParametersInput>",
+        bodyMediaType: "application/xml",
+        params: {
+            value: 5,
+        },
+        appliesTo: "server"
+    }
+])
+
+@input
+structure ContentTypeParametersInput {
+    value: Integer,
+}
+
+@output
+structure ContentTypeParametersOutput {}

--- a/smithy-aws-protocol-tests/model/restXml/main.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/main.smithy
@@ -105,6 +105,9 @@ service RestXml {
         FractionalSeconds,
 
         // requestCompression trait tests
-        PutWithContentEncoding
+        PutWithContentEncoding,
+
+        // Content-Type header tests
+        ContentTypeParameters,
     ]
 }


### PR DESCRIPTION
#### Background
This change adds tests to document/enforce how the Content-Type headers should be handled by servers. They are important to ensure that clients get the same experience regardless of which language the server is written in.

These are being added as smithy-rs was rejecting requests with parameters added to the Content-Type header, but the customer's existing requests were being accepted by existing servers.

#### Testing
* ./gradlew check
* did some local testing in smithy-rs; also had similar tests there (which these will replace): https://github.com/smithy-lang/smithy-rs/pull/3576

#### Links
* Smithy-rs issue: https://github.com/smithy-lang/smithy-rs/issues/3471

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
