### PR TITLE
Add validator to warn on ignored idempotency token trait

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/IdempotencyTokenIgnoredValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/IdempotencyTokenIgnoredValidator.java
@@ -5,8 +5,6 @@
 
 package software.amazon.smithy.model.validation.validators;
 
-import static java.lang.String.format;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -15,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
 import software.amazon.smithy.model.neighbor.NeighborProvider;
@@ -29,7 +28,6 @@ import software.amazon.smithy.model.traits.MixinTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
-import software.amazon.smithy.utils.ListUtils;
 
 /**
  * Emits warnings when a structure member has an idempotency token trait that will be ignored.
@@ -43,31 +41,28 @@ public final class IdempotencyTokenIgnoredValidator extends AbstractValidator {
         }
         List<ValidationEvent> events = new ArrayList<>();
         NeighborProvider reverse = NeighborProviderIndex.of(model).getReverseProvider();
-        for (MemberShape memberShape : model.getMemberShapes()) {
+        for (MemberShape memberShape : model.getMemberShapesWithTrait(IdempotencyTokenTrait.class)) {
             Shape container = model.expectShape(memberShape.getContainer());
             // Skip non-structures (invalid) and mixins (handled at mixed site).
             if (!container.isStructureShape() || container.hasTrait(MixinTrait.class)) {
                 continue;
             }
-
-            if (memberShape.hasTrait(IdempotencyTokenTrait.class)) {
-                Trait trait = memberShape.expectTrait(IdempotencyTokenTrait.class);
-                events.addAll(checkRelationships(container.asStructureShape().get(), memberShape, trait, reverse));
-            }
+            Trait trait = memberShape.expectTrait(IdempotencyTokenTrait.class);
+            checkRelationships(container.asStructureShape().get(), memberShape, trait, reverse, events);
         }
         return events;
     }
 
-    private List<ValidationEvent> checkRelationships(
+    private void checkRelationships(
         StructureShape containerShape,
         MemberShape memberShape,
         Trait trait,
-        NeighborProvider reverse
+        NeighborProvider reverse,
+        List<ValidationEvent> events
     ) {
 
         // Store relationships so we can emit one event per ignored binding.
         Map<RelationshipType, List<ShapeId>> ignoredRelationships = new TreeMap<>();
-        List<ValidationEvent> events = new ArrayList<>();
         List<Relationship> relationships = reverse.getNeighbors(containerShape);
         int checkedRelationshipCount = relationships.size();
         for (Relationship relationship : relationships) {
@@ -77,54 +72,40 @@ public final class IdempotencyTokenIgnoredValidator extends AbstractValidator {
                 continue;
             }
             if (relationship.getRelationshipType() != RelationshipType.INPUT) {
-                ignoredRelationships.merge(relationship.getRelationshipType(),
-                                           ListUtils.of(relationship.getShape().getId()), this::mergeShapeIdLists);
+                ignoredRelationships.computeIfAbsent(relationship.getRelationshipType(), x -> new ArrayList<>())
+                                    .add(relationship.getShape().getId());
             }
         }
 
         // If we detected invalid relationships, build the right event message.
         if (!ignoredRelationships.isEmpty()) {
-            events.add(emit(memberShape, trait, checkedRelationshipCount, ignoredRelationships));
+            events.add(emit(memberShape, trait, ignoredRelationships));
         }
-
-        return events;
-    }
-
-    private List<ShapeId> mergeShapeIdLists(List<ShapeId> shapeIds1, List<ShapeId> shapeIds2) {
-        List<ShapeId> shapeIds = new ArrayList<>();
-        shapeIds.addAll(shapeIds1);
-        shapeIds.addAll(shapeIds2);
-        return shapeIds;
     }
 
     private ValidationEvent emit(
         MemberShape memberShape,
         Trait trait,
-        int checkedRelationshipCount,
         Map<RelationshipType, List<ShapeId>> ignoredRelationships
     ) {
-        String mixedIn = memberShape.getMixins().isEmpty() ? "" : " mixed in";
-        String message = "The `%s` trait applied to this%s member is ";
-        if (checkedRelationshipCount == ignoredRelationships.size()) {
-            message += "ignored in all contexts.";
-        } else {
-            message += "ignored in some contexts: " + formatIgnoredRelationships(ignoredRelationships);
-        }
-        return warning(memberShape, trait, format(message, Trait.getIdiomaticTraitName(trait), mixedIn));
+        String message =
+            "The `idempotencyToken` trait only has an effect when applied to a top-level operation input member, "
+            + "but it was applied and ignored in the following contexts: "
+            + formatIgnoredRelationships(ignoredRelationships);
+        return warning(memberShape, trait, message);
     }
 
     private String formatIgnoredRelationships(Map<RelationshipType, List<ShapeId>> ignoredRelationships) {
         List<String> relationshipTypeBindings = new ArrayList<>();
         for (Map.Entry<RelationshipType, List<ShapeId>> ignoredRelationshipType : ignoredRelationships.entrySet()) {
-            StringBuilder stringBuilder = new StringBuilder(ignoredRelationshipType.getKey().toString()
-                                                                                   .toLowerCase(Locale.US)
-                                                                                   .replace("_", " "));
-            Set<String> bindings = new TreeSet<>();
-            for (ShapeId binding : ignoredRelationshipType.getValue()) {
-                bindings.add(binding.toString());
-            }
-            stringBuilder.append(": [").append(String.join(", ", bindings)).append("]");
-            relationshipTypeBindings.add(stringBuilder.toString());
+            StringBuilder buf = new StringBuilder(ignoredRelationshipType.getKey().toString()
+                                                                         .toLowerCase(Locale.US)
+                                                                         .replace("_", " "));
+            Set<String> bindings = ignoredRelationshipType.getValue().stream()
+                                                          .map(ShapeId::toString)
+                                                          .collect(Collectors.toCollection(TreeSet::new));
+            buf.append(": [").append(String.join(", ", bindings)).append("]");
+            relationshipTypeBindings.add(buf.toString());
         }
         return "{" + String.join(", ", relationshipTypeBindings) + "}";
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/IdempotencyTokenIgnoredValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/IdempotencyTokenIgnoredValidator.java
@@ -64,11 +64,9 @@ public final class IdempotencyTokenIgnoredValidator extends AbstractValidator {
         // Store relationships so we can emit one event per ignored binding.
         Map<RelationshipType, List<ShapeId>> ignoredRelationships = new TreeMap<>();
         List<Relationship> relationships = reverse.getNeighbors(containerShape);
-        int checkedRelationshipCount = relationships.size();
         for (Relationship relationship : relationships) {
             // Skip members of the container.
             if (relationship.getRelationshipType() == RelationshipType.MEMBER_CONTAINER) {
-                checkedRelationshipCount--;
                 continue;
             }
             if (relationship.getRelationshipType() != RelationshipType.INPUT) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/IdempotencyTokenIgnoredValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/IdempotencyTokenIgnoredValidator.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.model.validation.validators;
+
+import static java.lang.String.format;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.knowledge.NeighborProviderIndex;
+import software.amazon.smithy.model.neighbor.NeighborProvider;
+import software.amazon.smithy.model.neighbor.Relationship;
+import software.amazon.smithy.model.neighbor.RelationshipType;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
+import software.amazon.smithy.model.traits.MixinTrait;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.utils.ListUtils;
+
+/**
+ * Emits warnings when a structure member has an idempotency token trait that will be ignored.
+ */
+public class IdempotencyTokenIgnoredValidator extends AbstractValidator {
+
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        if (!model.getAppliedTraits().contains(IdempotencyTokenTrait.ID)) {
+            return Collections.emptyList();
+        }
+        List<ValidationEvent> events = new ArrayList<>();
+        NeighborProvider reverse = NeighborProviderIndex.of(model).getReverseProvider();
+        for (MemberShape memberShape : model.getMemberShapes()) {
+            Shape container = model.expectShape(memberShape.getContainer());
+            // Skip non-structures (invalid) and mixins (handled at mixed site).
+            if (!container.isStructureShape() || container.hasTrait(MixinTrait.class)) {
+                continue;
+            }
+
+            if (memberShape.hasTrait(IdempotencyTokenTrait.class)) {
+                Trait trait = memberShape.expectTrait(IdempotencyTokenTrait.class);
+                events.addAll(checkRelationships(container.asStructureShape().get(), memberShape, trait, reverse));
+            }
+        }
+        return events;
+    }
+
+    private List<ValidationEvent> checkRelationships(
+        StructureShape containerShape,
+        MemberShape memberShape,
+        Trait trait,
+        NeighborProvider reverse
+    ) {
+
+        // Store relationships so we can emit one event per ignored binding.
+        Map<RelationshipType, List<ShapeId>> ignoredRelationships = new TreeMap<>();
+        List<ValidationEvent> events = new ArrayList<>();
+        List<Relationship> relationships = reverse.getNeighbors(containerShape);
+        int checkedRelationshipCount = relationships.size();
+        for (Relationship relationship : relationships) {
+            // Skip members of the container.
+            if (relationship.getRelationshipType() == RelationshipType.MEMBER_CONTAINER) {
+                checkedRelationshipCount--;
+                continue;
+            }
+            if (relationship.getRelationshipType() != RelationshipType.INPUT) {
+                ignoredRelationships.merge(relationship.getRelationshipType(),
+                                           ListUtils.of(relationship.getShape().getId()), this::mergeShapeIdLists);
+            }
+        }
+
+        // If we detected invalid relationships, build the right event message.
+        if (!ignoredRelationships.isEmpty()) {
+            events.add(emit(memberShape, trait, checkedRelationshipCount, ignoredRelationships));
+        }
+
+        return events;
+    }
+
+    private List<ShapeId> mergeShapeIdLists(List<ShapeId> shapeIds1, List<ShapeId> shapeIds2) {
+        List<ShapeId> shapeIds = new ArrayList<>();
+        shapeIds.addAll(shapeIds1);
+        shapeIds.addAll(shapeIds2);
+        return shapeIds;
+    }
+
+    private ValidationEvent emit(
+        MemberShape memberShape,
+        Trait trait,
+        int checkedRelationshipCount,
+        Map<RelationshipType, List<ShapeId>> ignoredRelationships
+    ) {
+        String mixedIn = memberShape.getMixins().isEmpty() ? "" : " mixed in";
+        String message = "The `%s` trait applied to this%s member is ";
+        if (checkedRelationshipCount == ignoredRelationships.size()) {
+            message += "ignored in all contexts.";
+        } else {
+            message += "ignored in some contexts: " + formatIgnoredRelationships(ignoredRelationships);
+        }
+        return warning(memberShape, trait, format(message, Trait.getIdiomaticTraitName(trait), mixedIn));
+    }
+
+    private String formatIgnoredRelationships(Map<RelationshipType, List<ShapeId>> ignoredRelationships) {
+        List<String> relationshipTypeBindings = new ArrayList<>();
+        for (Map.Entry<RelationshipType, List<ShapeId>> ignoredRelationshipType : ignoredRelationships.entrySet()) {
+            StringBuilder stringBuilder = new StringBuilder(ignoredRelationshipType.getKey().toString()
+                                                                                   .toLowerCase(Locale.US)
+                                                                                   .replace("_", " "));
+            Set<String> bindings = new TreeSet<>();
+            for (ShapeId binding : ignoredRelationshipType.getValue()) {
+                bindings.add(binding.toString());
+            }
+            stringBuilder.append(": [").append(String.join(", ", bindings)).append("]");
+            relationshipTypeBindings.add(stringBuilder.toString());
+        }
+        return "{" + String.join(", ", relationshipTypeBindings) + "}";
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/IdempotencyTokenIgnoredValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/IdempotencyTokenIgnoredValidator.java
@@ -34,7 +34,7 @@ import software.amazon.smithy.utils.ListUtils;
 /**
  * Emits warnings when a structure member has an idempotency token trait that will be ignored.
  */
-public class IdempotencyTokenIgnoredValidator extends AbstractValidator {
+public final class IdempotencyTokenIgnoredValidator extends AbstractValidator {
 
     @Override
     public List<ValidationEvent> validate(Model model) {

--- a/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/smithy-model/src/main/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -22,6 +22,7 @@ software.amazon.smithy.model.validation.validators.HttpResponseCodeSemanticsVali
 software.amazon.smithy.model.validation.validators.HttpUriGreedyLabelValidator
 software.amazon.smithy.model.validation.validators.HttpUriConflictValidator
 software.amazon.smithy.model.validation.validators.HttpUriFormatValidator
+software.amazon.smithy.model.validation.validators.IdempotencyTokenIgnoredValidator
 software.amazon.smithy.model.validation.validators.JsonNameValidator
 software.amazon.smithy.model.validation.validators.LengthTraitValidator
 software.amazon.smithy.model.validation.validators.MediaTypeValidator

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/idempotency-token-trait-ignored.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/idempotency-token-trait-ignored.errors
@@ -1,0 +1,4 @@
+[WARNING] io.smithy.example#StructureOne$stringMember: The `idempotencyToken` trait applied to this member is ignored in some contexts: {member target: [io.smithy.example#StructureTwo$structureOne]} | IdempotencyTokenIgnored
+[WARNING] io.smithy.example#StructureThree$stringMember: The `idempotencyToken` trait applied to this mixed in member is ignored in some contexts: {output: [io.smithy.example#OperationFour]} | IdempotencyTokenIgnored
+
+

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/idempotency-token-trait-ignored.errors
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/idempotency-token-trait-ignored.errors
@@ -1,4 +1,3 @@
-[WARNING] io.smithy.example#StructureOne$stringMember: The `idempotencyToken` trait applied to this member is ignored in some contexts: {member target: [io.smithy.example#StructureTwo$structureOne]} | IdempotencyTokenIgnored
-[WARNING] io.smithy.example#StructureThree$stringMember: The `idempotencyToken` trait applied to this mixed in member is ignored in some contexts: {output: [io.smithy.example#OperationFour]} | IdempotencyTokenIgnored
-
+[WARNING] io.smithy.example#StructureOne$stringMember: The `idempotencyToken` trait only has an effect when applied to a top-level operation input member, but it was applied and ignored in the following contexts: {member target: [io.smithy.example#StructureTwo$structureOne]} | IdempotencyTokenIgnored
+[WARNING] io.smithy.example#StructureThree$stringMember: The `idempotencyToken` trait only has an effect when applied to a top-level operation input member, but it was applied and ignored in the following contexts: {output: [io.smithy.example#OperationFour]} | IdempotencyTokenIgnored
 

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/idempotency-token-trait-ignored.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/errorfiles/validators/idempotency-token-trait-ignored.smithy
@@ -1,0 +1,62 @@
+$version: "2"
+
+namespace io.smithy.example
+
+service SmithyExample {
+    operations: [
+        OperationOne
+        OperationTwo
+        OperationThree
+        OperationFour
+    ]
+}
+
+operation OperationOne {
+    input := {
+        @idempotencyToken
+        stringMember: String
+        integerMember: Integer
+    }
+    output: Unit
+}
+
+operation OperationTwo {
+    input: StructureOne
+    output: Unit
+}
+
+operation OperationThree {
+    input: StructureTwo
+    output: Unit
+}
+
+operation OperationFour {
+    input: StructureThree
+    output: StructureThree
+}
+
+
+structure StructureOne {
+    @idempotencyToken
+    stringMember: String
+    integerMember: Integer
+}
+
+
+structure StructureTwo {
+    stringMember: String
+    structureOne: StructureOne
+}
+
+
+@mixin
+structure StructureMixin {
+    @idempotencyToken
+    stringMember: String
+}
+
+
+structure StructureThree with [StructureMixin] {
+    integerMember: Integer
+}
+


### PR DESCRIPTION
#### Background
* What do these changes do? 

Added a validator to warn on ignored use of @idempotencyToken trait. As per [spec](https://smithy.io/2.0/spec/behavior-traits.html#idempotencytoken-trait), 

> Only a single member of the input of an operation can be targeted by the idempotencyToken trait; only top-level structure members of the input of an operation are considered.

This validator warns when we find a member using the trait in a context where it will be ignored. We cannot ERROR here as the structures might be reused in valid and invalid context, thus we only warning about the context where it will be ignored.

* Why are they important?

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
