### PR TITLE
Update `NullAndEmptyHeadersServer` tests for `restJson1` and `restXml`

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-headers.smithy
@@ -412,7 +412,7 @@ structure InputAndOutputWithHeadersIO {
     headerIntegerEnumList: IntegerEnumList,
 }
 
-/// Null and empty headers are not sent over the wire.
+/// Null headers are not sent over the wire, empty headers are serialized to ""
 @readonly
 @http(uri: "/NullAndEmptyHeadersClient", method: "GET")
 @tags(["client-only"])
@@ -443,7 +443,7 @@ apply NullAndEmptyHeadersClient @httpRequestTests([
     },
 ])
 
-/// Null and empty headers are not sent over the wire.
+/// Null headers are not sent over the wire, empty headers are serialized to ""
 @readonly
 @http(uri: "/NullAndEmptyHeadersServer", method: "GET")
 @tags(["server-only"])
@@ -455,10 +455,14 @@ operation NullAndEmptyHeadersServer {
 apply NullAndEmptyHeadersServer @httpResponseTests([
     {
         id: "RestJsonNullAndEmptyHeaders",
-        documentation: "Do not send null or empty headers",
+        documentation: "Do not send null values, but do send empty strings and empty lists over the wire in headers",
         protocol: restJson1,
         code: 200,
-        forbidHeaders: ["X-A", "X-B", "X-C"],
+        forbidHeaders: ["X-A"],
+        headers: {
+            "X-B": ""
+            "X-C": ""
+        }
         params: {
             a: null,
             b: "",

--- a/smithy-aws-protocol-tests/model/restXml/http-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-headers.smithy
@@ -355,7 +355,7 @@ structure InputAndOutputWithHeadersIO {
     headerEnumList: FooEnumList,
 }
 
-/// Null and empty headers are not sent over the wire.
+/// Null headers are not sent over the wire, empty headers are serialized to ""
 @readonly
 @http(uri: "/NullAndEmptyHeadersClient", method: "GET")
 @tags(["client-only"])
@@ -386,7 +386,7 @@ apply NullAndEmptyHeadersClient @httpRequestTests([
     },
 ])
 
-/// Null and empty headers are not sent over the wire.
+/// Null headers are not sent over the wire, empty headers are serialized to ""
 @readonly
 @http(uri: "/NullAndEmptyHeadersServer", method: "GET")
 @tags(["server-only"])
@@ -398,10 +398,14 @@ operation NullAndEmptyHeadersServer {
 apply NullAndEmptyHeadersServer @httpResponseTests([
     {
         id: "NullAndEmptyHeaders",
-        documentation: "Do not send null or empty headers",
+        documentation: "Do not send null values, but do send empty strings and empty lists over the wire in headers",
         protocol: restXml,
         code: 200,
-        forbidHeaders: ["X-A", "X-B", "X-C"],
+        forbidHeaders: ["X-A"],
+        headers: {
+            "X-B": ""
+            "X-C": ""
+        }
         body: "",
         params: {
             a: null,


### PR DESCRIPTION

#### Background
* What do these changes do? 
* Why are they important?

`NullAndEmptyHeaderClient` tests were [recently updated](https://github.com/smithy-lang/smithy/pull/2403) to expect empty headers to be serialized. Similar changes were not made for the server variants of those tests. This leads to an unexpected difference in serialization between servers and clients and prevents clients from receiving semantically meaningful headers from the server.

The test now align with the similar tests for clients. They expect empty headers to be serialized as "" and null headers to not be serialized

#### Testing
* How did you test these changes?
Confirmed that the same changes made for client header serialization in https://github.com/smithy-lang/smithy-rs/pull/3887 worked for the server tests as well.

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
