### PR TITLE
add doc autobuild and dev target

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,9 +4,10 @@ SPHINXBUILD   = python3 -msphinx
 SPHINXPROJ    = Smithy
 SHELL         := /bin/bash
 
-install:
+install: requirements.txt
 	python3 -m venv build/venv
 	source build/venv/bin/activate && pip3 install -r requirements.txt . && pip3 install -e .
+	touch install
 
 clean:
 	-rm -rf build/*
@@ -27,5 +28,8 @@ merge-versions:
 
 openhtml:
 	open "build/html/index.html"
+
+dev: install
+	@source build/venv/bin/activate && sphinx-autobuild "source-2.0" "build/2.0" $(SPHINXOPTS) $(O)
 
 .PHONY: Makefile clean

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,4 @@ Sphinx-Substitution-Extensions==2022.2.16
 sphinx-tabs>=3.4.4
 
 sphinx_copybutton==0.5.0
+sphinx-autobuild>=2024.4.16


### PR DESCRIPTION
#### Background
- We don't have a great doc-writing experience (lots of outdated tooling for rst/sphinx)
- This doesn't make it much better, but it does add incremental autobuild
- Making updates to a doc-file renders in ~2 seconds, making it easier to see your changes live

#### Testing
- run `make dev`, should install and run autobuild
- run `touch requirements.txt`, should re-run install and run autobuild

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
