### PR TITLE
Fix for tagsProperty in CFN schema creation

### DIFF
--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/weather-service-wide.cfn.json
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/weather-service-wide.cfn.json
@@ -80,7 +80,7 @@
     },
     "tagging": {
         "tagOnCreate": false,
-        "tagProperty": "Tags",
+        "tagProperty": "/properties/Tags",
         "tagUpdatable": true,
         "cloudFormationSystemTags": true,
         "taggable": true

--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/weather.cfn.json
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/weather.cfn.json
@@ -79,7 +79,7 @@
     },
     "tagging": {
         "tagOnCreate": false,
-        "tagProperty": "Tags",
+        "tagProperty": "/properties/Tags",
         "tagUpdatable": true,
         "cloudFormationSystemTags": true,
         "taggable": true


### PR DESCRIPTION
This value is expected to be a JSON pointer to a property, not just the name of the property.

See: https://github.com/aws-cloudformation/cloudformation-cli/blob/master/src/rpdk/core/data/schema/provider.definition.schema.v1.json#L193-L197

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
