### PR TITLE
Clarify RPCv2 response event stream behavior

### DIFF
--- a/docs/source-2.0/additional-specs/protocols/smithy-rpc-v2.rst
+++ b/docs/source-2.0/additional-specs/protocols/smithy-rpc-v2.rst
@@ -214,10 +214,10 @@ Buffered RPC requests for the ``rpcv2Cbor`` protocol SHOULD include a
 ``Content-Length`` header. Event streaming requests MUST NOT specify a content
 length (instead using ``Transfer-Encoding: chunked`` on HTTP/1.1).
 
-Event streaming requests for the ``rpcv2Cbor`` protocol MUST include an
-``Accept`` header set to the value ``application/vnd.amazon.eventstream``.
-Other forms of content streaming MAY be added in the future, utilizing
-different values for ``Accept``.
+Requests with event stream responses for the ``rpcv2Cbor`` protocol MUST
+include an ``Accept`` header set to the value
+``application/vnd.amazon.eventstream``. Other forms of content streaming MAY be
+added in the future, utilizing different values for ``Accept``.
 
 In summary, the ``rpcv2Cbor`` protocol defines behavior for the following
 headers for requests:
@@ -242,7 +242,8 @@ headers for requests:
         For event streaming requests, this MUST NOT be set.
     * - ``Accept``
       - Conditional
-      - For event streaming requests, to the value ``application/vnd.amazon.eventstream``.
+      - For requests with event streaming responses, this is
+        ``application/vnd.amazon.eventstream``.
 
 
 ~~~~~~~~~


### PR DESCRIPTION
#### Background
* What do these changes do? 
Clarify when an `Accept` header is needed for Smithy RPCv2 response event streams.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
