### PR TITLE
Remove header from empty payload test

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
@@ -193,9 +193,7 @@ apply TestPayloadBlob @httpRequestTests([
         uri: "/blob_payload",
         body: "",
         bodyMediaType: "application/octet-stream",
-        headers: {
-            "Content-Type": "application/octet-stream"
-        },
+        headers: {},
         params: {}
     }
 ])


### PR DESCRIPTION
#### Background
* What do these changes do? 

  When a header is bound to a member, it should be set in both params and headers or in neither. Other empty blob tests do not set a Content-Type header.

* Why are they important?

  Request deserialization tests will fail if they explicitly check the header binding.


#### Testing
* How did you test these changes?

  I didn't!

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
