### PR TITLE
More httpChecksum trait validation for responses

### DIFF
--- a/docs/source-2.0/aws/aws-core.rst
+++ b/docs/source-2.0/aws/aws-core.rst
@@ -958,7 +958,8 @@ The ``httpChecksum`` trait is a structure that contains the following members:
 The ``httpChecksum`` trait MUST define at least one of the request checksumming
 behavior, by setting the ``requestAlgorithmMember`` or
 ``requestChecksumRequired`` property, or the response checksumming behavior, by
-setting the ``requestValidationModeMember`` property.
+setting the ``requestValidationModeMember`` and ``responseAlgorithms``
+properties.
 
 The following is an example of the ``httpChecksum`` trait that defines required
 request checksum behavior with support for the "CRC32C", "CRC32", "SHA1", and

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/http-checksum-trait.errors
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/http-checksum-trait.errors
@@ -1,5 +1,7 @@
 [SUPPRESSED] smithy.example#NoBehavior: This shape applies a trait that is unstable: aws.protocols#httpChecksum | UnstableTrait
 [SUPPRESSED] smithy.example#NoModeForResponse: This shape applies a trait that is unstable: aws.protocols#httpChecksum | UnstableTrait
 [SUPPRESSED] smithy.example#NoOutputForResponse: This shape applies a trait that is unstable: aws.protocols#httpChecksum | UnstableTrait
+[SUPPRESSED] smithy.example#NoResponseAlgorithms: This shape applies a trait that is unstable: aws.protocols#httpChecksum | UnstableTrait
 [ERROR] smithy.example#NoBehavior: The `httpChecksum` trait must define at least one of the `request` or `response` checksum behaviors. | HttpChecksumTrait
 [ERROR] smithy.example#NoModeForResponse: The `httpChecksum` trait must model the `requestValidationModeMember` property to support response checksum behavior. | HttpChecksumTrait
+[ERROR] smithy.example#NoResponseAlgorithms: The `httpChecksum` trait must model the `responseAlgorithms` property to support response checksum behavior. | HttpChecksumTrait

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/http-checksum-trait.smithy
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/http-checksum-trait.smithy
@@ -38,6 +38,24 @@ structure NoModeForResponseInput {}
 structure NoModeForResponseOutput {}
 
 @httpChecksum(
+    requestValidationModeMember: "validationMode"
+)
+@suppress(["UnstableTrait"])
+operation NoResponseAlgorithms {
+    input: NoResponseAlgorithmsInput,
+    output: NoResponseAlgorithmsOutput,
+}
+
+@input
+structure NoResponseAlgorithmsInput {
+    validationMode: ValidationMode
+}
+
+@output
+structure NoResponseAlgorithmsOutput {}
+
+
+@httpChecksum(
     requestAlgorithmMember: "requestAlgorithm",
     requestValidationModeMember: "validationMode",
     responseAlgorithms: ["CRC32C"]


### PR DESCRIPTION
#### Background
This adds validation to [httpChecksum](https://smithy.io/2.0/aws/aws-core.html#aws-protocols-httpchecksum-trait) trait for response checksumming behavior. When configuring the trait for response checksumming, the list of checksum algorithms to consider must be provided. Else, the client behavior would have no algorithms to validate.

The [docs for response validation](https://smithy.io/2.0/aws/aws-core.html#http-response-checksums) say 
> A client MUST use the list of supported algorithms modeled in the responseAlgorithms property to look up the checksum(s) for which validation MUST be performed.

So, this list should not be empty.

#### Testing
Added tests for this case.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
