### PR TITLE
Add IDL serializer option to coerce inline IO

### DIFF
--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializerTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -49,7 +50,7 @@ public class SmithyIdlModelSerializerTest {
         }
 
         String serializedString = serialized.entrySet().iterator().next().getValue();
-        Assertions.assertEquals(IoUtils.readUtf8File(path).replaceAll("\\R", "\n"), serializedString);
+        assertEquals(IoUtils.readUtf8File(path).replaceAll("\\R", "\n"), serializedString);
     }
 
     @Test
@@ -259,7 +260,7 @@ public class SmithyIdlModelSerializerTest {
         String expectedOutput = IoUtils.readUtf8Resource(getClass(), "idl-serialization/enum-mixin-output.smithy")
                 .replaceAll("\\R", "\n");
         String serializedString = serialized.entrySet().iterator().next().getValue();
-        Assertions.assertEquals(expectedOutput, serializedString);
+        assertEquals(expectedOutput, serializedString);
     }
 
     @Test
@@ -305,5 +306,22 @@ public class SmithyIdlModelSerializerTest {
             String expected = IoUtils.readUtf8Url(resources.get(path)).replace("\r\n", "\n");
             assertThat(actual, equalTo(expected));
         }
+    }
+
+    @Test
+    public void coercesInlineIO() {
+        Model before = Model.assembler()
+                .addImport(getClass().getResource("idl-serialization/coerced-io/before.smithy"))
+                .assemble().unwrap();
+
+        Map<Path, String> reserialized = SmithyIdlModelSerializer.builder()
+                .coerceInlineIo(true)
+                .build()
+                .serialize(before);
+        String modelResult = reserialized.values().iterator().next().replace("\r\n", "\n");
+
+        String expected = IoUtils.readUtf8Url(getClass().getResource("idl-serialization/coerced-io/after.smithy"))
+                .replace("\r\n", "\n");
+        assertEquals(expected, modelResult);
     }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/coerced-io/after.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/coerced-io/after.smithy
@@ -1,0 +1,40 @@
+$version: "2.0"
+$operationInputSuffix: "Request"
+$operationOutputSuffix: "Response"
+
+namespace com.example
+
+service InlineService {
+    operations: [
+        MultipleBind1
+        MultipleBind2
+        WithoutTraits
+        WithTraits
+    ]
+}
+
+operation MultipleBind1 {
+    input: MultipleBindRequest
+    output: MultipleBindResponse
+}
+
+operation MultipleBind2 {
+    input: MultipleBindRequest
+    output: MultipleBindResponse
+}
+
+operation WithoutTraits {
+    input := {}
+    output := {}
+}
+
+operation WithTraits {
+    input := {
+        a: String
+    }
+    output := {}
+}
+
+structure MultipleBindRequest {}
+
+structure MultipleBindResponse {}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/coerced-io/before.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/coerced-io/before.smithy
@@ -1,0 +1,48 @@
+$version: "2.0"
+
+namespace com.example
+
+service InlineService {
+    operations: [
+        MultipleBind1
+        MultipleBind2
+        WithoutTraits
+        WithTraits
+    ]
+}
+
+operation MultipleBind1 {
+    input: MultipleBindRequest
+    output: MultipleBindResponse
+}
+
+operation MultipleBind2 {
+    input: MultipleBindRequest
+    output: MultipleBindResponse
+}
+
+operation WithoutTraits {
+    input: WithoutTraitsRequest
+    output: WithoutTraitsResponse
+}
+
+operation WithTraits {
+    input: WithTraitsRequest
+    output: WithTraitsResponse
+}
+
+structure MultipleBindRequest {}
+
+structure MultipleBindResponse {}
+
+structure WithoutTraitsRequest {}
+
+structure WithoutTraitsResponse {}
+
+@input
+structure WithTraitsRequest {
+    a: String
+}
+
+@output
+structure WithTraitsResponse {}


### PR DESCRIPTION
This commit adds a new IDL serializer configuration, coerceInlineIo, that will use inline IO to write input and output shapes that are only bound to one operation - even if they don't have the input or output trait applied.

It also fixes a bug where an empty newline was written before empty inline IO shape definitions.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
