### PR TITLE
Use most common suffix for IDL inline IO

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/shared.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/inferred-io/shared.smithy
@@ -4,6 +4,11 @@ $operationOutputSuffix: "Response"
 
 namespace com.example
 
+operation NotShared {
+    input: NotSharedInput
+    output: NotSharedOutput
+}
+
 operation SharedCustomA {
     input := {}
     output := {}
@@ -13,3 +18,9 @@ operation SharedCustomB {
     input := {}
     output := {}
 }
+
+@input
+structure NotSharedInput {}
+
+@output
+structure NotSharedOutput {}


### PR DESCRIPTION
This commit updates IDL serialization to use the most common suffix for serializing IDL models when inlining input/output shapes. Before this update, the first suffix encountered would be used, even if it was only used that one time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
