### PR TITLE
Add protocol tests relating to `Content-Type` and `@httpPayload`

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
@@ -6,6 +6,7 @@ $version: "2.0"
 namespace aws.protocoltests.restjson
 
 use aws.protocols#restJson1
+use smithy.test#httpMalformedRequestTests
 use aws.protocoltests.shared#TextPlainBlob
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
@@ -75,6 +76,26 @@ apply HttpPayloadTraits @httpRequestTests([
             blob: "This is definitely a jpeg"
         },
         appliesTo: "server",
+    },
+    {
+        id: "RestJsonHttpPayloadTraitsWithBlobAcceptsNoContentType",
+        documentation: """
+            Servers must accept no content type for blob inputs
+            without the media type trait.""",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/HttpPayloadTraits",
+        body: "This is definitely a jpeg",
+        bodyMediaType: "application/octet-stream",
+        headers: {
+            "X-Foo": "Foo",
+        },
+        params: {
+            foo: "Foo",
+            blob: "This is definitely a jpeg"
+        },
+        appliesTo: "server",
+        tags: [ "content-type" ]
     },
     {
         id: "RestJsonHttpPayloadTraitsWithBlobAcceptsAllAccepts",
@@ -353,3 +374,120 @@ structure HttpPayloadWithUnionInputOutput {
 union UnionPayload {
     greeting: String
 }
+
+/// This example serializes a string shape in the payload.
+///
+/// In this example, no JSON document is synthesized because the payload is
+/// not a structure or a union type.
+@http(uri: "/HttpPayloadTraitOnString", method: "POST")
+operation HttpPayloadTraitOnString {
+    input: HttpPayloadTraitOnStringInputOutput,
+    output: HttpPayloadTraitOnStringInputOutput
+}
+
+structure HttpPayloadTraitOnStringInputOutput {
+    @httpPayload
+    foo: String,
+}
+
+apply HttpPayloadTraitOnString @httpRequestTests([
+    {
+        id: "RestJsonHttpPayloadTraitOnString",
+        documentation: "Serializes a string in the HTTP payload",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/HttpPayloadTraitOnString",
+        body: "Foo",
+        bodyMediaType: "text/plain",
+        headers: {
+            "Content-Type": "text/plain",
+        },
+        requireHeaders: [
+            "Content-Length"
+        ],
+        params: {
+            foo: "Foo",
+        }
+    },
+])
+
+apply HttpPayloadTraitOnString @httpResponseTests([
+    {
+        id: "RestJsonHttpPayloadTraitOnString",
+        documentation: "Serializes a string in the HTTP payload",
+        protocol: restJson1,
+        code: 200,
+        body: "Foo",
+        bodyMediaType: "text/plain",
+        headers: {
+            "Content-Type": "text/plain",
+        },
+        params: {
+            foo: "Foo",
+        }
+    },
+])
+
+apply HttpPayloadTraitOnString @httpMalformedRequestTests([
+    {
+        id: "RestJsonHttpPayloadTraitOnStringNoContentType",
+        documentation: "Serializes a string in the HTTP payload without a content-type header",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/HttpPayloadTraitOnString",
+            body: "Foo",
+            // We expect a `Content-Type` header but none was provided.
+        },
+        response: {
+            code: 415,
+            headers: {
+                "x-amzn-errortype": "UnsupportedMediaTypeException"
+            }
+        },
+        tags: [ "content-type" ]
+    },
+    {
+        id: "RestJsonHttpPayloadTraitOnStringWrongContentType",
+        documentation: "Serializes a string in the HTTP payload without the expected content-type header",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/HttpPayloadTraitOnString",
+            body: "Foo",
+            headers: {
+                // We expect `text/plain`.
+                "Content-Type": "application/json",
+            },
+        },
+        response: {
+            code: 415,
+            headers: {
+                "x-amzn-errortype": "UnsupportedMediaTypeException"
+            }
+        },
+        tags: [ "content-type" ]
+    },
+    {
+        id: "RestJsonHttpPayloadTraitOnStringUnsatisfiableAccept",
+        documentation: "Serializes a string in the HTTP payload with an unstatisfiable accept header",
+        protocol: restJson1,
+        request: {
+            method: "POST",
+            uri: "/HttpPayloadTraitOnString",
+            body: "Foo",
+            headers: {
+                "Content-Type": "text/plain",
+                // We can't satisfy this requirement; the server will return `text/plain`.
+                "Accept": "application/json",
+            },
+        },
+        response: {
+            code: 406,
+            headers: {
+                "x-amzn-errortype": "NotAcceptableException"
+            }
+        },
+        tags: [ "accept" ]
+    },
+])

