### PR TITLE
Add properties for controlling JReleaser configurations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
     id "io.codearte.nexus-staging" version "0.30.0"
     id "me.champeau.jmh" version "0.7.2"
     id "com.github.johnrengelman.shadow" version "7.1.2"
-    id "org.jreleaser" version "1.11.0"
+    id "org.jreleaser" version "1.12.0" apply false
 }
 
 ext {
@@ -40,10 +40,6 @@ allprojects {
     group = "software.amazon.smithy"
     version = libraryVersion
 }
-
-// Only using JReleaser based on a flag allows going back to the old
-// release process if necessary. We can remove this later.
-def useJreleaser = project.hasProperty("useJreleaser")
 
 // JReleaser publishes artifacts from a local staging repository, rather than maven local.
 // https://jreleaser.org/guide/latest/examples/maven/staging-artifacts.html#_gradle
@@ -138,22 +134,9 @@ subprojects {
     publishing {
         repositories {
             // JReleaser's `publish` task publishes to all repositories, so only configure one.
-            if (useJreleaser) {
-                maven {
-                    name = "localStaging"
-                    url = stagingDirectory
-                }
-            } else {
-               mavenCentral {
-                   name = "sonatypeNexus"
-                   url = uri("https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/")
-                   if (project.hasProperty("sonatypeUser")) {
-                       credentials {
-                           username = project.property("sonatypeUser")
-                           password = project.property("sonatypePassword")
-                       }
-                   }
-               }
+            maven {
+                name = "localStaging"
+                url = stagingDirectory
             }
         }
 
@@ -290,7 +273,11 @@ allprojects {
     }
 }
 
-if (useJreleaser) {
+// We're using JReleaser in the smithy-cli subproject, so we want to have a flag to control
+// which JReleaser configuration to use to prevent conflicts
+if (project.hasProperty("release.main")) {
+    apply plugin: 'org.jreleaser'
+
     jreleaser {
         dryrun = false
 
@@ -334,24 +321,5 @@ if (useJreleaser) {
                 }
             }
         }
-    }
-}
-
-/*
- * Sonatype Staging Finalization
- * ====================================================
- *
- * When publishing to Maven Central, we need to close the staging
- * repository and release the artifacts after they have been
- * validated. This configuration is for the root project because
- * it operates at the "group" level.
- */
-if (!useJreleaser && project.hasProperty("sonatypeUser") && project.hasProperty("sonatypePassword")) {
-    apply plugin: "io.codearte.nexus-staging"
-    nexusStaging {
-        packageGroup = "software.amazon"
-        stagingProfileId = "e789115b6c941"
-        username = project.property("sonatypeUser")
-        password = project.property("sonatypePassword")
     }
 }

--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -20,7 +20,7 @@ import java.nio.file.Paths
 plugins {
     id "application"
     id "org.beryx.runtime" version "1.12.7"
-    id "org.jreleaser" version "1.11.0"
+    id "org.jreleaser" version "1.12.0" apply false
 }
 
 description = "This module implements the Smithy command line interface."
@@ -254,100 +254,104 @@ task integ(type: Test) {
 tasks["integ"].dependsOn("runtime")
 
 // ------ Setup Jreleaser -------
-tasks["assembleDist"].dependsOn("runtimeZip")
-tasks.assembleDist.doFirst {
-    // This is a workaround for a weird behavior.
-    // https://github.com/jreleaser/jreleaser/issues/1292
-    mkdir "$buildDir/jreleaser"
-}
-
-jreleaser {
-    gitRootSearch = true
-
-    project {
-        website = 'https://smithy.io'
-        authors = ['Smithy']
-        vendor = "Smithy"
-        license = 'Apache-2.0'
-        description = "Smithy CLI - A CLI for building, validating, querying, and iterating on Smithy models"
-        copyright = "2019"
+if (project.hasProperty("release.cli")) {
+    apply plugin: 'org.jreleaser'
+    tasks["assembleDist"].doFirst {
+        // This is a workaround for a weird behavior.
+        // https://github.com/jreleaser/jreleaser/issues/1292
+        mkdir "$buildDir/jreleaser"
     }
+    tasks["assembleDist"].dependsOn("runtimeZip")
 
-    checksum {
-        individual = true
-        files = false
-    }
+    jreleaser {
+        gitRootSearch = true
+        dryrun = false
 
-    release {
-        github {
-            overwrite = true
-            tagName = '{{projectVersion}}'
-            changelog {
-                // For now, we won't have a changelog added to the release. In the future, we could create a changelog-snippet
-                // from the real changelog as part of a command hook prior to the release step
-                enabled = false
-            }
-            commitAuthor {
-                name = "smithy-automation"
-                email = "github-smithy-automation@amazon.com"
+        project {
+            website = 'https://smithy.io'
+            authors = ['Smithy']
+            vendor = "Smithy"
+            license = 'Apache-2.0'
+            description = "Smithy CLI - A CLI for building, validating, querying, and iterating on Smithy models"
+            copyright = "2019"
+        }
+
+        checksum {
+            individual = true
+            files = false
+        }
+
+        release {
+            github {
+                overwrite = true
+                tagName = '{{projectVersion}}'
+                changelog {
+                    // For now, we won't have a changelog added to the release. In the future, we could create a changelog-snippet
+                    // from the real changelog as part of a command hook prior to the release step
+                    enabled = false
+                }
+                commitAuthor {
+                    name = "smithy-automation"
+                    email = "github-smithy-automation@amazon.com"
+                }
             }
         }
-    }
 
-    files {
-        active = "ALWAYS"
-        artifact {
-            // We'll include the VERSION file in the release artifacts so that the version can be easily
-            // retrieving by hitting the GitHub `releases/latest` url 
-            path = "../VERSION"
-            extraProperties.put('skipSigning', true)
-        }
-    }
-
-    platform {
-        // These replacements are for the names of files that are released, *not* for names within this build config
-        replacements = [
-            'osx': 'darwin',
-            'aarch_64': 'aarch64',
-            'windows_x86_64': 'windows_x64'
-        ]
-    }
-
-    distributions {
-        smithy {
-            distributionType = 'JLINK'
-            stereotype = 'CLI'
-
+        files {
+            active = "ALWAYS"
             artifact {
-                path = "build/image/smithy-cli-linux-x86_64.zip"
-                platform = "linux-x86_64"
-            }
-
-            artifact {
-                path = "build/image/smithy-cli-linux-aarch64.zip"
-                platform = "linux-aarch_64"
-            }
-
-            artifact {
-                path = "build/image/smithy-cli-darwin-x86_64.zip"
-                platform = "osx-x86_64"
-            }
-
-            artifact {
-                path = "build/image/smithy-cli-darwin-aarch64.zip"
-                platform = "osx-aarch_64"
-            }
-
-            artifact {
-                path = "build/image/smithy-cli-windows-x64.zip"
-                platform = "windows-x86_64"
+                // We'll include the VERSION file in the release artifacts so that the version can be easily
+                // retrieving by hitting the GitHub `releases/latest` url
+                path = "../VERSION"
+                extraProperties.put('skipSigning', true)
             }
         }
-    }
 
-    signing {
-        active = "RELEASE"
-        armored = true
-        verify = true
+        platform {
+            // These replacements are for the names of files that are released, *not* for names within this build config
+            replacements = [
+                    'osx': 'darwin',
+                    'aarch_64': 'aarch64',
+                    'windows_x86_64': 'windows_x64'
+            ]
+        }
+
+        distributions {
+            smithy {
+                distributionType = 'JLINK'
+                stereotype = 'CLI'
+
+                artifact {
+                    path = "build/image/smithy-cli-linux-x86_64.zip"
+                    platform = "linux-x86_64"
+                }
+
+                artifact {
+                    path = "build/image/smithy-cli-linux-aarch64.zip"
+                    platform = "linux-aarch_64"
+                }
+
+                artifact {
+                    path = "build/image/smithy-cli-darwin-x86_64.zip"
+                    platform = "osx-x86_64"
+                }
+
+                artifact {
+                    path = "build/image/smithy-cli-darwin-aarch64.zip"
+                    platform = "osx-aarch_64"
+                }
+
+                artifact {
+                    path = "build/image/smithy-cli-windows-x64.zip"
+                    platform = "windows-x86_64"
+                }
+            }
+        }
+
+        signing {
+            active = "RELEASE"
+            armored = true
+            verify = true
+        }
     }
 }


### PR DESCRIPTION
#### Background
- We have two JReleaser configurations: one for main smithy releases, and one for releasing the CLI itself
- Currently, when running a release, both configurations are used and therefore both releases happen concurrently
- When something goes wrong, it can be difficult to track down the issue, since the logs for each release become intertwined
- By adding a property to control which configuration to apply, we can easily switch between main releases and CLI releases
- We can also remove the stale configuration from the old way of releasing using `nexus-staging` 
- Also, update to latest version of JReleaser (`1.12.0`)

#### Testing
- To verify configurations, you can run with `--dry-run` to see the task order:
  - Do not set a property
    - JReleaser is not configured
  - Set main: `./gradlew jreleaserConfig -P release.main --dry-run`
    - JReleaser is only configured for a main release
  - Set cli: `./gradlew jreleaserConfig -P release.cli --dry-run`
    - JReleaser is only configured for a CLI release
  - Set both: `./gradlew jreleaserConfig -P release.main -P release.cli --dry-run`
    - JReleaser is configured for both (if that's what you really want)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
