### PR TITLE
Add restJson1 protocol test for content-type and POST operation with no input

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
@@ -228,7 +228,7 @@ structure TestPayloadBlobInputOutput {
     data: Blob
 }
 
-/// This example operation serializes a request without an HTTP body.
+/// This example GET operation serializes a request without a modeled HTTP body.
 ///
 /// These tests are to ensure we do not attach a body or related headers
 /// (Content-Length, Content-Type) to operations that semantically
@@ -278,7 +278,7 @@ apply TestGetNoPayload @httpRequestTests([
     }
 ])
 
-/// This example operation serializes a request without an HTTP body for POST.
+/// This example POST operation serializes a request without a modeled HTTP body.
 ///
 /// These tests are to ensure we do not attach a body or related headers
 /// (Content-Type) to a POST operation with no modeled payload.
@@ -330,21 +330,15 @@ structure TestNoPayloadInputOutput {
     testId: String,
 }
 
-/// This example operation has no input and serializes a request without an HTTP body.
+/// This example GET operation has no input and serializes a request without a modeled HTTP body.
 ///
 /// These tests are to ensure we do not attach a body or related headers
-/// (Content-, Content-Type) to operations that semantically
+/// (Content-Length, Content-Type) to operations that semantically
 /// cannot produce an HTTP body.
 ///
 @readonly
 @http(uri: "/no_input_no_payload", method: "GET")
 operation TestGetNoInputNoPayload {
-    output: TestNoPayloadInputOutput
-}
-
-@readonly
-@http(uri: "/no_input_no_payload", method: "POST")
-operation TestPostNoInputNoPayload {
     output: TestNoPayloadInputOutput
 }
 
@@ -363,6 +357,17 @@ apply TestGetNoInputNoPayload @httpRequestTests([
         params: {}
     }
 ])
