### PR TITLE
Add model directories to the source directories

### DIFF
--- a/smithy-aws-protocol-tests/build.gradle
+++ b/smithy-aws-protocol-tests/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 
 tasks["sourcesJar"].dependsOn("smithyJarStaging")
 
+sourceSets.main.java.srcDirs += ['model']
+
 smithy {
     format.set(false)
     smithyBuildConfigs.set(project.files())

--- a/smithy-protocol-tests/build.gradle
+++ b/smithy-protocol-tests/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 
 tasks["sourcesJar"].dependsOn("smithyJarStaging")
 
+sourceSets.main.java.srcDirs += ['model']
+
 smithy {
     format.set(false)
     smithyBuildConfigs.set(project.files())

--- a/smithy-validation-model/build.gradle
+++ b/smithy-validation-model/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 
 tasks["sourcesJar"].dependsOn("smithyJarStaging")
 
+sourceSets.main.java.srcDirs += ['model']
+
 smithy {
     smithyBuildConfigs.set(project.files())
 }


### PR DESCRIPTION
#### Background
* What do these changes do? 

Marks model directories as the sources directories in `gradle.build` files

* Why are they important?

This helps IntelliJ to identify those directories as sources and use the Smithy IntelliJ plugin on those smithy files in those directories.

#### Testing

* How did you test these changes?

Manually loading the project in IntelliJ.


#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
