### PR TITLE
Add protocol test for when content-type must be set but no headers are sent

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-content-type.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-content-type.smithy
@@ -36,7 +36,7 @@ apply MalformedContentTypeWithBody @httpMalformedRequestTests([
     {
         id: "RestJsonWithBodyExpectsApplicationJsonContentType",
         documentation: """
-        When there is modeled input, they content type must be application/json""",
+        When there is modeled input, the content type must be application/json""",
         protocol: restJson1,
         request: {
             method: "POST",
@@ -46,6 +46,27 @@ apply MalformedContentTypeWithBody @httpMalformedRequestTests([
                 // this should be application/json
                 "content-type": "application/hal+json"
             }
+        },
+        response: {
+            code: 415,
+            headers: {
+                "x-amzn-errortype": "UnsupportedMediaTypeException"
+            }
+        },
+        tags: [ "content-type" ]
+    }
+])
+
+apply MalformedContentTypeWithBody @httpMalformedRequestTests([
+    {
+        id: "RestJsonWithBodyExpectsApplicationJsonContentTypeNoHeaders",
+        documentation: """
+        When there is modeled input, the content type must be application/json""",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/MalformedContentTypeWithBody",
+            body: "{}",
         },
         response: {
             code: 415,

--- a/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-content-type.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-content-type.smithy
@@ -55,9 +55,6 @@ apply MalformedContentTypeWithBody @httpMalformedRequestTests([
         },
         tags: [ "content-type" ]
     }
-])
-
-apply MalformedContentTypeWithBody @httpMalformedRequestTests([
     {
         id: "RestJsonWithBodyExpectsApplicationJsonContentTypeNoHeaders",
         documentation: """


### PR DESCRIPTION
The suite already contains a test with ID
`RestJsonWithBodyExpectsApplicationJsonContentType` for when `Content-Type:
aplication/json` is expected by the server but the client sends a wrong value
for the header. However, there is no test testing the case where the client
sends no headers. This commit adds such a test.

#### Testing

* Ran the test in smithy-rs server.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
