### PR TITLE
Add restJson1 protocol test for content-type and operation with no input

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
@@ -284,3 +284,31 @@ structure TestNoPayloadInputOutput {
     @httpHeader("X-Amz-Test-Id")
     testId: String,
 }
+
+/// This example operation has no input and serializes a request without an HTTP body.
+///
+/// These tests are to ensure we do not attach a body or related headers
+/// (Content-Length, Content-Type) to operations that semantically
+/// cannot produce an HTTP body.
+///
+@readonly
+@http(uri: "/no_input_no_payload", method: "GET")
+operation TestNoInputNoPayload {
+    output: TestNoPayloadInputOutput
+}
+
+apply TestNoInputNoPayload @httpRequestTests([
+    {
+        id: "RestJsonHttpWithNoInput",
+        documentation: "Serializes a GET request for an operation with no input, and therefore no modeled body",
+        protocol: restJson1,
+        method: "GET",
+        uri: "/no_input_no_payload",
+        body: "",
+        forbidHeaders: [
+            "Content-Length",
+            "Content-Type"
+        ],
+        params: {}
+    }
+])

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -145,6 +145,7 @@ service RestJson {
         TestPayloadStructure,
         TestPayloadBlob,
         TestNoPayload,
+        TestNoInputNoPayload,
 
         // client-only timestamp parsing tests
         DatetimeOffsets,


### PR DESCRIPTION
#### Background
- Requests should not have the content-type header added when there is no input shape (and therefore no payload)
  - This doesn't appear to be a case in the aws sdk (operations with no input), but could be in generic clients 

#### Testing
- Tested by running protocol tests in the typescript sdk

#### Links
- Related to https://github.com/smithy-lang/smithy-typescript/pull/1304

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
