### PR TITLE
Allow examples for service level errors

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-service-errors.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-service-errors.errors
@@ -1,0 +1,3 @@
+[ERROR] ns.foo#WithError: Error parameters provided for operation without the `ns.foo#ServiceError` error: `Testing 2` | ExamplesTrait
+[ERROR] ns.foo#WithoutError: Error parameters provided for operation without the `ns.foo#OperationError` error: `Testing 3` | ExamplesTrait
+[ERROR] ns.foo#WithoutError: Error parameters provided for operation without the `ns.foo#ServiceError` error: `Testing 4` | ExamplesTrait

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-service-errors.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/examples-trait-service-errors.smithy
@@ -1,0 +1,109 @@
+$version: "2"
+
+namespace ns.foo
+
+service ErrorBound {
+    version: "2020-07-02"
+    operations: [
+        WithError
+        WithoutError
+    ]
+    errors: [ServiceError]
+}
+
+service ErrorBound2 {
+    version: "2020-07-02"
+    operations: [
+        WithoutError2
+    ]
+    errors: [ServiceError2]
+}
+
+service NoError {
+    version: "2020-07-02"
+    operations: [
+        WithError
+        WithoutError
+    ]
+}
+
+@examples([
+    {
+        "title": "Testing 1",
+        "error": {
+            "shapeId": "ns.foo#OperationError"
+            "content": {
+                "foo": "baz"
+            }
+        }
+    }
+    {
+        "title": "Testing 2"
+        "error": {
+            "shapeId": "ns.foo#ServiceError"
+            "content": {
+                "foo": "baz"
+            }
+        }
+    }
+])
+operation WithError {
+    input := {}
+    errors: [OperationError]
+}
+
+@examples([
+    {
+        "title": "Testing 3",
+        "error": {
+            "shapeId": "ns.foo#OperationError"
+            "content": {
+                "foo": "baz"
+            }
+        }
+    }
+    {
+        "title": "Testing 4"
+        "error": {
+            "shapeId": "ns.foo#ServiceError"
+            "content": {
+                "foo": "baz"
+            }
+        }
+    }
+])
+operation WithoutError {
+    input := {}
+    output := {}
+}
+
+@examples([
+    {
+        "title": "Testing 5"
+        "error": {
+            "shapeId": "ns.foo#ServiceError2"
+            "content": {
+                "foo": "baz"
+            }
+        }
+    }
+])
+operation WithoutError2 {
+    input := {}
+    output := {}
+}
+
+@error("client")
+structure ServiceError {
+    foo: String
+}
+
+@error("client")
+structure ServiceError2 {
+    foo: String
+}
+
+@error("client")
+structure OperationError {
+    foo: String
+}


### PR DESCRIPTION
This commit enables validating error examples for operations with errors that are bound to services. All services the operation with said example are bound to must bind the error.

Fixes #2299 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
