### PR TITLE
Fix expected defaultTimestamp value in RestJsonClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/defaults.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/defaults.smithy
@@ -323,7 +323,7 @@ apply OperationWithDefaults @httpResponseTests([
             defaultDocumentBoolean: false
             defaultDocumentList: ["b"]
             defaultNullDocument: "notNull"
-            defaultTimestamp: 1
+            defaultTimestamp: 2
             defaultBlob: "hi"
             defaultByte: 2
             defaultShort: 2


### PR DESCRIPTION
This PR updates the expected `defaultTimestamp` to 2 in `RestJsonClientIgnoresDefaultValuesIfMemberValuesArePresentInResponse`. The value 1 may have been incorrectly specified [in this PR](https://github.com/smithy-lang/smithy/pull/2280) based on the corresponding Rails Json test where the timestamp format is httpdate instead of epoch seconds.

The issue was discovered while upgrading Smithy to 1.50.0 in the [smithy-rs](https://github.com/smithy-lang/smithy-rs) repository.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
