### PR TITLE
Use lowercase headers for prefix-header test

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-prefix-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-prefix-headers.smithy
@@ -28,15 +28,15 @@ apply HttpPrefixHeaders @httpRequestTests([
         uri: "/HttpPrefixHeaders",
         body: "",
         headers: {
-            "X-Foo": "Foo",
-            "X-Foo-Abc": "Abc value",
-            "X-Foo-Def": "Def value",
+            "x-foo": "Foo",
+            "x-foo-abc": "Abc value",
+            "x-foo-def": "Def value",
         },
         params: {
             foo: "Foo",
             fooMap: {
-                Abc: "Abc value",
-                Def: "Def value",
+                abc: "Abc value",
+                def: "Def value",
             }
         }
     },
@@ -48,7 +48,7 @@ apply HttpPrefixHeaders @httpRequestTests([
         uri: "/HttpPrefixHeaders",
         body: "",
         headers: {
-            "X-Foo": "Foo"
+            "x-foo": "Foo"
         },
         params: {
             foo: "Foo",
@@ -65,11 +65,11 @@ apply HttpPrefixHeaders @httpRequestTests([
         body: "",
         params: {
             fooMap: {
-                Abc: ""
+                abc: ""
             }
         },
         headers: {
-            "X-Foo-Abc": ""
+            "x-foo-abc": ""
         }
         appliesTo: "client",
     },
@@ -82,15 +82,15 @@ apply HttpPrefixHeaders @httpResponseTests([
         protocol: restJson1,
         code: 200,
         headers: {
-            "X-Foo": "Foo",
-            "X-Foo-Abc": "Abc value",
-            "X-Foo-Def": "Def value",
+            "x-foo": "Foo",
+            "x-foo-abc": "Abc value",
+            "x-foo-def": "Def value",
         },
         params: {
             foo: "Foo",
             fooMap: {
-                Abc: "Abc value",
-                Def: "Def value",
+                abc: "Abc value",
+                def: "Def value",
             }
         }
     },
@@ -98,19 +98,19 @@ apply HttpPrefixHeaders @httpResponseTests([
 
 @input
 structure HttpPrefixHeadersInput {
-    @httpHeader("X-Foo")
+    @httpHeader("x-foo")
     foo: String,
 
-    @httpPrefixHeaders("X-Foo-")
+    @httpPrefixHeaders("x-foo-")
     fooMap: StringMap,
 }
 
 @output
 structure HttpPrefixHeadersOutput {
-    @httpHeader("X-Foo")
+    @httpHeader("x-foo")
     foo: String,
 
-    @httpPrefixHeaders("X-Foo-")
+    @httpPrefixHeaders("x-foo-")
     fooMap: StringMap,
 }
 
@@ -129,13 +129,13 @@ apply HttpPrefixHeadersInResponse @httpResponseTests([
         protocol: restJson1,
         code: 200,
         headers: {
-            "X-Foo": "Foo",
-            "Hello": "Hello"
+            "x-foo": "Foo",
+            "hello": "Hello"
         },
         params: {
             prefixHeaders: {
-                "X-Foo": "Foo",
-                "Hello": "Hello"
+                "x-foo": "Foo",
+                "hello": "Hello"
             }
         }
     },

--- a/smithy-aws-protocol-tests/model/restXml/http-prefix-headers.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/http-prefix-headers.smithy
@@ -27,15 +27,15 @@ apply HttpPrefixHeaders @httpRequestTests([
         uri: "/HttpPrefixHeaders",
         body: "",
         headers: {
-            "X-Foo": "Foo",
-            "X-Foo-Abc": "Abc value",
-            "X-Foo-Def": "Def value",
+            "x-foo": "Foo",
+            "x-foo-abc": "Abc value",
+            "x-foo-def": "Def value",
         },
         params: {
             foo: "Foo",
             fooMap: {
-                Abc: "Abc value",
-                Def: "Def value",
+                abc: "Abc value",
+                def: "Def value",
             }
         }
     },
@@ -47,7 +47,7 @@ apply HttpPrefixHeaders @httpRequestTests([
         uri: "/HttpPrefixHeaders",
         body: "",
         headers: {
-            "X-Foo": "Foo"
+            "x-foo": "Foo"
         },
         params: {
             foo: "Foo",
@@ -64,11 +64,11 @@ apply HttpPrefixHeaders @httpRequestTests([
         body: "",
         params: {
             fooMap: {
-                Abc: ""
+                abc: ""
             }
         },
         headers: {
-            "X-Foo-Abc": ""
+            "x-foo-abc": ""
         }
         appliesTo: "client",
     },
@@ -82,15 +82,15 @@ apply HttpPrefixHeaders @httpResponseTests([
         code: 200,
         body: "",
         headers: {
-            "X-Foo": "Foo",
-            "X-Foo-Abc": "Abc value",
-            "X-Foo-Def": "Def value",
+            "x-foo": "Foo",
+            "x-foo-abc": "Abc value",
+            "x-foo-def": "Def value",
         },
         params: {
             foo: "Foo",
             fooMap: {
-                Abc: "Abc value",
-                Def: "Def value",
+                abc: "Abc value",
+                def: "Def value",
             }
         }
     },
@@ -101,7 +101,7 @@ apply HttpPrefixHeaders @httpResponseTests([
         code: 200,
         body: "",
         headers: {
-            "X-Foo": "Foo"
+            "x-foo": "Foo"
         },
         params: {
             foo: "Foo",
@@ -111,10 +111,10 @@ apply HttpPrefixHeaders @httpResponseTests([
 ])
 
 structure HttpPrefixHeadersInputOutput {
-    @httpHeader("X-Foo")
+    @httpHeader("x-foo")
     foo: String,
 
-    @httpPrefixHeaders("X-Foo-")
+    @httpPrefixHeaders("x-foo-")
     fooMap: FooPrefixHeaders,
 }
 


### PR DESCRIPTION
HTTP headers are case-insensitive so using casing in prefix header tests adds unnecessary challenges when implementing rest-xml and rest-json protocol tests. Many HTTP implementations lowercase header names to make them case-insensitive (e.g., Go), and it's even a requirement of h2 (https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2).

This commit updates httpPrefixHeaders tests to use lowercase header names to avoid any kind of header casing issues when implementing these tests.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
