### PR TITLE
Add the elliptic curve crypto module to jlink

### DIFF
--- a/smithy-cli/build.gradle
+++ b/smithy-cli/build.gradle
@@ -155,7 +155,7 @@ System.setProperty("SMITHY_BINARY", "${smithyBinary}")
 
 runtime {
     addOptions("--compress", "2", "--strip-debug", "--no-header-files", "--no-man-pages")
-    addModules("java.logging", "java.xml", "java.naming")
+    addModules("java.logging", "java.xml", "java.naming", "jdk.crypto.ec")
 
     launcher {
         // This script is a combination of the default startup script used by the badass runtime


### PR DESCRIPTION
Adding this module is necessary to connect to Maven repositories that require elliptic curve ciphers, such as GitHub's package repository.

I can't really write a test for this, because we don't have any official GitHub package repository packages. Maybe we should? We've been asked for them, in snapshot form.

This adds around ~120kb to the bundle size.

Resolves #2370

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
