### PR TITLE
Make the `NonEmptyString` type public

### DIFF
--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -552,7 +552,6 @@ structure xmlNamespace {
     prefix: NonEmptyString
 }
 
-@private
 @length(min: 1)
 string NonEmptyString
 


### PR DESCRIPTION
Any reason to keep it private?

It's a quite useful type.
Making it private forces everyone to redefine it