--- a/smithy-aws-protocol-tests/model/restJson1/http-string-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-string-payload.smithy
@@ -10,6 +10,7 @@ use smithy.test#httpResponseTests
     {
         id: "RestJsonEnumPayloadRequest",
         uri: "/EnumPayload",
+        headers: { "Content-Type": "text/plain" },
         body: "enumvalue",
         params: { payload: "enumvalue" },
         method: "POST",
@@ -19,6 +20,7 @@ use smithy.test#httpResponseTests
 @httpResponseTests([
     {
         id: "RestJsonEnumPayloadResponse",
+        headers: { "Content-Type": "text/plain" },
         body: "enumvalue",
         params: { payload: "enumvalue" },
         protocol: "aws.protocols#restJson1",
@@ -44,6 +46,7 @@ enum StringEnum {
     {
         id: "RestJsonStringPayloadRequest",
         uri: "/StringPayload",
+        headers: { "Content-Type": "text/plain" },
         body: "rawstring",
         params: { payload: "rawstring" },
         method: "POST",
@@ -53,6 +56,7 @@ enum StringEnum {
 @httpResponseTests([
     {
         id: "RestJsonStringPayloadResponse",
+        headers: { "Content-Type": "text/plain" },
         body: "rawstring",
         params: { payload: "rawstring" },
         protocol: "aws.protocols#restJson1",

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -62,6 +62,7 @@ service RestJson {
         HttpEnumPayload,
         HttpStringPayload,
         HttpPayloadWithUnion,
+        HttpPayloadTraitOnString,
 
         // @httpResponseCode tests
         HttpResponseCode,

--- a/smithy-aws-protocol-tests/model/restXml/http-string-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-string-payload.smithy
@@ -10,6 +10,7 @@ use smithy.test#httpResponseTests
     {
         id: "RestXmlEnumPayloadRequest",
         uri: "/EnumPayload",
+        headers: { "Content-Type": "text/plain" },
         body: "enumvalue",
         params: { payload: "enumvalue" },
         method: "POST",
@@ -19,6 +20,7 @@ use smithy.test#httpResponseTests
 @httpResponseTests([
     {
         id: "RestXmlEnumPayloadResponse",
+        headers: { "Content-Type": "text/plain" },
         body: "enumvalue",
         params: { payload: "enumvalue" },
         protocol: "aws.protocols#restXml",
@@ -44,6 +46,7 @@ enum StringEnum {
     {
         id: "RestXmlStringPayloadRequest",
         uri: "/StringPayload",
+        headers: { "Content-Type": "text/plain" },
         body: "rawstring",
         params: { payload: "rawstring" },
         method: "POST",
@@ -53,6 +56,7 @@ enum StringEnum {
 @httpResponseTests([
     {
         id: "RestXmlStringPayloadResponse",
+        headers: { "Content-Type": "text/plain" },
         body: "rawstring",
         params: { payload: "rawstring" },
         protocol: "aws.protocols#restXml",


### PR DESCRIPTION
Add protocol tests relating to `Content-Type` and `@httpPayload`

Initial motivation for this stems off #2310, but for when the input is
`@httpPayload`-bound. It's important that we test `Content-Type`
specifically with `@httpPayload` operations, because the header can be
checked without having to inspect the body, and because the spec has
special provisions
(https://smithy.io/2.0/aws/protocols/aws-restjson1-protocol.html#content-type).

There were no protocol tests exercising `Content-Type` when the input is
`@httpPayload`-bound:

- In the case of blobs, servers must accept any (test already exists)
  and no `Content-Type` (test added in this commit).
- In other cases, there were protocol tests for `union` and `structure`
  shapes. I've added an operation with an `@httpPayload`-bound string
  shape. Note that `document` shapes remain untested.

#### Testing

* Ran tests against smithy-rs servers.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
