### PR TITLE
Fix several issues with IAM trait classes

### DIFF
--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ActionResource.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ActionResource.java
@@ -60,7 +60,7 @@ public final class ActionResource implements ToNode, ToSmithyBuilder<ActionResou
     }
 
     @Override
-    public SmithyBuilder<ActionResource> toBuilder() {
+    public Builder toBuilder() {
         return builder().conditionKeys(conditionKeys);
     }
 

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ActionResources.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ActionResources.java
@@ -79,18 +79,20 @@ public final class ActionResources implements ToNode, ToSmithyBuilder<ActionReso
             for (Map.Entry<String, ActionResource> requiredEntry : required.entrySet()) {
                 requiredBuilder.withMember(requiredEntry.getKey(), requiredEntry.getValue().toNode());
             }
+            builder.withMember(REQUIRED, requiredBuilder.build());
         }
         if (!optional.isEmpty()) {
             ObjectNode.Builder optionalBuilder = Node.objectNodeBuilder();
             for (Map.Entry<String, ActionResource> optionalEntry : optional.entrySet()) {
                 optionalBuilder.withMember(optionalEntry.getKey(), optionalEntry.getValue().toNode());
             }
+            builder.withMember(OPTIONAL, optionalBuilder.build());
         }
         return builder.build();
     }
 
     @Override
-    public SmithyBuilder<ActionResources> toBuilder() {
+    public Builder toBuilder() {
         return builder().required(required).optional(optional);
     }
 

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeyDefinition.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeyDefinition.java
@@ -108,7 +108,7 @@ public final class ConditionKeyDefinition implements ToNode, ToSmithyBuilder<Con
     }
 
     @Override
-    public SmithyBuilder<ConditionKeyDefinition> toBuilder() {
+    public Builder toBuilder() {
         return builder()
                 .documentation(documentation)
                 .externalDocumentation(externalDocumentation)

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/DefineConditionKeysTrait.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/DefineConditionKeysTrait.java
@@ -15,7 +15,6 @@
 
 package software.amazon.smithy.aws.iam.traits;
 
-import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -78,7 +77,7 @@ public final class DefineConditionKeysTrait extends AbstractTrait implements ToS
      * Get a specific condition key by name.
      *
      * @param name Name of the condition key to get.
-     * @return Returns the optionall found condition key.
+     * @return Returns the optionally found condition key.
      */
     public Optional<ConditionKeyDefinition> getConditionKey(String name) {
         return Optional.ofNullable(conditionKeys.get(name));
@@ -86,11 +85,11 @@ public final class DefineConditionKeysTrait extends AbstractTrait implements ToS
 
     @Override
     protected Node createNode() {
-        return conditionKeys.entrySet().stream()
-                .map(entry -> new AbstractMap.SimpleImmutableEntry<>(
-                        Node.from(entry.getKey()), entry.getValue().toNode()))
-                .collect(ObjectNode.collect(Map.Entry::getKey, Map.Entry::getValue))
-                .toBuilder().sourceLocation(getSourceLocation()).build();
+        ObjectNode.Builder builder = ObjectNode.builder().sourceLocation(getSourceLocation());
+        for (Map.Entry<String, ConditionKeyDefinition> entry : conditionKeys.entrySet()) {
+            builder.withMember(entry.getKey(), entry.getValue().toNode());
+        }
+        return builder.build();
     }
 
     @Override

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/IamActionTrait.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/IamActionTrait.java
@@ -28,7 +28,6 @@ import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.FunctionalUtils;
 import software.amazon.smithy.utils.ListUtils;
-import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -191,7 +190,7 @@ public final class IamActionTrait extends AbstractTrait
     }
 
     @Override
-    public SmithyBuilder<IamActionTrait> toBuilder() {
+    public Builder toBuilder() {
         return builder().sourceLocation(getSourceLocation()).name(name);
     }
 

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/IamResourceTrait.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/IamResourceTrait.java
@@ -23,7 +23,6 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.Trait;
-import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -106,7 +105,7 @@ public final class IamResourceTrait extends AbstractTrait
     }
 
     @Override
-    public SmithyBuilder<IamResourceTrait> toBuilder() {
+    public Builder toBuilder() {
         return builder().sourceLocation(getSourceLocation()).name(name);
     }
 


### PR DESCRIPTION
This commit foremost fixes an issue where the toNode method on ActionResources does not function properly, omitting all values instead.

It also updates several type signatures for SmithyBuilder generic type responses to use the specific implementation of the interface.

It also includes an simplification of the createNode method for the defineConditionKeys trait.

-----
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
