### PR TITLE
Add validation for null members in structures, lists and maps

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
@@ -392,29 +392,28 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
     }
 
     public List<ValidationEvent> checkNullMember(MemberShape shape) {
-        List<ValidationEvent> events = new ArrayList<>();
-        if (!shape.asMemberShape().filter(nullableIndex::isMemberNullable).isPresent()) {
+        if (!nullableIndex.isMemberNullable(shape)) {
             switch (model.expectShape(shape.getContainer()).getType()) {
                 case LIST:
-                    events.add(event(
+                    return ListUtils.of(event(
                             String.format(
-                                    "Non-sparse list shape %s cannot contain null values", shape.getContainer())));
+                                    "Non-sparse list shape `%s` cannot contain null values", shape.getContainer())));
                     break;
                 case MAP:
-                    events.add(event(
+                    return ListUtils.of(event(
                             String.format(
-                                    "Non-sparse map shape %s cannot contain null values", shape.getContainer())));
+                                    "Non-sparse map shape `%s` cannot contain null values", shape.getContainer())));
                     break;
                 case STRUCTURE:
-                    events.add(event(
-                            String.format("Required member `%s` for structure %s for cannot be null",
+                    return ListUtils.of(event(
+                            String.format("Required structure member `%s` for `%s` cannot be null",
                                     shape.getMemberName(), shape.getContainer())));
                     break;
                 default:
                     break;
             }
         }
-        return events;
+        return ListUtils.of();
     }
 
     @Override

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
@@ -398,17 +398,14 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
                     return ListUtils.of(event(
                             String.format(
                                     "Non-sparse list shape `%s` cannot contain null values", shape.getContainer())));
-                    break;
                 case MAP:
                     return ListUtils.of(event(
                             String.format(
                                     "Non-sparse map shape `%s` cannot contain null values", shape.getContainer())));
-                    break;
                 case STRUCTURE:
                     return ListUtils.of(event(
                             String.format("Required structure member `%s` for `%s` cannot be null",
                                     shape.getMemberName(), shape.getContainer())));
-                    break;
                 default:
                     break;
             }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
@@ -368,7 +368,7 @@ public class NodeValidationVisitorTest {
 
         assertThat(events, hasSize(1));
         assertThat(events.get(0).getMessage(), containsString(
-                "foo: Required member `foo` for structure ns.foo#Structure for cannot be null"));
+                "foo: Required structure member `foo` for `ns.foo#Structure` cannot be null"));
     }
 
 
@@ -388,7 +388,7 @@ public class NodeValidationVisitorTest {
 
         assertThat(events, hasSize(1));
         assertThat(events.get(0).getMessage(), containsString(
-                "0: Non-sparse list shape ns.foo#List cannot contain null values"));
+                "0: Non-sparse list shape `ns.foo#List` cannot contain null values"));
     }
 
     @Test
@@ -424,7 +424,7 @@ public class NodeValidationVisitorTest {
 
         assertThat(events, hasSize(1));
         assertThat(events.get(0).getMessage(), containsString(
-                "a: Non-sparse map shape ns.foo#Map cannot contain null values"));
+                "a: Non-sparse map shape `ns.foo#Map` cannot contain null values"));
     }
 
     @Test

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/validation/node-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/validation/node-validator.json
@@ -159,6 +159,15 @@
                 "smithy.api#uniqueItems": {}
             }
         },
+        "ns.foo#SparseList": {
+            "type": "list",
+            "member": {
+                "target": "ns.foo#String"
+            },
+            "traits": {
+                "smithy.api#sparse": {}
+            }
+        },
         "ns.foo#String": {
             "type": "string"
         },
@@ -184,6 +193,18 @@
                     "min": 1,
                     "max": 2
                 }
