### PR TITLE
Add useSymbolWriter function

### DIFF
--- a/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/WriterDelegatorTest.java
+++ b/smithy-codegen-core/src/test/java/software/amazon/smithy/codegen/core/WriterDelegatorTest.java
@@ -48,6 +48,22 @@ public class WriterDelegatorTest {
     }
 
     @Test
+    public void createsFilesForSymbolWriters() {
+        MockManifest mockManifest = new MockManifest();
+        SymbolProvider provider = (shape) -> null;
+        WriterDelegator<MySimpleWriter> delegator = new WriterDelegator<>(
+                mockManifest, provider, (f, n) -> new MySimpleWriter(n));
+        Symbol symbol =  Symbol.builder()
+                .namespace("com.foo", ".")
+                .name("Baz")
+                .definitionFile("com/foo/Baz.bam")
+                .build();
+        delegator.useSymbolWriter(symbol, writer -> { });
+
+        assertThat(delegator.getWriters(), hasKey(Paths.get("com/foo/Baz.bam").toString()));
+    }
+
+    @Test
     public void aggregatesDependencies() {
         MockManifest mockManifest = new MockManifest();
         SymbolProvider provider = (shape) -> null;


### PR DESCRIPTION
This adds a method to the `WriterDelegator` to check out a writer from a symbol. This saves on a good amount of space when writing opening files to write, for example, private helper functions that are defined as symbols attached to shape symbols via properties.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
