### PR TITLE
Fix small typos and grammatical errors in the full-stack-tutorial

### DIFF
--- a/docs/source-2.0/tutorials/full-stack-tutorial.rst
+++ b/docs/source-2.0/tutorials/full-stack-tutorial.rst
@@ -136,7 +136,7 @@ of coffee-related structures:
 
     namespace com.example
 
-    /// A enum describing the types of coffees available
+    /// An enum describing the types of coffees available
     enum CoffeeType {
         DRIP
         POUR_OVER
@@ -417,7 +417,7 @@ Run the build:
 
     smithy build
 
-The build will should fail for the following reason:
+The build should fail for the following reason:
 
 .. code-block:: text
     :caption: ``failure message``


### PR DESCRIPTION
#### Background
- Fixes typos, spelling mistakes, and grammatical errors in the tutorial

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
