### PR TITLE
Add missing node mapper for document types

### DIFF
--- a/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/CreatesTraitTest.java
+++ b/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/CreatesTraitTest.java
@@ -9,11 +9,13 @@ import com.example.traits.documents.StructWithNestedDocumentTrait;
 import com.example.traits.enums.IntEnumTrait;
 import com.example.traits.enums.StringEnumTrait;
 import com.example.traits.enums.SuitTrait;
+import com.example.traits.lists.DocumentListTrait;
 import com.example.traits.lists.ListMember;
 import com.example.traits.lists.NumberListTrait;
 import com.example.traits.lists.StringListTrait;
 import com.example.traits.lists.StructureListTrait;
 import com.example.traits.maps.MapValue;
+import com.example.traits.maps.StringDocumentMapTrait;
 import com.example.traits.maps.StringStringMapTrait;
 import com.example.traits.maps.StringToStructMapTrait;
 import com.example.traits.mixins.StructWithMixinTrait;
@@ -81,6 +83,10 @@ public class CreatesTraitTest {
                         ListMember.builder().a("first").b(1).c("other").build().toNode(),
                         ListMember.builder().a("second").b(2).c("more").build().toNode()
                 )),
+                Arguments.of(DocumentListTrait.ID, ArrayNode.fromNodes(
+                        ObjectNode.builder().withMember("a", "b").build(),
+                        ObjectNode.builder().withMember("c", "d").withMember("e", "f").build()
+                )),
                 // Maps
                 Arguments.of(StringStringMapTrait.ID, StringStringMapTrait.builder()
                         .putValues("a", "first").putValues("b", "other").build().toNode()
@@ -88,6 +94,11 @@ public class CreatesTraitTest {
                 Arguments.of(StringToStructMapTrait.ID, StringToStructMapTrait.builder()
                         .putValues("one", MapValue.builder().a("foo").b(2).build())
                         .putValues("two", MapValue.builder().a("bar").b(4).build())
+                        .build().toNode()
+                ),
+                Arguments.of(StringDocumentMapTrait.ID, StringDocumentMapTrait.builder()
+                        .putValues("a", ObjectNode.builder().withMember("a", "a").build())
+                        .putValues("b", ObjectNode.builder().withMember("b", "b").build())
                         .build().toNode()
                 ),
                 // Mixins

--- a/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/CreatesTraitTest.java
+++ b/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/CreatesTraitTest.java
@@ -97,8 +97,10 @@ public class CreatesTraitTest {
                         .build().toNode()
                 ),
                 Arguments.of(StringDocumentMapTrait.ID, StringDocumentMapTrait.builder()
-                        .putValues("a", ObjectNode.builder().withMember("a", "a").build())
-                        .putValues("b", ObjectNode.builder().withMember("b", "b").build())
+                        .putValues("a", ObjectNode.builder().withMember("a", "a").build().toNode())
+                        .putValues("b", ObjectNode.builder().withMember("b", "b").build().toNode())
+                        .putValues("string", Node.from("stuff"))
+                        .putValues("number", Node.from(1))
                         .build().toNode()
                 ),
                 // Mixins

--- a/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/LoadsFromModelTest.java
+++ b/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/LoadsFromModelTest.java
@@ -16,10 +16,12 @@ import com.example.traits.idref.IdRefStringTrait;
 import com.example.traits.idref.IdRefStructTrait;
 import com.example.traits.idref.IdRefStructWithNestedIdsTrait;
 import com.example.traits.idref.NestedIdRefHolder;
+import com.example.traits.lists.DocumentListTrait;
 import com.example.traits.lists.ListMember;
 import com.example.traits.lists.NumberListTrait;
 import com.example.traits.lists.StructureListTrait;
 import com.example.traits.maps.MapValue;
+import com.example.traits.maps.StringDocumentMapTrait;
 import com.example.traits.maps.StringStringMapTrait;
 import com.example.traits.maps.StringToStructMapTrait;
 import com.example.traits.mixins.ListMemberWithMixin;
@@ -115,6 +117,10 @@ public class LoadsFromModelTest {
                         MapUtils.of("getValues", ListUtils.of(
                                 ListMember.builder().a("first").b(1).c("other").build(),
                                 ListMember.builder().a("second").b(2).c("more").build()))),
+                Arguments.of("lists/document-list-trait.smithy", DocumentListTrait.class,
+                        MapUtils.of("getValues", ListUtils.of(
+                            ObjectNode.builder().withMember("a", "a").build(),
+                            ObjectNode.builder().withMember("b", "b").withMember("c", "c").build()))),
                 // Maps
                 Arguments.of("maps/string-string-map-trait.smithy", StringStringMapTrait.class,
                         MapUtils.of("getValues", MapUtils.of("a", "stuff",
@@ -123,6 +129,11 @@ public class LoadsFromModelTest {
                         MapUtils.of("getValues", MapUtils.of(
                                 "one", MapValue.builder().a("foo").b(2).build(),
                                 "two", MapValue.builder().a("bar").b(4).build()))),
+                Arguments.of("maps/string-to-document-map-trait.smithy", StringDocumentMapTrait.class,
+                        MapUtils.of("getValues", MapUtils.of(
+                                "a", ObjectNode.builder().withMember("a", "a").build(),
+                                "b", ObjectNode.builder().withMember("b", "b").withMember("c", "c").build()
+                        ))),
                 // Mixins
                 Arguments.of("mixins/struct-with-mixin-member.smithy", StructureListWithMixinMemberTrait.class,
                         MapUtils.of("getValues", ListUtils.of(

--- a/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/LoadsFromModelTest.java
+++ b/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/LoadsFromModelTest.java
@@ -119,8 +119,9 @@ public class LoadsFromModelTest {
                                 ListMember.builder().a("second").b(2).c("more").build()))),
                 Arguments.of("lists/document-list-trait.smithy", DocumentListTrait.class,
                         MapUtils.of("getValues", ListUtils.of(
-                            ObjectNode.builder().withMember("a", "a").build(),
-                            ObjectNode.builder().withMember("b", "b").withMember("c", "c").build()))),
+                            ObjectNode.builder().withMember("a", "a").build().toNode(),
+                            ObjectNode.builder().withMember("b", "b").withMember("c", 1).build().toNode(),
+                            Node.from("string")))),
                 // Maps
                 Arguments.of("maps/string-string-map-trait.smithy", StringStringMapTrait.class,
                         MapUtils.of("getValues", MapUtils.of("a", "stuff",
@@ -131,8 +132,10 @@ public class LoadsFromModelTest {
                                 "two", MapValue.builder().a("bar").b(4).build()))),
                 Arguments.of("maps/string-to-document-map-trait.smithy", StringDocumentMapTrait.class,
                         MapUtils.of("getValues", MapUtils.of(
-                                "a", ObjectNode.builder().withMember("a", "a").build(),
-                                "b", ObjectNode.builder().withMember("b", "b").withMember("c", "c").build()
+                                "a", ObjectNode.builder().withMember("a", "a").build().toNode(),
+                                "b", ObjectNode.builder().withMember("b", "b").withMember("c", 1).build().toNode(),
+                                "c", Node.from("stuff"),
+                                "d", Node.from(1)
                         ))),
                 // Mixins
                 Arguments.of("mixins/struct-with-mixin-member.smithy", StructureListWithMixinMemberTrait.class,

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/defaults/defaults.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/defaults/defaults.smithy
@@ -5,5 +5,4 @@ namespace test.smithy.traitcodegen
 use test.smithy.traitcodegen.defaults#StructDefaults
 
 @StructDefaults
-structure myStruct {
-}
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/documents/document-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/documents/document-trait.smithy
@@ -4,9 +4,5 @@ namespace test.smithy.traitcodegen
 
 use test.smithy.traitcodegen.documents#DocumentTrait
 
-@DocumentTrait({
-    metadata: "woo"
-    more: "yay"
-})
-structure myStruct {
-}
+@DocumentTrait({ metadata: "woo", more: "yay" })
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/documents/struct-with-nested-document.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/documents/struct-with-nested-document.smithy
@@ -5,10 +5,6 @@ namespace test.smithy.traitcodegen
 use test.smithy.traitcodegen.documents#structWithNestedDocument
 
 @structWithNestedDocument(
-    doc: {
-        foo: "bar"
-        fizz: "buzz"
-    }
+    doc: { foo: "bar", fizz: "buzz" }
 )
-structure myStruct {
-}
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/enums/enum-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/enums/enum-trait.smithy
@@ -5,5 +5,4 @@ namespace test.smithy.traitcodegen
 use test.smithy.traitcodegen.enums#StringEnum
 
 @StringEnum("yes")
-structure myStruct {
-}
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/enums/string-enum-compatibility.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/enums/string-enum-compatibility.smithy
@@ -5,5 +5,4 @@ namespace test.smithy.traitcodegen
 use test.smithy.traitcodegen.enums#Suit
 
 @Suit("club")
-structure myStruct {
-}
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/errorfiles/number-trait-errors.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/errorfiles/number-trait-errors.smithy
@@ -9,5 +9,3 @@ namespace test.smithy.traitcodegen.numbers
 @ShortTrait("bad")
 @DoubleTrait("bad")
 structure structWithInvalidStringInput {}
-
-

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/errorfiles/set-trait-errors.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/errorfiles/set-trait-errors.smithy
@@ -4,9 +4,7 @@ namespace test.smithy.traitcodegen.uniqueitems
 
 // Doesnt have unique items. Expect failure
 @NumberSetTrait([1, 1, 3, 4])
-structure repeatedNumberValues {
-}
+structure repeatedNumberValues {}
 
 @StringSetTrait(["a", "a", "b"])
-structure repeatedStringValues {
-}
+structure repeatedStringValues {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/errorfiles/structure-trait-warns.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/errorfiles/structure-trait-warns.smithy
@@ -2,24 +2,15 @@ $version: "2.0"
 
 namespace test.smithy.traitcodegen.structures
 
-
 @structureTrait(
     fieldA: "first"
     fieldB: false
-    fieldC: {
-        fieldN: "nested"
-        fieldQ: true
-        fieldZ: "A"
-    }
+    fieldC: { fieldN: "nested", fieldQ: true, fieldZ: "A" }
     fieldD: ["a", "b", "c"]
-    fieldE: {
-        a: "one"
-        b: "two"
-    }
-    fieldF: 100.01,
-    fieldG: 100,
-    extraA: 100,
+    fieldE: { a: "one", b: "two" }
+    fieldF: 100.01
+    fieldG: 100
+    extraA: 100
     extraB: 200
 )
-structure myStruct {
-}
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/idref/idref-map.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/idref/idref-map.smithy
@@ -4,10 +4,7 @@ namespace test.smithy.traitcodegen
 
 use test.smithy.traitcodegen.idref#IdRefMap
 
-@IdRefMap(
-    a: IdRefTarget1
-    b: IdRefTarget2
-)
+@IdRefMap(a: IdRefTarget1, b: IdRefTarget2)
 structure myStruct {}
 
 string IdRefTarget1

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/idref/idref-struct-with-nested-refs.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/idref/idref-struct-with-nested-refs.smithy
@@ -5,14 +5,9 @@ namespace test.smithy.traitcodegen
 use test.smithy.traitcodegen.idref#IdRefStructWithNestedIds
 
 @IdRefStructWithNestedIds(
-    idRefHolder: {
-        id: IdRefTarget1
-    }
+    idRefHolder: { id: IdRefTarget1 }
     idList: [IdRefTarget1, IdRefTarget2]
-    idMap: {
-        a: IdRefTarget1
-        b: IdRefTarget2
-    }
+    idMap: { a: IdRefTarget1, b: IdRefTarget2 }
 )
 structure myStruct {}
 

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/lists/document-list-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/lists/document-list-trait.smithy
@@ -4,14 +4,14 @@ namespace test.smithy.traitcodegen
 
 use test.smithy.traitcodegen.lists#DocumentListTrait
 
-
 @DocumentListTrait([
-    { a : "a"}
     {
-        b : "b"
-        c : 1
+        a: "a"
+    }
+    {
+        b: "b"
+        c: 1
     }
     "string"
 ])
-structure myStruct {
-}
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/lists/document-list-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/lists/document-list-trait.smithy
@@ -1,0 +1,16 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen
+
+use test.smithy.traitcodegen.lists#DocumentListTrait
+
+
+@DocumentListTrait([
+    { a : "a"},
+    {
+        b : "b"
+        c : "c"
+    }
+])
+structure myStruct {
+}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/lists/document-list-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/lists/document-list-trait.smithy
@@ -6,11 +6,12 @@ use test.smithy.traitcodegen.lists#DocumentListTrait
 
 
 @DocumentListTrait([
-    { a : "a"},
+    { a : "a"}
     {
         b : "b"
-        c : "c"
+        c : 1
     }
+    "string"
 ])
 structure myStruct {
 }

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/lists/number-list-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/lists/number-list-trait.smithy
@@ -5,5 +5,4 @@ namespace test.smithy.traitcodegen
 use test.smithy.traitcodegen.lists#NumberListTrait
 
 @NumberListTrait([1, 2, 3, 4, 5])
-structure myStruct {
-}
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/lists/string-list-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/lists/string-list-trait.smithy
@@ -5,5 +5,4 @@ namespace test.smithy.traitcodegen
 use test.smithy.traitcodegen.lists#StringListTrait
 
 @StringListTrait(["a", "b", "c", "d"])
-structure myStruct {
-}
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/lists/struct-list-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/lists/struct-list-trait.smithy
@@ -9,11 +9,11 @@ use test.smithy.traitcodegen.lists#StructureListTrait
         a: "first"
         b: 1
         c: "other"
-    } {
+    }
+    {
         a: "second"
         b: 2
         c: "more"
     }
 ])
-structure myStruct {
-}
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/maps/string-string-map-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/maps/string-string-map-trait.smithy
@@ -4,10 +4,5 @@ namespace test.smithy.traitcodegen
 
 use test.smithy.traitcodegen.maps#StringStringMap
 
-@StringStringMap(
-    a: "stuff"
-    b: "other"
-    c: "more!"
-)
-structure myStruct {
-}
+@StringStringMap(a: "stuff", b: "other", c: "more!")
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/maps/string-to-document-map-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/maps/string-to-document-map-trait.smithy
@@ -1,0 +1,15 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen
+
+use test.smithy.traitcodegen.maps#StringDocumentMap
+
+@StringDocumentMap(
+    a: { a : "a" }
+    b: {
+        b : "b"
+        c : "c"
+    }
+)
+structure myStruct {
+}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/maps/string-to-document-map-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/maps/string-to-document-map-trait.smithy
@@ -8,8 +8,10 @@ use test.smithy.traitcodegen.maps#StringDocumentMap
     a: { a : "a" }
     b: {
         b : "b"
-        c : "c"
+        c : 1
     }
+    c: "stuff"
+    d: 1
 )
 structure myStruct {
 }

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/maps/string-to-document-map-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/maps/string-to-document-map-trait.smithy
@@ -5,13 +5,9 @@ namespace test.smithy.traitcodegen
 use test.smithy.traitcodegen.maps#StringDocumentMap
 
 @StringDocumentMap(
-    a: { a : "a" }
-    b: {
-        b : "b"
-        c : 1
-    }
+    a: { a: "a" }
+    b: { b: "b", c: 1 }
     c: "stuff"
     d: 1
 )
-structure myStruct {
-}
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/maps/string-to-struct-map-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/maps/string-to-struct-map-trait.smithy
@@ -5,14 +5,7 @@ namespace test.smithy.traitcodegen
 use test.smithy.traitcodegen.maps#StringToStructMap
 
 @StringToStructMap(
-    one: {
-        a: "foo"
-        b: 2
-    }
-    two: {
-        a: "bar"
-        b: 4
-    }
+    one: { a: "foo", b: 2 }
+    two: { a: "bar", b: 4 }
 )
-structure myStruct {
-}
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/mixins/struct-with-mixin-member.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/mixins/struct-with-mixin-member.smithy
@@ -10,7 +10,8 @@ use test.smithy.traitcodegen.mixins#structureListWithMixinMember
         b: 1
         c: "other"
         d: "mixed-in"
-    } {
+    }
+    {
         a: "second"
         b: 2
         c: "more"

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/mixins/struct-with-only-mixin-member.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/mixins/struct-with-only-mixin-member.smithy
@@ -4,8 +4,5 @@ namespace test.smithy.traitcodegen
 
 use test.smithy.traitcodegen.mixins#structWithMixin
 
-@structWithMixin(
-    d: "mixed-in"
-)
-structure myStruct {
-}
+@structWithMixin(d: "mixed-in")
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/names/snake-case-struct.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/names/snake-case-struct.smithy
@@ -4,8 +4,5 @@ namespace test.smithy.traitcodegen
 
 use test.smithy.traitcodegen.names#snake_case_structure
 
-@snake_case_structure(
-    snake_case_member: "stuff"
-)
-structure myStruct {
-}
+@snake_case_structure(snake_case_member: "stuff")
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/structures/struct-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/structures/struct-trait.smithy
@@ -7,18 +7,10 @@ use test.smithy.traitcodegen.structures#structureTrait
 @structureTrait(
     fieldA: "first"
     fieldB: false
-    fieldC: {
-        fieldN: "nested"
-        fieldQ: true
-        fieldZ: "A"
-    }
+    fieldC: { fieldN: "nested", fieldQ: true, fieldZ: "A" }
     fieldD: ["a", "b", "c"]
-    fieldE: {
-        a: "one"
-        b: "two"
-    }
-    fieldF: 100.01,
+    fieldE: { a: "one", b: "two" }
+    fieldF: 100.01
     fieldG: 100
 )
-structure myStruct {
-}
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/structures/struct-with-non-existent-collections.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/structures/struct-with-non-existent-collections.smithy
@@ -7,11 +7,6 @@ use test.smithy.traitcodegen.structures#structureTrait
 @structureTrait(
     fieldA: "first"
     fieldB: false
-    fieldC: {
-        fieldN: "nested"
-        fieldQ: true
-        fieldZ: "A"
-    }
+    fieldC: { fieldN: "nested", fieldQ: true, fieldZ: "A" }
 )
-structure myStruct {
-}
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/uniqueitems/number-set-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/uniqueitems/number-set-trait.smithy
@@ -5,5 +5,4 @@ namespace test.smithy.traitcodegen
 use test.smithy.traitcodegen.uniqueitems#NumberSetTrait
 
 @NumberSetTrait([1, 2, 3, 4])
-structure myStruct {
-}
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/uniqueitems/string-set-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/uniqueitems/string-set-trait.smithy
@@ -5,5 +5,4 @@ namespace test.smithy.traitcodegen
 use test.smithy.traitcodegen.uniqueitems#StringSetTrait
 
 @StringSetTrait(["a", "b", "c", "d"])
-structure myStruct {
-}
+structure myStruct {}

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/uniqueitems/struct-set-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/uniqueitems/struct-set-trait.smithy
@@ -9,11 +9,11 @@ use test.smithy.traitcodegen.uniqueitems#StructureSetTrait
         a: "first"
         b: 1
         c: "other"
-    } {
+    }
+    {
         a: "second"
         b: 2
         c: "more"
     }
 ])
