### PR TITLE
Add multiselect and filter to supported operationContextParams paths

### DIFF
--- a/docs/source-2.0/additional-specs/rules-engine/parameters.rst
+++ b/docs/source-2.0/additional-specs/rules-engine/parameters.rst
@@ -318,8 +318,13 @@ to a subset of JMESPath:
   exist in the JSON document, than a null value is returned.
 * `Sub Expressions`_ - a combination of two expressions separated by the ``.`` char.
   Example:  ``grandparent.parent.child``
-* `Wildcard Expressions`_ - Creates a projection over the values in an array or map.
+* `Wildcard Expressions`_ - creates a projection over the values in an array or map.
   Remaining expressions are evaluated against each returned element.
+* `MultiSelect List`_ - extract a subset of elements from a JSON document.  Each expression is evaluated
+  against the JSON document.  A Multiselect list with ``N`` expressions will result in a list of
+  length ``N``.
+* `Flatten Operator`_ - merge sublists in the current result into a single list. Subsequent operations are
+  projected onto the flattened list with the same semantics as a wildcard expression
 * `Keys function`_ - return a list of the keys in a map.  This is the only supported function but is required
   for binding to key values.
 
@@ -430,4 +435,6 @@ The rules engine is highly extensible through
 .. _Identifiers: https://jmespath.org/specification.html#identifiers
 .. _Sub expressions: https://jmespath.org/specification.html#subexpressions
 .. _Wildcard expressions: https://jmespath.org/specification.html#wildcard-expressions
+.. _MultiSelect List: https://jmespath.org/specification.html#multiselect-list
+.. _Flatten Operator: https://jmespath.org/specification.html#flatten-operator
 .. _Keys function: https://jmespath.org/specification.html#keys

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/OperationContextParamsTraitValidator.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/OperationContextParamsTraitValidator.java
@@ -114,7 +114,7 @@ public final class OperationContextParamsTraitValidator extends AbstractValidato
 
         @Override
         public List<String> visitCurrentNode(CurrentExpression expression) {
-            return ListUtils.of("current node");
+            return Collections.emptyList();
         }
 
         @Override
@@ -124,7 +124,7 @@ public final class OperationContextParamsTraitValidator extends AbstractValidato
 
         @Override
         public List<String> visitFlatten(FlattenExpression expression) {
-            return ListUtils.of("flatten");
+            return expression.getExpression().accept(this);
         }
 
         @Override
@@ -156,7 +156,9 @@ public final class OperationContextParamsTraitValidator extends AbstractValidato
 
         @Override
         public List<String> visitMultiSelectList(MultiSelectListExpression expression) {
-            return ListUtils.of("multiselect list");
+            List<String> unsupported = new ArrayList<>();
+            expression.getExpressions().forEach(e -> unsupported.addAll(e.accept(this)));
+            return Collections.unmodifiableList(unsupported);
         }
 
         @Override
@@ -181,7 +183,10 @@ public final class OperationContextParamsTraitValidator extends AbstractValidato
 
         @Override
         public List<String> visitProjection(ProjectionExpression expression) {
-            return Collections.emptyList();
+            List<String> unsupported = new ArrayList<>();
+            unsupported.addAll(expression.getLeft().accept(this));
+            unsupported.addAll(expression.getRight().accept(this));
+            return Collections.unmodifiableList(unsupported);
         }
 
         @Override

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-operation-context-params.errors
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-operation-context-params.errors
@@ -5,5 +5,6 @@
 [ERROR] example#Bar: The operation `example#Bar` is marked with `smithy.rules#operationContextParams` which contains a path `projectionOnScalar` with an invalid JMESPath path `nested.foo[*]`: 'Array projection performed on string'. | OperationContextParamsTrait
 [ERROR] example#Bar: The operation `example#Bar` is marked with `smithy.rules#operationContextParams` which contains a key `unsupportedFunction` with a JMESPath path `length(listOfObjects)` with unsupported expressions: '`length` function'. | OperationContextParamsTrait
 [ERROR] example#Bar: The operation `example#Bar` is marked with `smithy.rules#operationContextParams` which contains a key `unsupportedExpression` with a JMESPath path `listOfObjects[1]` with unsupported expressions: 'index'. | OperationContextParamsTrait
+[ERROR] example#Bar: The operation `example#Bar` is marked with `smithy.rules#operationContextParams` which contains a key `projectionAndUnsupportedExpression` with a JMESPath path `listOfObjects[*].listOfStrings[0]` with unsupported expressions: 'index'. | OperationContextParamsTrait
 
 

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-operation-context-params.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-operation-context-params.smithy
@@ -14,7 +14,8 @@ service FizzBuzz {
     incorrectKey: {path: "nested.bar"},
     projectionOnScalar: {path: "nested.foo[*]"},
     unsupportedFunction: {path: "length(listOfObjects)"},
-    unsupportedExpression: {path: "listOfObjects[1]"}
+    unsupportedExpression: {path: "listOfObjects[1]"},
+    projectionAndUnsupportedExpression: {path: "listOfObjects[*].listOfStrings[0]"}
 )
 operation Bar {
     input: BarInput
@@ -31,10 +32,15 @@ list ListOfObjects {
 
 structure ObjectMember {
     key: Key,
+    listOfStrings: ListOfStrings
 }
 
 structure Nested {
     foo: String,
+}
+
+list ListOfStrings {
+    member: String
 }
 
 string Key

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/valid/operation-context-params.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/valid/operation-context-params.smithy
@@ -13,7 +13,8 @@ service FizzBuzz {
     projection: {path: "listOfObjects[*].key"},
     subExpression: {path: "nested.nested.bar"},
     recursive: {path: "nested.nested.recursiveMember.foo"}
-    keysFunction: {path: "keys(map)"}
+    keysFunction: {path: "keys(map)"},
+    multiSelectFlatten: {path: "listOfUnions[*].[nested.foo, object.key][]"}
 )
 operation Bar {
     input: BarInput
@@ -23,11 +24,21 @@ structure BarInput {
     resourceId: String,
     nested: Nested1,
     listOfObjects: ListOfObjects,
+    listOfUnions: ListOfUnions,
     map: Map
 }
 
 list ListOfObjects {
     member: ObjectMember
+}
+
+list ListOfUnions {
+    member: UnionMember
+}
+
+union UnionMember {
+    nested: Nested1,
+    object: ObjectMember
 }
 
 structure ObjectMember {


### PR DESCRIPTION
#### Background
* Add multiselect and filter to supported operationContextParams paths
* Fix bugs in OperationContextParamsValidator.

#### Testing
* New + Existing unit tests

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
