### PR TITLE
Check the stringArray type ignoring case

### DIFF
--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/parameters/ParameterType.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/parameters/ParameterType.java
@@ -51,7 +51,7 @@ public enum ParameterType {
         if (value.equalsIgnoreCase("boolean")) {
             return BOOLEAN;
         }
-        if (value.equals("stringArray")) {
+        if (value.equalsIgnoreCase("stringArray")) {
             return STRING_ARRAY;
         }
         throw new RuleError(new SourceException(


### PR DESCRIPTION
As reported in #2347 the stringArray parameter type is tested using equals whereas the other, `boolean` and `string` are tested ignoring case. This change aligns `stringArray` to also be tested ignoring case.

#### Background
* What do these changes do? 
* Why are they important?

#### Testing

#### Links
* Issue #2347

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
