### PR TITLE
Return Builders instead of SmithyBuilders

### DIFF
--- a/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceTrait.java
+++ b/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceTrait.java
@@ -25,7 +25,6 @@ import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.ListUtils;
-import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -75,7 +74,7 @@ public final class CfnResourceTrait extends AbstractTrait
     }
 
     @Override
-    public SmithyBuilder<CfnResourceTrait> toBuilder() {
+    public Builder toBuilder() {
         return builder().sourceLocation(getSourceLocation()).name(name).additionalSchemas(additionalSchemas);
     }
 

--- a/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/model/Handler.java
+++ b/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/model/Handler.java
@@ -61,7 +61,7 @@ public final class Handler implements ToNode, ToSmithyBuilder<Handler> {
     }
 
     @Override
-    public SmithyBuilder<Handler> toBuilder() {
+    public Builder toBuilder() {
         return builder()
                 .permissions(permissions);
     }

--- a/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/model/Property.java
+++ b/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/model/Property.java
@@ -62,7 +62,7 @@ public final class Property implements ToNode, ToSmithyBuilder<Property> {
     }
 
     @Override
-    public SmithyBuilder<Property> toBuilder() {
+    public Builder toBuilder() {
         return builder()
                 .insertionOrder(insertionOrder)
                 .dependencies(dependencies)

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/language/functions/partition/Partition.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/language/functions/partition/Partition.java
@@ -16,7 +16,6 @@ import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.rulesengine.language.RulesComponentBuilder;
 import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.ListUtils;
-import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -117,7 +116,7 @@ public final class Partition implements ToSmithyBuilder<Partition>, FromSourceLo
     }
 
     @Override
-    public SmithyBuilder<Partition> toBuilder() {
+    public Builder toBuilder() {
         return new Builder(getSourceLocation())
                 .id(id)
                 .regionRegex(regionRegex)

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/language/functions/partition/PartitionOutputs.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/language/functions/partition/PartitionOutputs.java
@@ -15,7 +15,6 @@ import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.rulesengine.language.RulesComponentBuilder;
 import software.amazon.smithy.utils.ListUtils;
-import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -142,7 +141,7 @@ public final class PartitionOutputs implements ToSmithyBuilder<PartitionOutputs>
     }
 
     @Override
-    public SmithyBuilder<PartitionOutputs> toBuilder() {
+    public Builder toBuilder() {
         return new Builder(getSourceLocation())
                 .name(name)
                 .dnsSuffix(dnsSuffix)

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/language/functions/partition/RegionOverride.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/language/functions/partition/RegionOverride.java
@@ -10,7 +10,6 @@ import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.rulesengine.language.RulesComponentBuilder;
-import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -54,7 +53,7 @@ public final class RegionOverride implements ToSmithyBuilder<RegionOverride>, Fr
     }
 
     @Override
-    public SmithyBuilder<RegionOverride> toBuilder() {
+    public Builder toBuilder() {
         return new Builder(getSourceLocation());
     }
 

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/PartitionEndpointSpecialCase.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/PartitionEndpointSpecialCase.java
@@ -86,7 +86,7 @@ public final class PartitionEndpointSpecialCase
     }
 
     @Override
-    public SmithyBuilder<PartitionEndpointSpecialCase> toBuilder() {
+    public Builder toBuilder() {
         return new Builder()
             .endpoint(endpoint)
             .region(region)

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/PartitionSpecialCase.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/PartitionSpecialCase.java
@@ -72,7 +72,7 @@ public final class PartitionSpecialCase implements FromSourceLocation, ToNode, T
     }
 
     @Override
-    public SmithyBuilder<PartitionSpecialCase> toBuilder() {
+    public Builder toBuilder() {
         return new Builder()
             .dualStack(dualStack)
             .endpoint(endpoint)

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/RegionSpecialCase.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/RegionSpecialCase.java
@@ -83,7 +83,7 @@ public final class RegionSpecialCase implements FromSourceLocation, ToNode, ToSm
     }
 
     @Override
-    public SmithyBuilder<RegionSpecialCase> toBuilder() {
+    public Builder toBuilder() {
         return new Builder()
             .dualStack(dualStack)
             .endpoint(endpoint)

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/StandardPartitionalEndpointsTrait.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/StandardPartitionalEndpointsTrait.java
@@ -17,7 +17,6 @@ import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.BuilderRef;
-import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -78,7 +77,7 @@ public final class StandardPartitionalEndpointsTrait extends AbstractTrait
     }
 
     @Override
-    public SmithyBuilder<StandardPartitionalEndpointsTrait> toBuilder() {
+    public Builder toBuilder() {
         return new Builder()
                 .partitionEndpointSpecialCases(partitionEndpointSpecialCases)
                 .endpointPatternType(endpointPatternType);

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/StandardRegionalEndpointsTrait.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/StandardRegionalEndpointsTrait.java
@@ -16,7 +16,6 @@ import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.BuilderRef;
-import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -84,7 +83,7 @@ public final class StandardRegionalEndpointsTrait extends AbstractTrait
     }
 
     @Override
-    public SmithyBuilder<StandardRegionalEndpointsTrait> toBuilder() {
+    public Builder toBuilder() {
         return new Builder()
                 .partitionSpecialCases(partitionSpecialCases)
                 .regionSpecialCases(regionSpecialCases);

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/HttpChecksumTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/HttpChecksumTrait.java
@@ -27,7 +27,6 @@ import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.ListUtils;
-import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -66,7 +65,7 @@ public final class HttpChecksumTrait extends AbstractTrait implements ToSmithyBu
     }
 
     @Override
-    public SmithyBuilder<HttpChecksumTrait> toBuilder() {
+    public Builder toBuilder() {
         return new Builder()
                 .sourceLocation(getSourceLocation())
                 .requestChecksumRequired(requestChecksumRequired)

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientDiscoveredEndpointTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientDiscoveredEndpointTrait.java
@@ -20,7 +20,6 @@ import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
-import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -63,7 +62,7 @@ public final class ClientDiscoveredEndpointTrait extends AbstractTrait
     }
 
     @Override
-    public SmithyBuilder<ClientDiscoveredEndpointTrait> toBuilder() {
+    public Builder toBuilder() {
         return builder().sourceLocation(getSourceLocation()).required(required);
     }
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/AwsQueryErrorTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/protocols/AwsQueryErrorTrait.java
@@ -74,7 +74,7 @@ public final class AwsQueryErrorTrait extends AbstractTrait implements ToSmithyB
     }
 
     @Override
-    public SmithyBuilder<AwsQueryErrorTrait> toBuilder() {
+    public Builder toBuilder() {
         return builder().code(code).httpResponseCode(httpResponseCode).sourceLocation(getSourceLocation());
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/node/ArrayNode.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/node/ArrayNode.java
@@ -73,7 +73,7 @@ public final class ArrayNode extends Node implements Iterable<Node>, ToSmithyBui
     }
 
     @Override
-    public SmithyBuilder<ArrayNode> toBuilder() {
+    public Builder toBuilder() {
         return new Builder().sourceLocation(getSourceLocation()).merge(this);
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/EnumValueTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/EnumValueTrait.java
@@ -21,7 +21,6 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.NumberNode;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -101,7 +100,7 @@ public final class EnumValueTrait extends AbstractTrait implements ToSmithyBuild
     }
 
     @Override
-    public SmithyBuilder<EnumValueTrait> toBuilder() {
+    public Builder toBuilder() {
         Builder builder = builder().sourceLocation(getSourceLocation());
         builder.value = value;
         return builder;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExamplesTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/ExamplesTrait.java
@@ -310,7 +310,7 @@ public final class ExamplesTrait extends AbstractTrait implements ToSmithyBuilde
         }
 
         @Override
-        public SmithyBuilder<ErrorExample> toBuilder() {
+        public Builder toBuilder() {
             return builder().content(content).shapeId(shapeId);
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/RequestCompressionTrait.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/RequestCompressionTrait.java
@@ -23,7 +23,6 @@ import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.SetUtils;
-import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -85,7 +84,7 @@ public final class RequestCompressionTrait extends AbstractTrait implements ToSm
     }
 
     @Override
-    public SmithyBuilder<RequestCompressionTrait> toBuilder() {
+    public Builder toBuilder() {
         return new Builder()
                 .sourceLocation(getSourceLocation())
                 .encodings(encodings);

--- a/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeMapperTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/node/NodeMapperTest.java
@@ -1351,7 +1351,7 @@ public class NodeMapperTest {
         }
 
         @Override
-        public SmithyBuilder<SourceLocationBearerTrait> toBuilder() {
+        public Builder toBuilder() {
             return new Builder().sourceLocation(getSourceLocation());
         }
 

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestOperationInput.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointTestOperationInput.java
@@ -79,7 +79,7 @@ public final class EndpointTestOperationInput implements FromSourceLocation,
     }
 
     @Override
-    public SmithyBuilder<EndpointTestOperationInput> toBuilder() {
+    public Builder toBuilder() {
         return builder()
                 .sourceLocation(sourceLocation)
                 .operationName(operationName)

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ExpectedEndpoint.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/ExpectedEndpoint.java
@@ -56,7 +56,7 @@ public final class ExpectedEndpoint implements FromSourceLocation, ToSmithyBuild
     }
 
     @Override
-    public SmithyBuilder<ExpectedEndpoint> toBuilder() {
+    public Builder toBuilder() {
         return builder()
                 .sourceLocation(sourceLocation)
                 .url(url)

--- a/smithy-waiters/src/main/java/software/amazon/smithy/waiters/WaitableTrait.java
+++ b/smithy-waiters/src/main/java/software/amazon/smithy/waiters/WaitableTrait.java
@@ -24,7 +24,6 @@ import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.TraitService;
 import software.amazon.smithy.utils.BuilderRef;
-import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -47,7 +46,7 @@ public final class WaitableTrait extends AbstractTrait implements ToSmithyBuilde
     }
 
     @Override
-    public SmithyBuilder<WaitableTrait> toBuilder() {
+    public Builder toBuilder() {
         return new Builder().sourceLocation(getSourceLocation()).replace(waiters);
     }
 

--- a/smithy-waiters/src/main/java/software/amazon/smithy/waiters/Waiter.java
+++ b/smithy-waiters/src/main/java/software/amazon/smithy/waiters/Waiter.java
@@ -69,7 +69,7 @@ public final class Waiter implements Tagged, ToNode, ToSmithyBuilder<Waiter> {
     }
 
     @Override
-    public SmithyBuilder<Waiter> toBuilder() {
+    public Builder toBuilder() {
         return builder()
                 .documentation(getDocumentation().orElse(null))
                 .acceptors(getAcceptors())


### PR DESCRIPTION
This commit updates all instances where a generic SmithyBuilder<> was returned to return the specific implementing Builder. This means users of these methods can easily use the Builder's functionality without using a cast.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
