### PR TITLE
Fix several bugs in AwsTagIndex

### DIFF
--- a/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/CfnConverter.java
+++ b/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/CfnConverter.java
@@ -44,7 +44,6 @@ import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.MemberShape;
-import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -425,11 +424,10 @@ public final class CfnConverter {
                     ShapeId definition = resource.getProperties().get(trait.getProperty().get());
                     builder.addMember(tagPropertyName, definition);
                 } else {
-                    // Taggability must be through service-wide TagResource operation
-                    OperationShape tagResourceOp = model.expectShape(
-                        tagIndex.getTagResourceOperation(resource.getId()).get(), OperationShape.class);
-                    // A valid TagResource operation certainly has a single tags input member
-                    MemberShape member = AwsTagIndex.getTagsMember(model, tagResourceOp).get();
+                    // A valid TagResource operation certainly has a single tags input member.
+                    AwsTagIndex awsTagIndex = AwsTagIndex.of(model);
+                    Optional<ShapeId> tagOperation = tagIndex.getTagResourceOperation(resource.getId());
+                    MemberShape member = awsTagIndex.getTagsMember(tagOperation.get()).get();
                     member = member.toBuilder().id(builder.getId().withMember(tagPropertyName)).build();
                     builder.addMember(member);
                 }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TagEnabledServiceValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TagEnabledServiceValidator.java
