### PR TITLE
Update make-docs.yml to use venv

### DIFF
--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -45,8 +45,8 @@ jobs:
     - name: Build Smithy docs
       run: |
         cd docs
-        pip3 install -r requirements.txt
         make clean
+        make install
         make html
         cp -R build/html/* $ARTIFACTS_DIR
         rm $ARTIFACTS_DIR/.buildinfo || true


### PR DESCRIPTION
#### Background
- The docs makefile was updated recently (https://github.com/smithy-lang/smithy/pull/2352), workflow needs to be updated to account for this 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
