### PR TITLE
serialize empty strings and lists to headers in restXml and restJson1

### DIFF
--- a/smithy-aws-protocol-tests/build.gradle
+++ b/smithy-aws-protocol-tests/build.gradle
@@ -38,3 +38,5 @@ smithy {
     format.set(false)
     smithyBuildConfigs.set(project.files())
 }
+
+sourceSets.main.java.srcDirs = ['model', 'src/main/smithy']

--- a/smithy-aws-protocol-tests/build.gradle
+++ b/smithy-aws-protocol-tests/build.gradle
@@ -38,5 +38,3 @@ smithy {
     format.set(false)
     smithyBuildConfigs.set(project.files())
 }
-
-sourceSets.main.java.srcDirs = ['model', 'src/main/smithy']

--- a/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
@@ -424,11 +424,15 @@ operation NullAndEmptyHeadersClient {
 apply NullAndEmptyHeadersClient @httpRequestTests([
     {
         id: "RestJsonNullAndEmptyHeaders",
-        documentation: "Do not send null values, empty strings, or empty lists over the wire in headers",
+        documentation: "Do not send null values, but do send empty strings and empty lists over the wire in headers",
         protocol: restJson1,
         method: "GET",
         uri: "/NullAndEmptyHeadersClient",
-        forbidHeaders: ["X-A", "X-B", "X-C"],
+        forbidHeaders: ["X-A"],
+        headers: {
+            "X-B": ""
+            "X-C": ""
+        }
         body: "",
         params: {
             a: null,

--- a/smithy-aws-protocol-tests/model/restXml/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-headers.smithy
@@ -367,11 +367,15 @@ operation NullAndEmptyHeadersClient {
 apply NullAndEmptyHeadersClient @httpRequestTests([
     {
         id: "NullAndEmptyHeaders",
-        documentation: "Do not send null values, empty strings, or empty lists over the wire in headers",
+        documentation: "Do not send null values, but do send empty strings and empty lists over the wire in headers",
         protocol: restXml,
         method: "GET",
         uri: "/NullAndEmptyHeadersClient",
-        forbidHeaders: ["X-A", "X-B", "X-C"],
+        forbidHeaders: ["X-A"],
+        headers: {
+            "X-B": ""
+            "X-C": ""
+        }
         body: "",
         params: {
             a: null,


### PR DESCRIPTION
#### Background
* What do these changes do? 
  * changes header serialization test assertions to include empty strings and lists, but still exclude null
* Why are they important?
  * absence and emptiness of headers differ in meaning

#### Testing
* How did you test these changes?

Tested protocol-test codegen and test execution in smithy-typescript + aws-sdk-js-v3

#### Links
https://github.com/smithy-lang/smithy-typescript/pull/1412
