### PR TITLE
test(cbor): remove map null value in test assertion

### DIFF
--- a/smithy-protocol-tests/model/rpcv2Cbor/cbor-maps.smithy
+++ b/smithy-protocol-tests/model/rpcv2Cbor/cbor-maps.smithy
@@ -171,8 +171,7 @@ apply RpcV2CborDenseMaps @httpResponseTests([
         params: {
             "denseSetMap": {
                 "x": [],
-                "y": ["a", "b"],
-                "z": null
+                "y": ["a", "b"]
             }
         }
     }


### PR DESCRIPTION
A cbor protocol test appears to have an extraneous value in its result matcher.

The description says "Clients SHOULD tolerate seeing a null value in a dense map, and they SHOULD drop the null key-value pair." This means the expected `params.denseSetMap` should not retain the null value present in the base64 payload.


#### Testing
Tested this change while building Smithy RPCv2 CBOR for TypeScript - https://github.com/smithy-lang/smithy-typescript/pull/1280