-structure myStruct {
-}
+structure myStruct {}

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/TraitCodegenSymbolProvider.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/TraitCodegenSymbolProvider.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.BigDecimalShape;
 import software.amazon.smithy.model.shapes.BigIntegerShape;
 import software.amazon.smithy.model.shapes.BlobShape;
@@ -166,7 +166,7 @@ final class TraitCodegenSymbolProvider extends ShapeVisitor.DataShapeVisitor<Sym
 
     @Override
     public Symbol documentShape(DocumentShape shape) {
-        return TraitCodegenUtils.fromClass(ObjectNode.class);
+        return TraitCodegenUtils.fromClass(Node.class);
     }
 
     @Override

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeMapperVisitor.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeMapperVisitor.java
@@ -112,7 +112,7 @@ final class FromNodeMapperVisitor extends ShapeVisitor.DataShapeVisitor<Void> {
 
     @Override
     public Void documentShape(DocumentShape shape) {
-        writer.write("$L.expectObjectNode()", varName);
+        writer.writeWithNoFormatting(varName);
         return null;
     }
 

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeMapperVisitor.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeMapperVisitor.java
@@ -112,6 +112,7 @@ final class FromNodeMapperVisitor extends ShapeVisitor.DataShapeVisitor<Void> {
 
     @Override
     public Void documentShape(DocumentShape shape) {
+        writer.write("$L.expectObjectNode()", varName);
         return null;
     }
 

--- a/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
+++ b/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.model.node.ObjectNode;
 
 
 public class TraitCodegenPluginTest {
-    private static final int EXPECTED_NUMBER_OF_FILES = 56;
+    private static final int EXPECTED_NUMBER_OF_FILES = 58;
 
     private MockManifest manifest;
     private Model model;

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/defaults/defaults.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/defaults/defaults.smithy
@@ -6,28 +6,40 @@ namespace test.smithy.traitcodegen.defaults
 structure StructDefaults {
     @default([])
     defaultList: StringList
+
     @default({})
     defaultMap: StringMap
+
     @default(true)
     defaultBoolean: Boolean
+
     @default("default")
     defaultString: String
+
     @default(1)
     defaultByte: Byte
+
     @default(1)
     defaultShort: Short
+
     @default(1)
     defaultInt: Integer
+
     @default(1)
     defaultLong: Long
+
     @default(2.2)
     defaultFloat: Float
+
     @default(1.1)
     defaultDouble: Double
+
     @default(100)
     defaultBigInt: BigInteger
+
     @default(100.01)
     defaultBigDecimal: BigDecimal
+
     @default("1985-04-12T23:20:50.52Z")
     defaultTimestamp: Timestamp
 }

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/enums/int-enum-trait.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/enums/int-enum-trait.smithy
@@ -10,4 +10,3 @@ intEnum IntEnum {
     /// Negative response
     NO = 2
 }
-

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/enums/string-enum-compatibility.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/enums/string-enum-compatibility.smithy
@@ -7,22 +7,21 @@ namespace test.smithy.traitcodegen.enums
 // ========================
 // The following trait check that the plugin can generate traits from a
 // legacy string enum (i.e. a string with the @enum trait applied).
-
 @enum([
     {
-        name: "DIAMOND",
+        name: "DIAMOND"
         value: "diamond"
-    },
+    }
     {
-        name: "CLUB",
+        name: "CLUB"
         value: "club"
-    },
+    }
     {
-        name: "HEART",
+        name: "HEART"
         value: "heart"
-    },
+    }
     {
-        name: "SPADE",
+        name: "SPADE"
         value: "spade"
     }
 ])

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/idref/idref-list.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/idref/idref-list.smithy
@@ -4,7 +4,6 @@ namespace test.smithy.traitcodegen.idref
 
 // The following trait check to make sure that Strings are converted to ShapeIds
 // when an @IdRef trait is added to a string
