### PR TITLE
Fix RestJsonMalformedPatternReDOSString test

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/validation/malformed-pattern.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/malformed-pattern.smithy
@@ -78,8 +78,8 @@ apply MalformedPattern @httpMalformedRequestTests([
                 mediaType: "application/json",
                 assertion: {
                     contents: """
-                    { "message" : "1 validation error detected. Value 000000000000000000000000000000000000000000000000000000000000000000000000000000000000! at '/evilString' failed to satisfy constraint: Member must satisfy regular expression pattern: ^([0-9]+)+$$",
-                      "fieldList" : [{"message": "Value 000000000000000000000000000000000000000000000000000000000000000000000000000000000000! at '/evilString' failed to satisfy constraint: Member must satisfy regular expression pattern: ^([0-9]+)+$$", "path": "/evilString"}]}"""
+                    { "message" : "1 validation error detected. Value at '/evilString' failed to satisfy constraint: Member must satisfy regular expression pattern: ^([0-9]+)+$$",
+                      "fieldList" : [{"message": "Value at '/evilString' failed to satisfy constraint: Member must satisfy regular expression pattern: ^([0-9]+)+$$", "path": "/evilString"}]}"""
                 }
             }
         }


### PR DESCRIPTION
The test was attempted to be fixed as part of https://github.com/smithy-lang/smithy/issues/1506. None of the other
tests echo back the value that failed the regex.

#### Testing

Ran tests in smithy-rs.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
