### PR TITLE
Update JReleaser config to push version tag in main release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -281,14 +281,12 @@ if (project.hasProperty("release.main")) {
     jreleaser {
         dryrun = false
 
-        // Used for creating a tagged release, uploading files and generating changelog.
-        // In the future we can set this up to push release tags to GitHub, but for now it's
-        // set up to do nothing.
-        // https://jreleaser.org/guide/latest/reference/release/index.html
+        // Used for creating and pushing the version tag, but this configuration ensures that
+        // an actual GitHub release isn't created (since the CLI release does that)
         release {
-            generic {
-                enabled = true
+            github {
                 skipRelease = true
+                tagName = '{{projectVersion}}'
             }
         }
 

--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -285,6 +285,8 @@ if (project.hasProperty("release.cli")) {
             github {
                 overwrite = true
                 tagName = '{{projectVersion}}'
+                skipTag = true
+                releaseName = 'Smithy CLI v{{{projectVersion}}}'
                 changelog {
                     // For now, we won't have a changelog added to the release. In the future, we could create a changelog-snippet
                     // from the real changelog as part of a command hook prior to the release step


### PR DESCRIPTION
#### Background
- Currently, the CLI release is what creates and pushes a version tag, which is backwards
- This change makes it so that the tag is created and pushed as part of the main release instead
  - If the tag already exists in the remote, this will (and should) fail
- Also, small change to the release title so that it is consistent with historical release titles
 
#### Testing
- Tested with personal fork
- Checked out 1.50.0 version bump commit, and ran a main-release
- Confirmed no release is created in GitHub and tag is created and pushed

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
