### PR TITLE
Update Endpoint AuthScheme docs to reflect current auth resolution process

### DIFF
--- a/docs/source-2.0/additional-specs/rules-engine/specification.rst
+++ b/docs/source-2.0/additional-specs/rules-engine/specification.rst
@@ -322,7 +322,8 @@ SHOULD modify the signing properties of the resolved and modeled authentication 
 #. Iterate through configuration objects in the ``authSchemes`` property.
 #. If the ``name`` property in a configuration object matches the resolved authentication scheme, update the resolved authentication and signing properties  from the matching ``authSchemes`` properties.
 #. If the ``name`` does not match, ignore it and continue iterating.
-#. If the list has been fully iterated and no scheme has matched, do not modify the resolved authentication scheme and do not raise an error.
+#. If the list has been fully iterated and no scheme has matched, do not
+   modify the resolved authentication scheme and do not raise an error.
 
 .. _rules-engine-standard-library-adding-authscheme-validators:
 

--- a/docs/source-2.0/additional-specs/rules-engine/specification.rst
+++ b/docs/source-2.0/additional-specs/rules-engine/specification.rst
@@ -310,7 +310,9 @@ authentication schemes and their configuration. These are used to modify
 properties of the resolved and modeled authentication scheme. Clients SHOULD
 resolve the authentication scheme following the service's :ref:`auth trait
 <auth-trait>` and SHOULD NOT use the endpoint's ``authSchemes`` property to
-determine which authentication scheme to use.
+determine which authentication scheme to use. Clients SHOULD use the
+endpoint's ``authSchemes`` property to modify signing properties of the
+resolved authentication scheme.
 
 The property is a list of configuration objects that MUST contain at least a
 ``name`` property and MAY contain additional properties. Each configuration

--- a/docs/source-2.0/additional-specs/rules-engine/specification.rst
+++ b/docs/source-2.0/additional-specs/rules-engine/specification.rst
@@ -317,7 +317,8 @@ additional properties. Each configuration object MUST have a unique value for it
 the list of configuration objects within a given ``authSchemes`` property.
 
 If an ``authSchemes`` property is present on an `Endpoint object`_, clients
-SHOULD modify the signing properties of the resolved and modeled authentication scheme via the following process:
+SHOULD modify the signing properties of the resolved and modeled authentication
+scheme via the following process:
 
 #. Iterate through configuration objects in the ``authSchemes`` property.
 #. If the ``name`` property in a configuration object matches the resolved

--- a/docs/source-2.0/additional-specs/rules-engine/specification.rst
+++ b/docs/source-2.0/additional-specs/rules-engine/specification.rst
@@ -329,7 +329,8 @@ scheme via the following process:
    properties from the matching ``authSchemes`` properties.
 #. If the ``name`` does not match, ignore it and continue iterating.
 #. If the list has been fully iterated and no scheme has matched, do not
-   modify the resolved authentication scheme and do not raise an error.
+   modify the resolved authentication scheme's properties
+   and do not raise an error.
 
 .. _rules-engine-standard-library-adding-authscheme-validators:
 

--- a/docs/source-2.0/additional-specs/rules-engine/specification.rst
+++ b/docs/source-2.0/additional-specs/rules-engine/specification.rst
@@ -297,29 +297,32 @@ booleans.
 
 .. note::
     To prevent ambiguity, the endpoint properties map MUST NOT contain
-    reference or function objects. Properties MAY contain :ref:`template string <rules-engine-endpoint-rule-set-template-string>`
+    reference or function objects. Properties MAY contain :ref:`template
+    string <rules-engine-endpoint-rule-set-template-string>`
 
 .. _rules-engine-endpoint-rule-set-endpoint-authschemes:
 
 Endpoint ``authSchemes`` list property
 --------------------------------------
 
-The ``authSchemes`` property of an endpoint is used to specify the priority
-ordered list of authentication schemes and their configuration supported by the
-endpoint. The property is a list of configuration objects that MUST contain at
-least a ``name`` property and MAY contain additional properties. Each
-configuration object MUST have a unique value for its ``name`` property within
+The ``authSchemes`` property of an endpoint is used to specify a
+list of authentication schemes and their configuration which are used to modify properties
+of the resolved and modeled authentication Scheme. Clients SHOULD resolve the authentication scheme
+following the service's :ref:`auth trait <auth-trait>` and SHOULD NOT use the endpoint's ``authSchemes`` property
+to determine which authentication scheme to use.
+
+The property is a list of configuration
+objects that MUST contain at least a ``name`` property and MAY contain
+additional properties. Each configuration object MUST have a unique value for its ``name`` property within
 the list of configuration objects within a given ``authSchemes`` property.
 
 If an ``authSchemes`` property is present on an `Endpoint object`_, clients
-MUST resolve an authentication scheme to use via the following process:
+SHOULD modify the signing properties of the resolved and modeled authentication scheme via the following process:
 
 #. Iterate through configuration objects in the ``authSchemes`` property.
-#. If the ``name`` property in a configuration object contains a supported
-   authentication scheme, resolve this scheme.
-#. If the ``name`` is unknown or unsupported, ignore it and continue iterating.
-#. If the list has been fully iterated and no scheme has been resolved, clients
-   MUST return an error.
+#. If the ``name`` property in a configuration object matches the resolved authentication scheme, update the resolved authentication and signing properties  from the matching ``authSchemes`` properties.
+#. If the ``name`` does not match, ignore it and continue iterating.
+#. If the list has been fully iterated and no scheme has matched, do not modify the resolved authentication scheme and do not raise an error.
 
 .. _rules-engine-standard-library-adding-authscheme-validators:
 

--- a/docs/source-2.0/additional-specs/rules-engine/specification.rst
+++ b/docs/source-2.0/additional-specs/rules-engine/specification.rst
@@ -320,7 +320,9 @@ If an ``authSchemes`` property is present on an `Endpoint object`_, clients
 SHOULD modify the signing properties of the resolved and modeled authentication scheme via the following process:
 
 #. Iterate through configuration objects in the ``authSchemes`` property.
-#. If the ``name`` property in a configuration object matches the resolved authentication scheme, update the resolved authentication and signing properties  from the matching ``authSchemes`` properties.
+#. If the ``name`` property in a configuration object matches the resolved
+   authentication scheme, update the resolved authentication and signing
+   properties from the matching ``authSchemes`` properties.
 #. If the ``name`` does not match, ignore it and continue iterating.
 #. If the list has been fully iterated and no scheme has matched, do not
    modify the resolved authentication scheme and do not raise an error.

--- a/docs/source-2.0/additional-specs/rules-engine/specification.rst
+++ b/docs/source-2.0/additional-specs/rules-engine/specification.rst
@@ -305,16 +305,17 @@ booleans.
 Endpoint ``authSchemes`` list property
 --------------------------------------
 
-The ``authSchemes`` property of an endpoint is used to specify a
-list of authentication schemes and their configuration which are used to modify properties
-of the resolved and modeled authentication Scheme. Clients SHOULD resolve the authentication scheme
-following the service's :ref:`auth trait <auth-trait>` and SHOULD NOT use the endpoint's ``authSchemes`` property
-to determine which authentication scheme to use.
+The ``authSchemes`` property of an endpoint is used to specify a list of
+authentication schemes and their configuration. These are used to modify
+properties of the resolved and modeled authentication scheme. Clients SHOULD
+resolve the authentication scheme following the service's :ref:`auth trait
+<auth-trait>` and SHOULD NOT use the endpoint's ``authSchemes`` property to
+determine which authentication scheme to use.
 
-The property is a list of configuration
-objects that MUST contain at least a ``name`` property and MAY contain
-additional properties. Each configuration object MUST have a unique value for its ``name`` property within
-the list of configuration objects within a given ``authSchemes`` property.
+The property is a list of configuration objects that MUST contain at least a
+``name`` property and MAY contain additional properties. Each configuration
+object MUST have a unique value for its ``name`` property within the list of
+configuration objects within a given ``authSchemes`` property.
 
 If an ``authSchemes`` property is present on an `Endpoint object`_, clients
 SHOULD modify the signing properties of the resolved and modeled authentication


### PR DESCRIPTION

#### Background
The existing docs are out of date and do not reflect the current process SDK's use to resolve authentication schemes and this has caused service team confusion.

#### Testing
* `make html`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