+            }
+        },
+        "ns.foo#SparseMap": {
+            "type": "map",
+            "key": {
+                "target": "ns.foo#KeyString"
+            },
+            "value": {
+                "target": "ns.foo#List"
+            },
+            "traits": {
+                "smithy.api#sparse": {}
             }
         },
         "ns.foo#Structure": {

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/invalid-static-null-param-value.errors
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/invalid-static-null-param-value.errors
@@ -1,3 +1,3 @@
 [WARNING] smithy.example#OperationNull: This shape applies a trait that is unstable: smithy.rules#staticContextParams | UnstableTrait
 [ERROR] smithy.example#OperationNull: The operation `smithy.example#OperationNull` is marked with `smithy.rules#staticContextParams` which contains a key `nullParam` with an unsupported document type value `null`. | StaticContextParamsTrait
-[ERROR] smithy.example#OperationNull: Error validating trait `smithy.rules#staticContextParams`.nullParam.value: Required member `value` for structure smithy.rules#StaticContextParamDefinition for cannot be null | TraitValue
+[ERROR] smithy.example#OperationNull: Error validating trait `smithy.rules#staticContextParams`.nullParam.value: Required structure member `value` for `smithy.rules#StaticContextParamDefinition` cannot be null | TraitValue

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/invalid-static-null-param-value.errors
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/invalid-static-null-param-value.errors
@@ -1,2 +1,3 @@
 [WARNING] smithy.example#OperationNull: This shape applies a trait that is unstable: smithy.rules#staticContextParams | UnstableTrait
 [ERROR] smithy.example#OperationNull: The operation `smithy.example#OperationNull` is marked with `smithy.rules#staticContextParams` which contains a key `nullParam` with an unsupported document type value `null`. | StaticContextParamsTrait
+[ERROR] smithy.example#OperationNull: Error validating trait `smithy.rules#staticContextParams`.nullParam.value: Required member `value` for structure smithy.rules#StaticContextParamDefinition for cannot be null | TraitValue


### PR DESCRIPTION
#### Background
Previously, a NullNode could be provided as a required structure member without emitting a ValidationEvent. So an example test below would fail. 

```    @Test
    public void nullRequiredStructureMember() {
        ObjectNode structure = ObjectNode.builder()
                .withMember("foo", Node.nullNode())
                .build();
        NodeValidationVisitor visitor = NodeValidationVisitor.builder()
                .value(structure)
                .model(MODEL)
                .allowOptionalNull(true)
                .build();
        List<ValidationEvent> events = MODEL
                .expectShape(ShapeId.from("ns.foo#Structure"))
                .accept(visitor);

        assertThat(events, hasSize(1));
        assertThat(events.get(0).getMessage(), containsString(
                "foo: Required member `foo` for structure ns.foo#Structure for cannot be null"));
    }

ns.foo#Structure schema:
"ns.foo#Structure": {
    "type": "structure",
    "members": {
        "foo": {
            "target": "ns.foo#String",
            "traits": {
                "smithy.api#required": {}
            }
        },
...
```

This happens because the memberShape function would check the member's [target](https://github.com/smithy-lang/smithy/blob/main/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java#L385) instead of itself, which always satisfies the !shape.isMemberShape() [condition](https://github.com/smithy-lang/smithy/blob/main/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java#L410) in the invalidShape function.

To fix this I added a new function to check null member nodes for structures, lists and maps. It relies on the `isMemberNullable` function, which checks that:
- If a structure member, member cannot be required
- If a list member, the list must have the sparse trait
- If a map value, the map must have the sparse trait (this case is not explicit but happens due to a fall through to the [default case](https://github.com/smithy-lang/smithy/blob/1e4458ee825b24490c03fbf22f4b2f79111c7ae5/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/NullableIndex.java#L191))


#### Testing
Added testcases:
- One that emits ValidationEvent when NullNode is provided as a required structure member
- One that emits ValidationEvent when NullNode is provided as member for a non-sparse list
- One that doesn't emit ValidationEvent when NullNode is provided as member for a sparse list
- One that emits ValidationEvent when NullNode is provided as a value for a non-sparse map
- One that doesn't emit ValidationEvent when NullNode is provided as a value for a sparse map

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
