### PR TITLE
Lower UnboundTestOperation to WARNING

### DIFF
--- a/smithy-aws-protocol-tests/model/shared-types.smithy
+++ b/smithy-aws-protocol-tests/model/shared-types.smithy
@@ -22,6 +22,7 @@ metadata validators = [
     {
         name: "EmitEachSelector"
         id: "UnboundTestOperation"
+        severity: "WARNING"
         message: "This operation in the AWS protocol tests is not bound to a service."
         namespaces: [
             // Overall protocol test suites.

--- a/smithy-protocol-tests/model/shared-types.smithy
+++ b/smithy-protocol-tests/model/shared-types.smithy
@@ -11,6 +11,7 @@ metadata validators = [
     {
         name: "EmitEachSelector"
         id: "UnboundTestOperation"
+        severity: "WARNING"
         message: "This operation in the Smithy protocol tests is not bound to a service."
         namespaces: [
             // Overall protocol test suites.


### PR DESCRIPTION
Consumers of this package using the `includeServices` transform may not also be running `removeUnusedShapes`, leaving behind operations that then trip this validation and cause an error. Lowering this to a warning still emits a message but doesn't block consumers until we find a better strategy for running this validation at Smithy-only build time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