+
+/// This example POST operation has no input and serializes a request without a modeled HTTP body.
+///
+/// These tests are to ensure we do not attach a body or related headers
+/// (Content-Type) to a POST operation with no modeled input.
+///
+@readonly
+@http(uri: "/no_input_no_payload", method: "POST")
+operation TestPostNoInputNoPayload {
+    output: TestNoPayloadInputOutput
+}
 
 apply TestPostNoInputNoPayload @httpRequestTests([
     {

--- a/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
@@ -330,7 +330,7 @@ structure TestNoPayloadInputOutput {
     testId: String,
 }
 
-/// This example GET operation has no input and serializes a request without a modeled HTTP body.
+/// This example GET operation has no input and serializes a request without a HTTP body.
 ///
 /// These tests are to ensure we do not attach a body or related headers
 /// (Content-Length, Content-Type) to operations that semantically
@@ -358,7 +358,7 @@ apply TestGetNoInputNoPayload @httpRequestTests([
     }
 ])
 
-/// This example POST operation has no input and serializes a request without a modeled HTTP body.
+/// This example POST operation has no input and serializes a request without a HTTP body.
 ///
 /// These tests are to ensure we do not attach a body or related headers
 /// (Content-Type) to a POST operation with no modeled input.

--- a/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
@@ -236,14 +236,14 @@ structure TestPayloadBlobInputOutput {
 ///
 @readonly
 @http(uri: "/no_payload", method: "GET")
-operation TestNoPayload {
+operation TestGetNoPayload {
     input: TestNoPayloadInputOutput,
     output: TestNoPayloadInputOutput
 }
 
-apply TestNoPayload @httpRequestTests([
+apply TestGetNoPayload @httpRequestTests([
     {
-        id: "RestJsonHttpWithNoModeledBody",
+        id: "RestJsonHttpGetWithNoModeledBody",
         documentation: "Serializes a GET request with no modeled body",
         protocol: restJson1,
         method: "GET",
@@ -257,9 +257,9 @@ apply TestNoPayload @httpRequestTests([
     }
 ])
 
-apply TestNoPayload @httpRequestTests([
+apply TestGetNoPayload @httpRequestTests([
     {
-        id: "RestJsonHttpWithHeaderMemberNoModeledBody",
+        id: "RestJsonHttpGetWithHeaderMemberNoModeledBody",
         documentation: "Serializes a GET request with header member but no modeled body",
         protocol: restJson1,
         method: "GET",
@@ -278,6 +278,53 @@ apply TestNoPayload @httpRequestTests([
     }
 ])
 
+/// This example operation serializes a request without an HTTP body for POST.
+///
+/// These tests are to ensure we do not attach a body or related headers
+/// (Content-Type) to a POST operation with no modeled payload.
+///
+@readonly
+@http(uri: "/no_payload", method: "POST")
+operation TestPostNoPayload {
+    input: TestNoPayloadInputOutput,
+    output: TestNoPayloadInputOutput
+}
+
+apply TestPostNoPayload @httpRequestTests([
+    {
+        id: "RestJsonHttpPostWithNoModeledBody",
+        documentation: "Serializes a POST request with no modeled body",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/no_payload",
+        body: "",
+        forbidHeaders: [
+            "Content-Type"
+        ],
+        params: {}
+    }
+])
+
+apply TestPostNoPayload @httpRequestTests([
+    {
+        id: "RestJsonHttpWithPostHeaderMemberNoModeledBody",
+        documentation: "Serializes a POST request with header member but no modeled body",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/no_payload",
+        body: "",
+        headers: {
+            "X-Amz-Test-Id": "t-12345"
+        },
+        forbidHeaders: [
+            "Content-Type"
+        ],
+        params: {
+            testId: "t-12345"
+        }
+    }
+])
+
 structure TestNoPayloadInputOutput {
     @httpHeader("X-Amz-Test-Id")
     testId: String,
@@ -286,7 +333,7 @@ structure TestNoPayloadInputOutput {
 /// This example operation has no input and serializes a request without an HTTP body.
 ///
 /// These tests are to ensure we do not attach a body or related headers
-/// (Content-Length, Content-Type) to operations that semantically
+/// (Content-, Content-Type) to operations that semantically
 /// cannot produce an HTTP body.
 ///
 @readonly

--- a/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-content-type.smithy
@@ -291,20 +291,41 @@ structure TestNoPayloadInputOutput {
 ///
 @readonly
 @http(uri: "/no_input_no_payload", method: "GET")
-operation TestNoInputNoPayload {
+operation TestGetNoInputNoPayload {
     output: TestNoPayloadInputOutput
 }
 
-apply TestNoInputNoPayload @httpRequestTests([
+@readonly
+@http(uri: "/no_input_no_payload", method: "POST")
+operation TestPostNoInputNoPayload {
+    output: TestNoPayloadInputOutput
+}
+
+apply TestGetNoInputNoPayload @httpRequestTests([
     {
-        id: "RestJsonHttpWithNoInput",
+        id: "RestJsonHttpGetWithNoInput",
         documentation: "Serializes a GET request for an operation with no input, and therefore no modeled body",
         protocol: restJson1,
         method: "GET",
         uri: "/no_input_no_payload",
         body: "",
         forbidHeaders: [
-            "Content-Length",
+            "Content-Type",
+            "Content-Length"
+        ],
+        params: {}
+    }
+])
+
+apply TestPostNoInputNoPayload @httpRequestTests([
+    {
+        id: "RestJsonHttpPostWithNoInput",
+        documentation: "Serializes a POST request for an operation with no input, and therefore no modeled body",
+        protocol: restJson1,
+        method: "POST",
+        uri: "/no_input_no_payload",
+        body: "",
+        forbidHeaders: [
             "Content-Type"
         ],
         params: {}

--- a/smithy-aws-protocol-tests/model/restJson1/main.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/main.smithy
@@ -144,8 +144,10 @@ service RestJson {
         TestBodyStructure,
         TestPayloadStructure,
         TestPayloadBlob,
-        TestNoPayload,
-        TestNoInputNoPayload,
+        TestGetNoPayload
+        TestPostNoPayload,
+        TestGetNoInputNoPayload,
+        TestPostNoInputNoPayload,
 
         // client-only timestamp parsing tests
         DatetimeOffsets,


### PR DESCRIPTION
#### Background
- Same as https://github.com/smithy-lang/smithy/pull/2322 but with a POST operation
- We should test both cases explicitly, since code-generation may have faulty assumptions (https://github.com/aws/aws-sdk-net/pull/3338)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
