### PR TITLE
Use venv when building docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,19 +2,20 @@
 SPHINXOPTS    =
 SPHINXBUILD   = python3 -msphinx
 SPHINXPROJ    = Smithy
+SHELL         := /bin/bash
 
 install:
-	pip3 install -r requirements.txt .
-	pip3 install -e .
+	python3 -m venv build/venv
+	source build/venv/bin/activate && pip3 install -r requirements.txt . && pip3 install -e .
 
 clean:
 	-rm -rf build/*
 
 html1:
-	@$(SPHINXBUILD) -M html "source-1.0" "build/1.0" $(SPHINXOPTS) -W --keep-going -n $(O)
+	@source build/venv/bin/activate && $(SPHINXBUILD) -M html "source-1.0" "build/1.0" $(SPHINXOPTS) -W --keep-going -n $(O)
 
 html2:
-	@$(SPHINXBUILD) -M html "source-2.0" "build/2.0" $(SPHINXOPTS) -W --keep-going -n $(O)
+	@source build/venv/bin/activate && $(SPHINXBUILD) -M html "source-2.0" "build/2.0" $(SPHINXOPTS) -W --keep-going -n $(O)
 
 html: html2 html1 merge-versions
 


### PR DESCRIPTION
MacOS and homebrew don't like installing global Python packages, so this solves that automatically.
