### PR TITLE
Fix ec2Query request ID names

### DIFF
--- a/docs/source-2.0/aws/protocols/aws-ec2-query-protocol.rst
+++ b/docs/source-2.0/aws/protocols/aws-ec2-query-protocol.rst
@@ -317,7 +317,7 @@ Operation error serialization
 
 Error responses in the ``ec2Query`` protocol are wrapped within an XML root
 node named ``Response``. Inside this, there is an ``Errors`` tag containing
-the actual error, and a ``RequestId`` tag holding the request ID. Nested inside
+the actual error, and a ``RequestID`` tag holding the request ID. Nested inside
 of the ``Errors`` tag is an ``Error`` tag which contains the serialized error
 structure members.
 
@@ -336,12 +336,12 @@ serialized in the response.
                 <AnotherSetting>setting</AnotherSetting>
             </Error>
         </Errors>
-        <RequestId>foo-id</RequestId>
+        <RequestID>foo-id</RequestID>
     </Response>
 
 * ``Code``: The :token:`shape name <smithy:Identifier>` of the error's
   :ref:`shape-id`.
-* ``RequestId``: Contains a unique identifier for the associated request.
+* ``RequestID``: Contains a unique identifier for the associated request.
 
 In the above example, ``Message``, and ``AnotherSetting`` are additional,
 hypothetical members of the serialized error structure.

