### PR TITLE
Add flexible timestamp validation option for nodes

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampValidationStrategy.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampValidationStrategy.java
@@ -34,7 +34,19 @@ public enum TimestampValidationStrategy implements NodeValidatorPlugin {
     FORMAT {
         @Override
         public void apply(Shape shape, Node value, Context context, Emitter emitter) {
-            new TimestampFormatPlugin().apply(shape, value, context, emitter);
+            new TimestampFormatPlugin(false).apply(shape, value, context, emitter);
+        }
+    },
+
+    /**
+     * Validates timestamps by requiring that the value uses matches the
+     * resolved timestamp format. If there is no resolved timestamp format,
+     * validates that the timestamp matches one of the supported formats.
+     */
+    FORMAT_FLEXIBLE {
+        @Override
+        public void apply(Shape shape, Node value, Context context, Emitter emitter) {
+            new TimestampFormatPlugin(true).apply(shape, value, context, emitter);
         }
     },
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
@@ -312,6 +312,76 @@ public class NodeValidationVisitorTest {
     }
 
     @Test
+    public void flexibleTimestampValidatorSupportsHttpDate() {
+        NodeValidationVisitor visitor = NodeValidationVisitor.builder()
+                .value(Node.from("Tue, 29 Apr 2014 18:30:38 GMT"))
+                .model(MODEL)
+                .timestampValidationStrategy(TimestampValidationStrategy.FORMAT_FLEXIBLE)
+                .build();
+        List<ValidationEvent> events = MODEL
+                .expectShape(ShapeId.from("ns.foo#Timestamp"))
+                .accept(visitor);
+
+        assertThat(events, empty());
+    }
+
+    @Test
+    public void flexibleTimestampValidatorSupportsDateTime() {
+        NodeValidationVisitor visitor = NodeValidationVisitor.builder()
+                .value(Node.from("1985-04-12T23:20:50.52Z"))
+                .model(MODEL)
+                .timestampValidationStrategy(TimestampValidationStrategy.FORMAT_FLEXIBLE)
+                .build();
+        List<ValidationEvent> events = MODEL
+                .expectShape(ShapeId.from("ns.foo#Timestamp"))
+                .accept(visitor);
+
+        assertThat(events, empty());
+    }
+
+    @Test
+    public void flexibleTimestampValidatorSupportsEpochSeconds() {
+        NodeValidationVisitor visitor = NodeValidationVisitor.builder()
+                .value(Node.from(1234))
+                .model(MODEL)
+                .timestampValidationStrategy(TimestampValidationStrategy.FORMAT_FLEXIBLE)
+                .build();
+        List<ValidationEvent> events = MODEL
+                .expectShape(ShapeId.from("ns.foo#Timestamp"))
+                .accept(visitor);
+
+        assertThat(events, empty());
+    }
+
+    @Test
+    public void flexibleTimestampValidatorRejectsInvalidStrings() {
+        NodeValidationVisitor visitor = NodeValidationVisitor.builder()
+                .value(Node.from("foo"))
+                .model(MODEL)
+                .timestampValidationStrategy(TimestampValidationStrategy.FORMAT_FLEXIBLE)
+                .build();
+        List<ValidationEvent> events = MODEL
+                .expectShape(ShapeId.from("ns.foo#Timestamp"))
+                .accept(visitor);
+
+        assertThat(events, not(empty()));
+    }
+
+    @Test
+    public void flexibleTimestampValidatorRejectsInvalidNodeTypes() {
+        NodeValidationVisitor visitor = NodeValidationVisitor.builder()
+                .value(Node.from(true))
+                .model(MODEL)
+                .timestampValidationStrategy(TimestampValidationStrategy.FORMAT_FLEXIBLE)
+                .build();
+        List<ValidationEvent> events = MODEL
+                .expectShape(ShapeId.from("ns.foo#Timestamp"))
+                .accept(visitor);
+
+        assertThat(events, not(empty()));
+    }
+
+    @Test
     public void doesNotAllowNullByDefault() {
         NodeValidationVisitor visitor = NodeValidationVisitor.builder()
                 .value(Node.nullNode())


### PR DESCRIPTION
This updates the node validator to add a timestamp validation strategy that will accept any one of the valid timestamp formats if there is no timestamp format trait. This can be useful when writing protocol tests or example traits for protocols where the default format is dependent on the binding location.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
