### PR TITLE
Update make-docs.yml to remove old docs first

### DIFF
--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -79,7 +79,8 @@ jobs:
     - name: Copy artifacts
       run: |
         git pull
-        cp -R /tmp/smithy-docs/* .
+        rm -r 1.0/ 2.0/
+        mv /tmp/smithy-docs/* .
         git config --global user.name "smithy-automation"
         git config --global user.email "github-smithy-automation@amazon.com"
         git add -A


### PR DESCRIPTION
#### Background
- When running this workflow, `cp -r` causes directories to be merged, instead of overwritten
- This means that files that get renamed or removed will not actually get deleted ([example](https://smithy.io/2.0/guides/gradle-plugin.html) - this shouldn't exist anymore ([stale source](https://github.com/smithy-lang/smithy/blob/gh-pages/2.0/guides/gradle-plugin.html)))
- The solution is to remove the checked-out doc directories first, and then move over doc-build artifacts
  - `mv` cannot overwrite non-empty directories, so we have to delete them first

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
