### PR TITLE
Add missing `Content-Type` headers to `@httpPayload` protocol tests

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-string-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-string-payload.smithy
@@ -10,6 +10,7 @@ use smithy.test#httpResponseTests
     {
         id: "RestJsonEnumPayloadRequest",
         uri: "/EnumPayload",
+        headers: { "Content-Type": "text/plain" },
         body: "enumvalue",
         params: { payload: "enumvalue" },
         method: "POST",
@@ -19,6 +20,7 @@ use smithy.test#httpResponseTests
 @httpResponseTests([
     {
         id: "RestJsonEnumPayloadResponse",
+        headers: { "Content-Type": "text/plain" },
         body: "enumvalue",
         params: { payload: "enumvalue" },
         protocol: "aws.protocols#restJson1",
@@ -44,6 +46,7 @@ enum StringEnum {
     {
         id: "RestJsonStringPayloadRequest",
         uri: "/StringPayload",
+        headers: { "Content-Type": "text/plain" },
         body: "rawstring",
         params: { payload: "rawstring" },
         method: "POST",
@@ -53,6 +56,7 @@ enum StringEnum {
 @httpResponseTests([
     {
         id: "RestJsonStringPayloadResponse",
+        headers: { "Content-Type": "text/plain" },
         body: "rawstring",
         params: { payload: "rawstring" },
         protocol: "aws.protocols#restJson1",

--- a/smithy-aws-protocol-tests/model/restXml/http-string-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-string-payload.smithy
@@ -10,6 +10,7 @@ use smithy.test#httpResponseTests
     {
         id: "RestXmlEnumPayloadRequest",
         uri: "/EnumPayload",
+        headers: { "Content-Type": "text/plain" },
         body: "enumvalue",
         params: { payload: "enumvalue" },
         method: "POST",
@@ -19,6 +20,7 @@ use smithy.test#httpResponseTests
 @httpResponseTests([
     {
         id: "RestXmlEnumPayloadResponse",
+        headers: { "Content-Type": "text/plain" },
         body: "enumvalue",
         params: { payload: "enumvalue" },
         protocol: "aws.protocols#restXml",
@@ -44,6 +46,7 @@ enum StringEnum {
     {
         id: "RestXmlStringPayloadRequest",
         uri: "/StringPayload",
+        headers: { "Content-Type": "text/plain" },
         body: "rawstring",
         params: { payload: "rawstring" },
         method: "POST",
@@ -53,6 +56,7 @@ enum StringEnum {
 @httpResponseTests([
     {
         id: "RestXmlStringPayloadResponse",
+        headers: { "Content-Type": "text/plain" },
         body: "rawstring",
         params: { payload: "rawstring" },
         protocol: "aws.protocols#restXml",


### PR DESCRIPTION
As per the specs for these protocols, a `Content-Type` header should be
set. Servers should reject requests when an expected `Content-Type`
header is not found (protocol tests for that are added in #2314).

- https://smithy.io/2.0/aws/protocols/aws-restjson1-protocol.html#content-type
- https://smithy.io/2.0/aws/protocols/aws-restxml-protocol.html#content-type

#### Testing

Ran tests in smithy-rs.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
