### PR TITLE
Add param to empty blob tests

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
@@ -196,7 +196,9 @@ apply TestPayloadBlob @httpRequestTests([
         headers: {
             "Content-Type": "application/octet-stream"
         },
-        params: {}
+        params: {
+            contentType: "application/octet-stream"
+        }
     }
 ])
 

--- a/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
@@ -52,10 +52,12 @@ apply HttpPayloadTraits @httpRequestTests([
         body: "",
         bodyMediaType: "application/octet-stream",
         headers: {
-            "X-Foo": "Foo"
+            "X-Foo": "Foo",
+            "Content-Type": "application/octet-stream"
         },
         params: {
-            foo: "Foo"
+            foo: "Foo",
+            contentType: "application/octet-stream"
         }
     },
     {


### PR DESCRIPTION
#### Background
* What do these changes do? 

Content-Type is bound to the contentType member, so if it is expected as a header, it should also be set as a param of the input.

* Why are they important?

When deserializing a request, header binding is generally independent of payload binding. If the request has a header set, it will be bound to the deserialized structure no matter the length of the payload.

#### Testing
* How did you test these changes?

That's the neat part, I didn't!

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
