### PR TITLE
Inject tagging operation permissions for CFN

### DIFF
--- a/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/mappers/CoreExtension.java
+++ b/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/mappers/CoreExtension.java
@@ -34,6 +34,7 @@ public final class CoreExtension implements Smithy2CfnExtension {
                 new IdentifierMapper(),
                 new JsonAddMapper(),
                 new MutabilityMapper(),
-                new RequiredMapper());
+                new RequiredMapper(),
+                new TaggingMapper());
     }
 }

--- a/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/mappers/HandlerPermissionMapper.java
+++ b/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/mappers/HandlerPermissionMapper.java
@@ -40,7 +40,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
  * @see <a href="https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html#schema-properties-handlers">handlers Docs</a>
  */
 @SmithyInternalApi
-public final class HandlerPermissionMapper implements CfnMapper {
+final class HandlerPermissionMapper implements CfnMapper {
     @Override
     public void before(Context context, ResourceSchema.Builder resourceSchema) {
         if (context.getConfig().getDisableHandlerPermissionGeneration()) {
@@ -97,7 +97,7 @@ public final class HandlerPermissionMapper implements CfnMapper {
                         .permissions(permissions).build()));
     }
 
-    private Set<String> getPermissionsEntriesForOperation(Model model, ServiceShape service, ShapeId operationId) {
+    static Set<String> getPermissionsEntriesForOperation(Model model, ServiceShape service, ShapeId operationId) {
         OperationShape operation = model.expectShape(operationId, OperationShape.class);
         Set<String> permissionsEntries = new TreeSet<>();
 

--- a/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/mappers/TaggingMapper.java
+++ b/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/mappers/TaggingMapper.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.aws.cloudformation.schema.fromsmithy.mappers;
+
+import static software.amazon.smithy.aws.cloudformation.schema.fromsmithy.mappers.HandlerPermissionMapper.getPermissionsEntriesForOperation;
+
+import java.util.Optional;
+import software.amazon.smithy.aws.cloudformation.schema.CfnConfig;
+import software.amazon.smithy.aws.cloudformation.schema.fromsmithy.CfnMapper;
+import software.amazon.smithy.aws.cloudformation.schema.fromsmithy.Context;
+import software.amazon.smithy.aws.cloudformation.schema.model.ResourceSchema;
+import software.amazon.smithy.aws.cloudformation.schema.model.Tagging;
+import software.amazon.smithy.aws.cloudformation.traits.CfnResource;
+import software.amazon.smithy.aws.cloudformation.traits.CfnResourceIndex;
+import software.amazon.smithy.aws.traits.tagging.AwsTagIndex;
+import software.amazon.smithy.aws.traits.tagging.TaggableTrait;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.ResourceShape;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.utils.SmithyInternalApi;
+import software.amazon.smithy.utils.StringUtils;
+
+/**
+ * Generates the resource's Tagging configuration based on the AwsTagIndex, including
+ * the tagging property and operations that interact with tags.
+ *
+ * @see <a href="https://github.com/aws-cloudformation/cloudformation-cli/blob/master/src/rpdk/core/data/schema/provider.definition.schema.v1.json#L198">permissions property definition</a>
+ */
+@SmithyInternalApi
+public final class TaggingMapper implements CfnMapper {
+    private static final String DEFAULT_TAGS_NAME = "Tags";
+
+    @SmithyInternalApi
+    public static void injectTagsMember(
+            CfnConfig config,
+            Model model,
+            ResourceShape resource,
+            StructureShape.Builder builder
+    ) {
+        String tagMemberName = getTagMemberName(config, resource);
+        if (resource.hasTrait(TaggableTrait.class)) {
+            AwsTagIndex tagIndex = AwsTagIndex.of(model);
+            TaggableTrait trait = resource.expectTrait(TaggableTrait.class);
+            CfnResourceIndex resourceIndex = CfnResourceIndex.of(model);
+            CfnResource cfnResource = resourceIndex.getResource(resource).get();
+
+            if (!trait.getProperty().isPresent() || !cfnResource.getProperties()
+                    .containsKey(trait.getProperty().get())) {
+                if (trait.getProperty().isPresent()) {
+                    ShapeId definition = resource.getProperties().get(trait.getProperty().get());
+                    builder.addMember(tagMemberName, definition);
+                } else {
+                    // A valid TagResource operation certainly has a single tags input member.
+                    Optional<ShapeId> tagOperation = tagIndex.getTagResourceOperation(resource.getId());
+                    MemberShape member = tagIndex.getTagsMember(tagOperation.get()).get();
+                    member = member.toBuilder().id(builder.getId().withMember(tagMemberName)).build();
+                    builder.addMember(member);
+                }
+            }
+        }
+    }
+
+    @Override
+    public ResourceSchema after(Context context, ResourceSchema resourceSchema) {
+        ResourceShape resourceShape = context.getResource();
+        if (!resourceShape.hasTrait(TaggableTrait.class)) {
+            return resourceSchema;
+        }
+
+        Model model = context.getModel();
+        ServiceShape service = context.getService();
+        AwsTagIndex tagsIndex = AwsTagIndex.of(model);
+        TaggableTrait trait = resourceShape.expectTrait(TaggableTrait.class);
+        Tagging.Builder tagBuilder = Tagging.builder()
+                .taggable(true)
+                .tagOnCreate(tagsIndex.isResourceTagOnCreate(resourceShape.getId()))
+                .tagProperty("/properties/" + getTagMemberName(context.getConfig(), resourceShape))
+                .cloudFormationSystemTags(!trait.getDisableSystemTags())
+                // Unless tag-on-create is supported, Smithy tagging means
+                .tagUpdatable(true);
+
+        // Add the tagging permissions based on the defined tagging operations.
+        tagsIndex.getTagResourceOperation(resourceShape)
+                .map(operation -> getPermissionsEntriesForOperation(model, service, operation))
+                .ifPresent(tagBuilder::addPermissions);
+        tagsIndex.getListTagsForResourceOperation(resourceShape)
+                .map(operation -> getPermissionsEntriesForOperation(model, service, operation))
+                .ifPresent(tagBuilder::addPermissions);
+        tagsIndex.getUntagResourceOperation(resourceShape)
+                .map(operation -> getPermissionsEntriesForOperation(model, service, operation))
+                .ifPresent(tagBuilder::addPermissions);
+
+        return resourceSchema.toBuilder().tagging(tagBuilder.build()).build();
+    }
+
+    private static String getTagMemberName(CfnConfig config, ResourceShape resource) {
+        return resource.getTrait(TaggableTrait.class)
+                .flatMap(TaggableTrait::getProperty)
+                .map(property -> {
+                    if (config.getDisableCapitalizedProperties()) {
+                        return property;
+                    }
+                    return StringUtils.capitalize(property);
+                })
+                .orElse(DEFAULT_TAGS_NAME);
+    }
+}

--- a/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/model/Tagging.java
+++ b/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/model/Tagging.java
@@ -15,6 +15,10 @@
 
 package software.amazon.smithy.aws.cloudformation.schema.model;
 
+import java.util.Collection;
+import java.util.Set;
+import java.util.TreeSet;
+import software.amazon.smithy.utils.SetUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -27,6 +31,7 @@ public final class Tagging implements ToSmithyBuilder<Tagging> {
     private final boolean tagUpdatable;
     private final String tagProperty;
     private final boolean cloudFormationSystemTags;
+    private final Set<String> permissions;
 
     private Tagging(Builder builder) {
         taggable = builder.taggable;
@@ -34,6 +39,7 @@ public final class Tagging implements ToSmithyBuilder<Tagging> {
         tagUpdatable = builder.tagUpdatable;
         cloudFormationSystemTags = builder.cloudFormationSystemTags;
         tagProperty = builder.tagProperty;
+        this.permissions = SetUtils.orderedCopyOf(builder.permissions);
     }
 
     public static Builder builder() {
@@ -85,6 +91,15 @@ public final class Tagging implements ToSmithyBuilder<Tagging> {
         return tagProperty;
     }
 
+    /**
+     * Returns the set of permissions required to interact with this resource's tags.
+     *
+     * @return the set of permissions.
+     */
+    public Set<String> getPermissions() {
+        return permissions;
+    }
+
     @Override
     public Builder toBuilder() {
         return builder()
@@ -92,7 +107,8 @@ public final class Tagging implements ToSmithyBuilder<Tagging> {
                 .tagOnCreate(tagOnCreate)
                 .tagUpdatable(tagUpdatable)
                 .cloudFormationSystemTags(cloudFormationSystemTags)
-                .tagProperty(tagProperty);
+                .tagProperty(tagProperty)
+                .permissions(permissions);
     }
 
     public static final class Builder implements SmithyBuilder<Tagging> {
@@ -101,6 +117,7 @@ public final class Tagging implements ToSmithyBuilder<Tagging> {
         private boolean tagUpdatable;
         private boolean cloudFormationSystemTags;
         private String tagProperty;
+        private final Set<String> permissions = new TreeSet<>();
 
         @Override
         public Tagging build() {
@@ -129,6 +146,29 @@ public final class Tagging implements ToSmithyBuilder<Tagging> {
 
         public Builder tagProperty(String tagProperty) {
             this.tagProperty = tagProperty;
+            return this;
+        }
+
+        public Builder permissions(Collection<String> permissions) {
+            this.permissions.clear();
+            this.permissions.addAll(permissions);
+            return this;
+        }
+
+        public Builder addPermissions(Collection<String> permissions) {
+            for (String permission : permissions) {
+                addPermission(permission);
+            }
+            return this;
+        }
+
+        public Builder addPermission(String permission) {
+            this.permissions.add(permission);
+            return this;
+        }
+
+        public Builder clearPermissions() {
+            this.permissions.clear();
             return this;
         }
     }

--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/provider.definition.schema.v1.json
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/provider.definition.schema.v1.json
@@ -145,6 +145,13 @@
                     "description": "A reference to the Tags property in the schema.",
                     "$ref": "http://json-schema.org/draft-07/schema#/properties/$ref",
                     "default": "/properties/Tags"
+                },
+                "permissions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "additionalItems": false
                 }
             },
             "required": [

--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/weather-service-wide.cfn.json
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/weather-service-wide.cfn.json
@@ -83,7 +83,12 @@
         "tagProperty": "/properties/Tags",
         "tagUpdatable": true,
         "cloudFormationSystemTags": true,
-        "taggable": true
+        "taggable": true,
+        "permissions": [
+            "weather:ListTagsForResource",
+            "weather:TagResource",
+            "weather:UntagResource"
+        ]
     },
     "additionalProperties": false
 }

--- a/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/weather.cfn.json
+++ b/smithy-aws-cloudformation/src/test/resources/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/weather.cfn.json
@@ -82,7 +82,12 @@
         "tagProperty": "/properties/Tags",
         "tagUpdatable": true,
         "cloudFormationSystemTags": true,
-        "taggable": true
+        "taggable": true,
+        "permissions": [
+            "weather:ListTagsForCity",
+            "weather:TagCity",
+            "weather:UntagCity"
+        ]
     },
     "additionalProperties": false
 }

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/tagging/tagging-warnings.errors
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/tagging/tagging-warnings.errors
@@ -3,3 +3,4 @@
 [WARNING] example.weather#Weather: Service marked `aws.api#TagEnabled` is missing an operation named 'UntagResource.' | ServiceTagging
 [WARNING] example.weather#City: Suggested tag property name is '[T|t]ags'. | TagResourcePropertyName
 [DANGER] example.weather#UpdateCity: Update and put resource lifecycle operations should not support updating tags because it is a privileged operation that modifies access. | TaggableResource
+[WARNING] example.weather#Weather2: Service has resources with `aws.api#taggable` applied but does not have the `aws.api#tagEnabled` trait. | TaggableResource

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/tagging/tagging-warnings.smithy
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/tagging/tagging-warnings.smithy
@@ -19,6 +19,11 @@ service Weather {
     operations: [GetCurrentTime]
 }
 
+service Weather2 {
+    version: "2006-03-01",
+    resources: [City]
+}
+
 structure Tag {
     key: String
     value: String


### PR DESCRIPTION
This commit updates the CFN resource schema generation to fill in the
permissions field of the tagging configuration for resources. The AwsTagIndex
is used to find the APIs and their relevant required actions to invoke.

This also refactors the Tagging updates into a single Mapper so the updates
aren't strewn about the general CfnConverter.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
