### PR TITLE
Add hiring announcement

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,14 +33,13 @@ html_theme_options = {
         "admonition-title-font-size": "100%",
         "color-brand-primary": "#C44536",
         "color-brand-content": "#00808b",
-        "color-announcement-background": "#711818de",
-        "color-announcement-text": "#fff"
+        "color-announcement-background": "#f8f8f8",
+        "color-announcement-text": "#383838"
     },
     "dark_css_variables": {
         "color-brand-primary": "#ed9d13",
         "color-brand-content": "#58d3ff",
-        "color-announcement-background": "#711818de",
-        "color-announcement-text": "#fff"
+        "color-announcement-background": "##1a1c1e;",
     },
     "footer_icons": [
         {

--- a/docs/source-2.0/conf.py
+++ b/docs/source-2.0/conf.py
@@ -12,3 +12,6 @@ release = u'2.0'
 version = release
 
 html_theme_options['source_directory'] = "docs/source-2.0"
+html_theme_options['announcement'] = '''<strong>The Smithy team at AWS is hiring software engineers.</strong>
+<br>Interested? Check out our job postings <a href="https://www.amazon.jobs/en/search?base_query=Smithy">here</a>.
+'''


### PR DESCRIPTION
#### Background
- Adds a hiring announcement to the smithy.io site, which links to open positions
- We may revert the announcement color changes when we remove the banner

#### Testing
- Rendered the doc-site locally, screenshots of both light and dark themes are attached

Light
![Screenshot 2024-07-03 at 9 36 55 AM](https://github.com/smithy-lang/smithy/assets/26096419/ceca20c8-903d-4ecf-93ae-9da573db7709)

Dark
![Screenshot 2024-07-03 at 9 37 07 AM](https://github.com/smithy-lang/smithy/assets/26096419/3cda85a4-56ab-47f4-a9eb-50fc084186eb)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
