### PR TITLE
Add protocol tests for sparse list primitives

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/json-lists.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/json-lists.smithy
@@ -12,6 +12,7 @@ use aws.protocoltests.shared#IntegerEnumList
 use aws.protocoltests.shared#GreetingList
 use aws.protocoltests.shared#IntegerList
 use aws.protocoltests.shared#NestedStringList
+use aws.protocoltests.shared#SparseShortList
 use aws.protocoltests.shared#StringList
 use aws.protocoltests.shared#SparseStringList
 use aws.protocoltests.shared#StringSet
@@ -334,12 +335,17 @@ structure StructureListMember {
                     "sparseStringList": [
                         null,
                         "hi"
+                    ],
+                    "sparseShortList": [
+                        null,
+                        2
                     ]
                 }"""
         bodyMediaType: "application/json"
         headers: {"Content-Type": "application/json"}
         params: {
-            sparseStringList: [null, "hi"]
+            sparseStringList: [null, "hi"],
+            sparseShortList: [null, 2]
         }
     }
 ])
@@ -354,12 +360,17 @@ structure StructureListMember {
                     "sparseStringList": [
                         null,
                         "hi"
+                    ],
+                    "sparseShortList": [
+                        null,
+                        2
                     ]
                 }"""
         bodyMediaType: "application/json"
         headers: {"Content-Type": "application/json"}
         params: {
-            sparseStringList: [null, "hi"]
+            sparseStringList: [null, "hi"],
+            sparseShortList: [null, 2]
         }
     }
 ])
@@ -372,4 +383,5 @@ operation SparseJsonLists {
 
 structure SparseJsonListsInputOutput {
     sparseStringList: SparseStringList
+    sparseShortList: SparseShortList
 }

--- a/smithy-aws-protocol-tests/model/shared-types.smithy
+++ b/smithy-aws-protocol-tests/model/shared-types.smithy
@@ -59,6 +59,11 @@ list ShortList {
     member: Short,
 }
 
+@sparse
+list SparseShortList {
+    member: Short
+}
+
 list IntegerList {
     member: Integer,
 }


### PR DESCRIPTION
#### Background
* What do these changes do? 
Adds a list of sparse shorts to existing sparse list tests

* Why are they important?
In some languages, like Java, Strings are naturally nullable and thus handling sparse collections of String values is straightforward, but sparse collection of values with primitives (such as shorts) may introduce complexities.

#### Testing
* How did you test these changes?
Ran these tests to verify that serde in a language implementation was broken, and then fixed the implementation and verified that tests pass.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