--- a/smithy-aws-protocol-tests/model/ec2Query/datetime-offsets.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/datetime-offsets.smithy
@@ -23,7 +23,7 @@ apply DatetimeOffsets @httpResponseTests([
         body: """
               <DatetimeOffsetsResponse xmlns="https://example.com/">
                   <datetime>2019-12-16T22:48:18-01:00</datetime>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </DatetimeOffsetsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -41,7 +41,7 @@ apply DatetimeOffsets @httpResponseTests([
         body: """
               <DatetimeOffsetsResponse xmlns="https://example.com/">
                   <datetime>2019-12-17T00:48:18+01:00</datetime>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </DatetimeOffsetsResponse>
               """,
         bodyMediaType: "application/xml",

--- a/smithy-aws-protocol-tests/model/ec2Query/empty-input-output.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/empty-input-output.smithy
@@ -43,7 +43,7 @@ apply NoInputAndOutput @httpResponseTests([
         },
         body: """
               <NoInputAndOutputResponse xmlns="https://example.com/">
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </NoInputAndOutputResponse>
               """,
         bodyMediaType: "application/xml",
@@ -87,7 +87,7 @@ apply EmptyInputAndEmptyOutput @httpResponseTests([
         },
         body: """
               <EmptyInputAndEmptyOutputResponse xmlns="https://example.com/">
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </EmptyInputAndEmptyOutputResponse>
               """,
         bodyMediaType: "application/xml",

--- a/smithy-aws-protocol-tests/model/ec2Query/fractional-seconds.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/fractional-seconds.smithy
@@ -22,7 +22,7 @@ apply FractionalSeconds @httpResponseTests([
         body: """
               <FractionalSecondsResponse xmlns="https://example.com/">
                   <datetime>2000-01-02T20:34:56.123Z</datetime>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </FractionalSecondsResponse>
               """,
         bodyMediaType: "application/xml",

--- a/smithy-aws-protocol-tests/model/ec2Query/main.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/main.smithy
@@ -18,7 +18,7 @@
 //
 // 1. Unlike aws.query, there's no result wrapper.
 // 2. EC2 does not utilize output maps.
-// 3. RequestId is a child of the root node. It's not nested in some
+// 3. requestId is a child of the root node. It's not nested in some
 //    ResponseMetadata element like aws.query.
 //
 // EC2 errors have an additional level of nesting. See xml-errors.smithy

--- a/smithy-aws-protocol-tests/model/ec2Query/xml-errors.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/xml-errors.smithy
@@ -47,7 +47,7 @@ apply GreetingWithErrors @httpResponseTests([
         body: """
               <GreetingWithErrorsResponse xmlns="https://example.com/">
                   <greeting>Hello</greeting>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </GreetingWithErrorsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -84,7 +84,7 @@ apply InvalidGreeting @httpResponseTests([
                           <Message>Hi</Message>
                       </Error>
                   </Errors>
-                  <RequestId>foo-id</RequestId>
+                  <RequestID>foo-id</RequestID>
               </Response>
               """,
         bodyMediaType: "application/xml",
@@ -128,7 +128,7 @@ apply ComplexError @httpResponseTests([
                           </Nested>
                       </Error>
                   </Errors>
-                  <RequestId>foo-id</RequestId>
+                  <RequestID>foo-id</RequestID>
               </Response>
               """,
         bodyMediaType: "application/xml",

--- a/smithy-aws-protocol-tests/model/ec2Query/xml-lists.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/xml-lists.smithy
@@ -98,7 +98,7 @@ apply XmlLists @httpResponseTests([
                           <other>4</other>
                       </item>
                   </myStructureList>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </XmlListsResponse>
               """,
         bodyMediaType: "application/xml",

--- a/smithy-aws-protocol-tests/model/ec2Query/xml-structs.smithy
+++ b/smithy-aws-protocol-tests/model/ec2Query/xml-structs.smithy
@@ -43,7 +43,7 @@ apply SimpleScalarXmlProperties @httpResponseTests([
                   <longValue>4</longValue>
                   <floatValue>5.5</floatValue>
                   <DoubleDribble>6.5</DoubleDribble>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </SimpleScalarXmlPropertiesResponse>
               """,
         bodyMediaType: "application/xml",
@@ -157,7 +157,7 @@ apply XmlBlobs @httpResponseTests([
         body: """
               <XmlBlobsResponse xmlns="https://example.com/">
                   <data>dmFsdWU=</data>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </XmlBlobsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -185,7 +185,7 @@ apply XmlEmptyBlobs @httpResponseTests([
         body: """
               <XmlEmptyBlobsResponse xmlns="https://example.com/">
                   <data></data>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </XmlEmptyBlobsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -205,7 +205,7 @@ apply XmlEmptyBlobs @httpResponseTests([
         body: """
               <XmlEmptyBlobsResponse xmlns="https://example.com/">
                   <data/>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </XmlEmptyBlobsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -239,7 +239,7 @@ apply XmlTimestamps @httpResponseTests([
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
                   <normal>2014-04-29T18:30:38Z</normal>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -258,7 +258,7 @@ apply XmlTimestamps @httpResponseTests([
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
                   <dateTime>2014-04-29T18:30:38Z</dateTime>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -277,7 +277,7 @@ apply XmlTimestamps @httpResponseTests([
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
                   <dateTimeOnTarget>2014-04-29T18:30:38Z</dateTimeOnTarget>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -296,7 +296,7 @@ apply XmlTimestamps @httpResponseTests([
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
                   <epochSeconds>1398796238</epochSeconds>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -315,7 +315,7 @@ apply XmlTimestamps @httpResponseTests([
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
                   <epochSecondsOnTarget>1398796238</epochSecondsOnTarget>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -334,7 +334,7 @@ apply XmlTimestamps @httpResponseTests([
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
                   <httpDate>Tue, 29 Apr 2014 18:30:38 GMT</httpDate>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -353,7 +353,7 @@ apply XmlTimestamps @httpResponseTests([
         body: """
               <XmlTimestampsResponse xmlns="https://example.com/">
                   <httpDateOnTarget>Tue, 29 Apr 2014 18:30:38 GMT</httpDateOnTarget>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </XmlTimestampsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -419,7 +419,7 @@ apply XmlEnums @httpResponseTests([
                           <value>0</value>
                       </entry>
                   </fooEnumMap>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </XmlEnumsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -483,7 +483,7 @@ apply XmlIntEnums @httpResponseTests([
                           <value>2</value>
                       </entry>
                   </intEnumMap>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </XmlIntEnumsResponse>
               """,
         bodyMediaType: "application/xml",
@@ -538,7 +538,7 @@ apply RecursiveXmlShapes @httpResponseTests([
                           </recursiveMember>
                       </nested>
                   </nested>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </RecursiveXmlShapesResponse>
               """,
         bodyMediaType: "application/xml",
@@ -596,7 +596,7 @@ apply XmlNamespaces @httpResponseTests([
                           <member xmlns="http://bux.com">Baz</member>
                       </values>
                   </nested>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </XmlNamespacesResponse>
               """,
         bodyMediaType: "application/xml",
@@ -653,7 +653,7 @@ apply IgnoresWrappingXmlName @httpResponseTests([
         body: """
               <IgnoresWrappingXmlNameResponse xmlns="https://example.com/">
                   <foo>bar</foo>
-                  <RequestId>requestid</RequestId>
+                  <requestId>requestid</requestId>
               </IgnoresWrappingXmlNameResponse>
               """,
         bodyMediaType: "application/xml",


### PR DESCRIPTION
Aligns with EC2 specs:

* Success: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CopyImage.html#API_CopyImage_Examples
* Error: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html#api-error-response

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
