### PR TITLE
Servers must reject `{}` when deserializing a union

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-union.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-union.smithy
@@ -79,6 +79,28 @@ apply MalformedUnion @httpMalformedRequestTests([
         }
     },
     {
+        id: "RestJsonMalformedUnionEmptyObjectNoFieldsSet",
+        documentation: """
+            When the union is an empty object, it has no fields set, so the
+            response should be a 400 SerializationException.""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedUnion",
+            body: """
+                { "union" : {  } }""",
+            headers: {
+                "content-type": "application/json"
+            }
+        },
+        response: {
+            code: 400,
+            headers: {
+                "x-amzn-errortype": "SerializationException"
+            }
+        }
+    },
+    {
         id: "RestJsonMalformedUnionValueIsArray",
         documentation: """
             When the union value is actually an array, the response should be a 400


### PR DESCRIPTION
Once we're inside of a `{}` JSON object, a known union variant must be
provided. Servers must not accept `{}` as "the union shape was not set"
when the union shape is optional (which was the behavior in smithy-rs
prior to https://github.com/smithy-lang/smithy-rs/pull/3481).

This commit adds a protocol test to pin this behavior.

#### Testing

I verified that the added test fails in smithy-rs when checking out a commit
prior to https://github.com/smithy-lang/smithy-rs/pull/3481

```
thread 'operation::server_union_with_empty_body_operation_test::rest_json_with_empty_json_object_for_union_variant_malformed_request' panicked at 'request should have been rejected, but we accepted it; we parsed operation input `UnionWithEmptyBodyOperationInput { member: None }`', rest_json_extras/rust-server-codegen/src/operation.rs:774:52
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