@@ -34,13 +34,12 @@ public final class TagEnabledServiceValidator extends AbstractValidator {
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         AwsTagIndex tagIndex = AwsTagIndex.of(model);
         for (ServiceShape service : model.getServiceShapesWithTrait(TagEnabledTrait.class)) {
-            events.addAll(validateService(model, service, tagIndex, topDownIndex));
+            events.addAll(validateService(service, tagIndex, topDownIndex));
         }
         return events;
     }
 
     private List<ValidationEvent> validateService(
-            Model model,
             ServiceShape service,
             AwsTagIndex tagIndex,
             TopDownIndex topDownIndex

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TagResourcePropertyNameValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TagResourcePropertyNameValidator.java
@@ -32,9 +32,7 @@ public final class TagResourcePropertyNameValidator extends AbstractValidator {
 
         for (ResourceShape resource : model.getResourceShapesWithTrait(TaggableTrait.class)) {
             TaggableTrait trait = resource.expectTrait(TaggableTrait.class);
-            if (trait.getProperty()
-                    .filter(property -> !TaggingShapeUtils.isTagDesiredName(property))
-                    .isPresent()) {
+            if (trait.getProperty().isPresent() && !TaggingShapeUtils.isTagDesiredName(trait.getProperty().get())) {
                 events.add(warning(resource, String.format("Suggested tag property name is '%s'.",
                     TaggingShapeUtils.getDesiredTagsPropertyName())));
             }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TagResourcePropertyTypeValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TagResourcePropertyTypeValidator.java
@@ -36,14 +36,11 @@ public final class TagResourcePropertyTypeValidator extends AbstractValidator {
         for (ResourceShape resource : model.getResourceShapesWithTrait(TaggableTrait.class)) {
             TaggableTrait trait = resource.expectTrait(TaggableTrait.class);
             Map<String, ShapeId> properties = resource.getProperties();
-            if (trait.getProperty().isPresent()) {
-                ShapeId propertyShapeId = properties.get(trait.getProperty().get());
-                if (propertyShapeId != null) {
-                    Shape propertyShape = model.expectShape(propertyShapeId);
-                    if (!TaggingShapeUtils.verifyTagsShape(model, propertyShape)) {
-                        events.add(error(resource, "Tag property must be a list shape targeting a member"
-                                + " containing a pair of strings, or a Map shape targeting a string member."));
-                    }
+            if (trait.getProperty().isPresent() && properties.containsKey(trait.getProperty().get())) {
+                Shape propertyShape = model.expectShape(properties.get(trait.getProperty().get()));
+                if (!TaggingShapeUtils.verifyTagsShape(model, propertyShape)) {
+                    events.add(error(resource, "Tag property must be a list shape targeting a member"
+                            + " containing a pair of strings, or a Map shape targeting a string member."));
                 }
             }
         }

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/tagging/AwsTagIndexTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/tagging/AwsTagIndexTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.aws.traits.tagging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+
+public final class AwsTagIndexTest {
+    private static final String NAMESPACE = "example.weather";
+    private static final ShapeId WEATHER_SERVICE_ID = ShapeId.fromParts(NAMESPACE, "Weather");
+    private static final ShapeId UNTAGGED_SERVICE_ID = ShapeId.fromParts(NAMESPACE, "UntaggedService");
+    private static final ShapeId CITY_RESOURCE_ID = ShapeId.fromParts(NAMESPACE, "City");
+
+    private static Model model;
+    private static AwsTagIndex tagIndex;
+
+    @BeforeAll
+    public static void loadModel() {
+        model = Model.assembler()
+                .addImport(AwsTagIndex.class.getResource("aws-tag-index-test-model.smithy"))
+                .discoverModels()
+                .assemble()
+                .unwrap();
+        tagIndex = AwsTagIndex.of(model);
+    }
+
+    @Test
+    public void detectsCompliantTaggingService() {
+        assertTrue(tagIndex.serviceHasTagApis(WEATHER_SERVICE_ID));
+        assertTrue(tagIndex.serviceHasValidTagResourceOperation(WEATHER_SERVICE_ID));
+        assertTrue(tagIndex.serviceHasValidUntagResourceOperation(WEATHER_SERVICE_ID));
+        assertTrue(tagIndex.serviceHasValidListTagsForResourceOperation(WEATHER_SERVICE_ID));
+    }
+
+    @Test
+    public void detectsNoncompliantTaggingService() {
+        assertFalse(tagIndex.serviceHasTagApis(UNTAGGED_SERVICE_ID));
+        assertFalse(tagIndex.serviceHasValidTagResourceOperation(UNTAGGED_SERVICE_ID));
+        assertFalse(tagIndex.serviceHasValidUntagResourceOperation(UNTAGGED_SERVICE_ID));
+        assertFalse(tagIndex.serviceHasValidListTagsForResourceOperation(UNTAGGED_SERVICE_ID));
+    }
+
+    @Test
+    public void detectsDefaultTagOperations() {
+        Optional<ShapeId> tagOptional = tagIndex.getTagResourceOperation(WEATHER_SERVICE_ID);
+        assertTrue(tagOptional.isPresent());
+        assertEquals(tagOptional.get(), ShapeId.fromParts(NAMESPACE, "TagResource"));
+
+        Optional<ShapeId> untagOptional = tagIndex.getUntagResourceOperation(WEATHER_SERVICE_ID);
+        assertTrue(untagOptional.isPresent());
+        assertEquals(untagOptional.get(), ShapeId.fromParts(NAMESPACE, "UntagResource"));
+
+        Optional<ShapeId> listTagsOptional = tagIndex.getListTagsForResourceOperation(WEATHER_SERVICE_ID);
+        assertTrue(listTagsOptional.isPresent());
+        assertEquals(listTagsOptional.get(), ShapeId.fromParts(NAMESPACE, "ListTagsForResource"));
+    }
+
+    @Test
+    public void detectsResourceCustomizedTagOperations() {
+        Optional<ShapeId> tagOptional = tagIndex.getTagResourceOperation(CITY_RESOURCE_ID);
+        assertTrue(tagOptional.isPresent());
+        assertEquals(tagOptional.get(), ShapeId.fromParts(NAMESPACE, "TagCity"));
+
+        Optional<ShapeId> untagOptional = tagIndex.getUntagResourceOperation(CITY_RESOURCE_ID);
+        assertTrue(untagOptional.isPresent());
+        assertEquals(untagOptional.get(), ShapeId.fromParts(NAMESPACE, "UntagCity"));
+
+        Optional<ShapeId> listTagsOptional = tagIndex.getListTagsForResourceOperation(CITY_RESOURCE_ID);
+        assertTrue(listTagsOptional.isPresent());
+        assertEquals(listTagsOptional.get(), ShapeId.fromParts(NAMESPACE, "ListTagsForCity"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("resourceTagMutabilities")
+    public void detectsResourceTagMutation(ShapeId shapeId, boolean isTagOnCreate, boolean isTagOnUpdate) {
+        assertEquals(tagIndex.isResourceTagOnCreate(shapeId), isTagOnCreate);
+        assertEquals(tagIndex.isResourceTagOnUpdate(shapeId), isTagOnUpdate);
+    }
+
+    public static Stream<Arguments> resourceTagMutabilities() {
+        return Stream.of(
+                Arguments.of(CITY_RESOURCE_ID, false, false),
+                Arguments.of(ShapeId.fromParts(NAMESPACE, "Town"), true, true),
+                Arguments.of(ShapeId.fromParts(NAMESPACE, "Farm"), true, true),
+                Arguments.of(ShapeId.fromParts(NAMESPACE, "Barn"), true, false),
+                Arguments.of(ShapeId.fromParts(NAMESPACE, "Silo"), true, true));
+    }
+
+    @Test
+    public void resolvesTagMember() {
+        assertFalse(tagIndex.getTagsMember(ShapeId.fromParts(NAMESPACE, "GetCity")).isPresent());
+
+        Optional<MemberShape> tagMember = tagIndex.getTagsMember(ShapeId.fromParts(NAMESPACE, "CreateTown"));
+        assertTrue(tagMember.isPresent());
+        assertEquals(tagMember.get().toShapeId(), ShapeId.fromParts(NAMESPACE, "CreateTownInput", "tags"));
+    }
+}

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/tagging/tagging-warnings.errors
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/tagging/tagging-warnings.errors
@@ -2,4 +2,4 @@
 [WARNING] example.weather#Weather: Service marked `aws.api#TagEnabled` is missing an operation named 'TagResource.' | ServiceTagging
 [WARNING] example.weather#Weather: Service marked `aws.api#TagEnabled` is missing an operation named 'UntagResource.' | ServiceTagging
 [WARNING] example.weather#City: Suggested tag property name is '[T|t]ags'. | TagResourcePropertyName
-[DANGER] example.weather#UpdateCity: Update resource lifecycle operation should not support updating tags because it is a privileged operation that modifies access. | TaggableResource
+[DANGER] example.weather#UpdateCity: Update and put resource lifecycle operations should not support updating tags because it is a privileged operation that modifies access. | TaggableResource

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/tagging/aws-tag-index-test-model.smithy
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/tagging/aws-tag-index-test-model.smithy
@@ -1,0 +1,321 @@
+$version: "2.0"
+
+metadata suppressions = [
+    {
+        id: "UnstableTrait",
+        namespace: "example.weather"
+    }
+]
+
+namespace example.weather
+
+use aws.api#taggable
+use aws.api#arn
+use aws.api#tagEnabled
+
+@tagEnabled
+service Weather {
+    version: "2006-03-01",
+    resources: [
+        City
+        Town
+        Farm
+        Barn
+    ]
+    operations: [GetCurrentTime, TagResource, UntagResource, ListTagsForResource]
+}
+
+service UntaggedService {}
+
+structure Tag {
+    key: String
+    value: String
+}
+
+list TagList {
+    member: Tag
+}
+
+list TagKeys {
+    member: String
+}
+
+operation TagResource {
+    input := {
+        @required
+        arn: String
+        @length(max: 128)
+        tags: TagList
+    }
+    output := { }
+}
+
+operation UntagResource {
+    input := {
+        @required
+        arn: String
+        @required
+        tagKeys: TagKeys
+    }
+    output := { }
+}
+
+operation ListTagsForResource {
+    input := {
+        @required
+        arn: String
+    }
+    output := {
+        @length(max: 128)
+        tags: TagList
+    }
+}
+
+operation TagCity {
+    input := {
+        @required
+        cityId: CityId
+        @length(max: 128)
+        tags: TagList
+    }
+    output := { }
+}
+
+operation UntagCity {
+    input := {
+        @required
+        cityId: CityId
+        @required
+        @notProperty
+        tagKeys: TagKeys
+    }
+    output := { }
+}
+
+operation ListTagsForCity {
+    input := {
+        @required
+        cityId: CityId
+    }
+    output := {
+        @length(max: 128)
+        tags: TagList
+    }
+}
+
+@taggable(property: "tags", apiConfig: {tagApi: TagCity, untagApi: UntagCity, listTagsApi: ListTagsForCity})
+resource City {
+    identifiers: { cityId: CityId },
+    properties: {
+        name: String
+        coordinates: CityCoordinates
+        tags: TagList
+    }
+    create: CreateCity
+    read: GetCity,
+    operations: [TagCity, UntagCity, ListTagsForCity],
+}
+
+operation CreateCity {
+    input := {
+        name: String
+        coordinates: CityCoordinates
+    }
+    output := {
+        @required
+        cityId: CityId
+    }
+}
+
+@pattern("^[A-Za-z0-9 ]+$")
+string CityId
+
+@readonly
+operation GetCity {
+    input: GetCityInput,
+    output: GetCityOutput,
+    errors: [NoSuchResource]
+}
+
+@input
+structure GetCityInput {
+    // "cityId" provides the identifier for the resource and
+    // has to be marked as required.
+    @required
+    cityId: CityId
+}
+
+@output
+structure GetCityOutput {
+    // "required" is used on output to indicate if the service
+    // will always provide a value for the member.
+    @required
+    name: String,
+
+    @required
+    coordinates: CityCoordinates,
+}
+
+// This structure is nested within GetCityOutput.
+structure CityCoordinates {
+    @required
+    latitude: Float,
+
+    @required
+    longitude: Float,
+}
+
+// "error" is a trait that is used to specialize
+// a structure as an error.
+@error("client")
+structure NoSuchResource {
+    @required
+    resourceType: String
+}
+
+@readonly
+operation GetCurrentTime {
+    input: GetCurrentTimeInput,
+    output: GetCurrentTimeOutput
+}
+
+@input
+structure GetCurrentTimeInput {}
+
+@output
+structure GetCurrentTimeOutput {
+    @required
+    time: Timestamp
+}
+
+// Create and Update
+@arn(template: "town/{townId}")
+@taggable(property: "tags")
+resource Town {
+    identifiers: { townId: String }
+    properties: {
+        name: String
+        tags: TagList
+    }
+    create: CreateTown
+    update: UpdateTown
+}
+
+operation CreateTown {
+    input := for Town {
+        $name
+        $tags
+    }
+    output := for Town {
+        @required
+        $townId
+    }
+}
+
+@suppress(["TaggableResource"])
+operation UpdateTown {
+    input := for Town {
+        @required
+        $townId
+
+        $name
+        $tags
+    }
+    output := for Town {
+        @required
+        $townId
+    }
+}
+
+// Put
+@taggable(property: "tags")
+@arn(template: "farm/{farmId}")
+resource Farm {
+    identifiers: { farmId: String }
+    properties: {
+        name: String
+        tags: TagList
+    }
+    put: PutFarm
+    resources: [Silo]
+}
+
+@idempotent
+@suppress(["TaggableResource"])
+operation PutFarm {
+    input := for Farm {
+        @required
+        $farmId
+
+        $name
+        $tags
+    }
+    output := for Farm {
+        @required
+        $farmId
+    }
+}
+
+// Put with noReplace
+@arn(template: "barn/{barnId}")
+@noReplace
+@taggable(property: "tags")
+resource Barn {
+    identifiers: { barnId: String }
+    properties: {
+        name: String
+        tags: TagList
+    }
+    put: PutBarn
+}
+
+@idempotent
+operation PutBarn {
+    input := for Barn {
+        @required
+        $barnId
+
+        $name
+        $tags
+    }
+    output := for Barn {
+        @required
+        $barnId
+    }
+}
+
+@taggable(property: "tags")
+@arn(template: "silo/{siloId}")
+resource Silo {
+    identifiers: {
+        farmId: String
+        siloId: String
+    }
+    properties: {
+        name: String
+        tags: TagList
+    }
+    put: PutSilo
+}
+
+@idempotent
+@suppress(["TaggableResource"])
+operation PutSilo {
+    input := for Silo {
+        @required
+        $farmId
+
+        @required
+        $siloId
+
+        $name
+        $tags
+    }
+    output := for Silo {
+        @required
+        $farmId
+
+        @required
+        $siloId
+    }
+}


### PR DESCRIPTION
This commit fixes several groups of bugs in the AwsTagIndex:
1. The index did not handle nested resource shapes.
2. The index did not handle the put lifecycle operation.
3. The index did not account for the `apiConfig` property of the `@taggable` trait.

A full suite of tests was added to account for the index's behavior and validate its previous functionality along with fixes for the above.

The `getTagsMember` method was stabilized and made non-static.

Minor cleanup was done to other tagging related files.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