-
 @trait
 list IdRefList {
     member: IdRefListmember

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/idref/idref-string.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/idref/idref-string.smithy
@@ -4,7 +4,6 @@ namespace test.smithy.traitcodegen.idref
 
 // The following trait check to make sure that Strings are converted to ShapeIds
 // when an @IdRef trait is added to a string
-
 @trait
 @idRef
 string IdRefString

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/lists/document-list-trait.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/lists/document-list-trait.smithy
@@ -1,0 +1,8 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen.lists
+
+@trait
+list DocumentListTrait {
+    member: Document
+}

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/manifest
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/manifest
@@ -13,8 +13,10 @@ ignored.smithy
 lists/number-list-trait.smithy
 lists/string-list-trait.smithy
 lists/struct-list-trait.smithy
+lists/document-list-trait.smithy
 maps/string-string-map-trait.smithy
 maps/string-to-struct-map-trait.smithy
+maps/string-to-document-map-trait.smithy
 mixins/struct-with-mixin-member.smithy
 mixins/struct-with-only-mixin-member.smithy
 names/snake-case-structure.smithy

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/maps/string-to-document-map-trait.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/maps/string-to-document-map-trait.smithy
@@ -1,0 +1,9 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen.maps
+
+@trait
+map StringDocumentMap {
+    key: String
+    value: Document
+}

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/mixins/struct-with-mixin-member.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/mixins/struct-with-mixin-member.smithy
@@ -4,7 +4,6 @@ namespace test.smithy.traitcodegen.mixins
 
 // The following trait checks that mixins are correctly flattened by
 // the trait codegen plugin
-
 @trait
 list structureListWithMixinMember {
     member: listMemberWithMixin

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/mixins/struct-with-only-mixin-member.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/mixins/struct-with-only-mixin-member.smithy
@@ -4,7 +4,6 @@ namespace test.smithy.traitcodegen.mixins
 
 // The following trait checks that mixins are correctly flattened by
 // the trait codegen plugin
-
 @trait
 structure structWithMixin with [extras] {}
 

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/names/snake-case-structure.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/names/snake-case-structure.smithy
@@ -7,7 +7,6 @@ namespace test.smithy.traitcodegen.names
 // ===================
 // The following traits check that non-java-style names are
 // correctly changed into a useable Java-compatible name
-
 /// Snake cased
 @trait
 structure snake_case_structure {

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/names/trait-with-name-conflict.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/names/trait-with-name-conflict.smithy
@@ -4,7 +4,6 @@ namespace test.smithy.traitcodegen.names
 
 // The following traits check to make sure that name conflicts between shapes and
 // java classes used in the generated codegen code are correctly handled
-
 /// Conflicts with AbstractTrait base class
 @trait
 structure Abstract {}

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/nested/nested-namespace.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/nested/nested-namespace.smithy
@@ -7,7 +7,6 @@ namespace test.smithy.traitcodegen.nested
 // =======================
 // The following traits check to make sure that traits within a nested smithy
 // namespace are mapped to a nested java namespace
-
 /// A trait that should be generated in a nested namespace
 @trait
 structure nestedNamespaceTrait {

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/structures/structure-trait.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/structures/structure-trait.smithy
@@ -60,6 +60,7 @@ structure NestedA {
 enum NestedB {
     /// An A!
     A
+
     /// A B!
     B
 }
@@ -68,6 +69,7 @@ enum NestedB {
 intEnum NestedC {
     /// An A!
     A = 1
+
     /// A B!
     B = 2
 }

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/timestamps/struct-with-nested-timestamps.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/timestamps/struct-with-nested-timestamps.smithy
@@ -6,10 +6,13 @@ namespace test.smithy.traitcodegen.timestamps
 structure structWithNestedTimestamps {
     @required
     baseTime: basicTimestamp
+
     @required
     dateTime: dateTimeTimestamp
+
     @required
     httpDate: httpDateTimestamp
+
     @required
     epochSeconds: epochSecondsTimestamp
 }


### PR DESCRIPTION
fixes #2312 

#### Background
Adds missing node mapper for documents in collection traits.

#### Testing
Added new integration tests for collections traits with document members 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
