### PR TITLE
fix: update prefix header tests to allow for empty headers

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-prefix-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-prefix-headers.smithy
@@ -42,7 +42,7 @@ apply HttpPrefixHeaders @httpRequestTests([
     },
     {
         id: "RestJsonHttpPrefixHeadersAreNotPresent",
-        documentation: "No prefix headers are serialized because the value is empty",
+        documentation: "No prefix headers are serialized because the value is not present",
         protocol: restJson1,
         method: "GET",
         uri: "/HttpPrefixHeaders",
@@ -55,6 +55,23 @@ apply HttpPrefixHeaders @httpRequestTests([
             fooMap: {}
         },
         appliesTo: "client"
+    },
+    {
+        id: "RestJsonHttpPrefixEmptyHeaders",
+        documentation: "Serialize prefix headers were the value is present but empty"
+        protocol: restJson1,
+        method: "GET",
+        uri: "/HttpPrefixHeaders",
+        body: "",
+        params: {
+            fooMap: {
+                Abc: ""
+            }
+        },
+        headers: {
+            "X-Foo-Abc": ""
+        }
+        appliesTo: "client",
     },
 ])
 

--- a/smithy-aws-protocol-tests/model/restXml/http-prefix-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-prefix-headers.smithy
@@ -41,7 +41,7 @@ apply HttpPrefixHeaders @httpRequestTests([
     },
     {
         id: "HttpPrefixHeadersAreNotPresent",
-        documentation: "No prefix headers are serialized because the value is empty",
+        documentation: "No prefix headers are serialized because the value is not present",
         protocol: restXml,
         method: "GET",
         uri: "/HttpPrefixHeaders",
@@ -54,6 +54,23 @@ apply HttpPrefixHeaders @httpRequestTests([
             fooMap: {}
         },
         appliesTo: "client"
+    },
+    {
+        id: "HttpPrefixEmptyHeaders",
+        documentation: "Serialize prefix headers were the value is present but empty"
+        protocol: restXml,
+        method: "GET",
+        uri: "/HttpPrefixHeaders",
+        body: "",
+        params: {
+            fooMap: {
+                Abc: ""
+            }
+        },
+        headers: {
+            "X-Foo-Abc": ""
+        }
+        appliesTo: "client",
     },
 ])
 


### PR DESCRIPTION
#### Background
* What do these changes do? 
Update protocol tests to catch an issue where SDKs were not serializing empty headers 

* Why are they important?
Had an issue where calling S3 with metadata with an empty value caused SDKs to not serialize the value and not send the header. While #2403 addresses the general case of headers present but with no values, it wouldn't cover this scenario since S3 metadata headers are not modeled as [httpHeader](https://smithy.io/2.0/spec/http-bindings.html#httpheader-trait) but as [httpPrefixHeader](https://smithy.io/2.0/spec/http-bindings.html#httpprefixheaders-trait)

#### Testing
* How did you test these changes?
Generated tests on [smithy-go](https://github.com/aws/smithy-go) and ran the new tests on [aws-sdk-go-v2](https://github.com/aws/aws-sdk-go-v2/)

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
