### PR TITLE
Fix broken link to smithy-rs design document in Code Gen documentation.

### DIFF
--- a/docs/source-2.0/guides/building-codegen/overview-and-concepts.rst
+++ b/docs/source-2.0/guides/building-codegen/overview-and-concepts.rst
@@ -75,7 +75,7 @@ choices were made and leave a record for future contributors.
 
 Example Smithy codegen design documents:
 
-- https://awslabs.github.io/smithy-rs/design/
+- https://smithy-lang.github.io/smithy-rs/design/
 - https://github.com/awslabs/smithy-kotlin/tree/main/docs/design
 - https://github.com/awslabs/aws-sdk-kotlin/tree/main/docs/design
 - https://github.com/awslabs/smithy-ruby/wiki


### PR DESCRIPTION
#### Background
* What do these changes do? 
 On this page: https://smithy.io/2.0/guides/building-codegen/overview-and-concepts.html#design-documents , the link to smithy-rs design docs is broken and returns a 404. This PR fixes the link to correct docs.

* Why are they important?
For correct documentation.


#### Testing
* How did you test these changes?
Using the process documented at : https://github.com/smithy-lang/smithy/blob/main/docs/README.md


#### Links
* Links to additional context, if necessary 

N/A 


* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

N/A

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
