### PR TITLE
Add test case for requestChecksumRequired=false

### DIFF
--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/http-checksum-trait.errors
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/http-checksum-trait.errors
@@ -3,5 +3,6 @@
 [SUPPRESSED] smithy.example#NoOutputForResponse: This shape applies a trait that is unstable: aws.protocols#httpChecksum | UnstableTrait
 [SUPPRESSED] smithy.example#NoResponseAlgorithms: This shape applies a trait that is unstable: aws.protocols#httpChecksum | UnstableTrait
 [ERROR] smithy.example#NoBehavior: The `httpChecksum` trait must define at least one of the `request` or `response` checksum behaviors. | HttpChecksumTrait
+[ERROR] smithy.example#NoBehaviorRequestChecksumRequiredFalse: The `httpChecksum` trait must define at least one of the `request` or `response` checksum behaviors. | HttpChecksumTrait
 [ERROR] smithy.example#NoModeForResponse: The `httpChecksum` trait must model the `requestValidationModeMember` property to support response checksum behavior. | HttpChecksumTrait
 [ERROR] smithy.example#NoResponseAlgorithms: The `httpChecksum` trait must model the `responseAlgorithms` property to support response checksum behavior. | HttpChecksumTrait

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/http-checksum-trait.smithy
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/http-checksum-trait.smithy
@@ -15,6 +15,18 @@ operation NoBehavior {
 structure NoBehaviorInput {}
 
 @httpChecksum(
+    requestChecksumRequired: false,
+)
+@suppress(["UnstableTrait"])
+operation NoBehaviorRequestChecksumRequiredFalse {
+    input: NoBehaviorRequestChecksumRequiredFalseInput,
+    output: Unit
+}
+
+@input
+structure NoBehaviorRequestChecksumRequiredFalseInput {}
+
+@httpChecksum(
     requestChecksumRequired: true,
 )
 @suppress(["UnstableTrait"])


### PR DESCRIPTION
#### Background
Clarifying behavior for when `httpChecksum` trait is used with only `requestChecksumRequired=false`.

#### Testing
Added test case

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
