### PR TITLE
Add config for inline JSON Schema maps

### DIFF
--- a/docs/source-2.0/guides/model-translations/converting-to-openapi.rst
+++ b/docs/source-2.0/guides/model-translations/converting-to-openapi.rst
@@ -804,6 +804,26 @@ mapStrategy (``string``)
             }
         }
 
+.. _generate-openapi-jsonschema-setting-useInlineMaps:
+
+useInlineMaps (``boolean``)
+    Configures Smithy to generate ``map`` shapes inline instead of as
+    references. This is necessary for some code generators to distinguish
+    between ``maps`` and ``structure`` shapes when generating.
+
+    .. code-block:: json
+        :caption: smithy-build.json
+
+        {
+            "version": "1.0",
+            "plugins": {
+                "openapi": {
+                    "service": "example.weather#Weather",
+                    "useInlineMaps": true
+                }
+            }
+        }
+
 .. _generate-openapi-jsonschema-setting-schemaDocumentExtensions:
 
 schemaDocumentExtensions (``Map<String, any>``)

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/DefaultRefStrategy.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/DefaultRefStrategy.java
@@ -148,6 +148,17 @@ final class DefaultRefStrategy implements RefStrategy {
             return true;
         }
 
+        // Maps are not inlined by default, but can be if configured.
+        // Maps are usually not a generated type in programming languages,
+        // but JSON schema represents them as "object" types which code
+        // generators may not distinguish from converted structures.
+        //
+        // Some code generators, however, will treat inline "object" types
+        // as maps and referenced ones as structures.
+        if (shape.isMapShape() && config.getUseInlineMaps()) {
+            return true;
+        }
+
         // Strings with the enum trait are never inlined. This helps to ensure
         // that the name of an enum string can be round-tripped from
         // Smithy -> JSON Schema -> Smithy, helps OpenAPI code generators to

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
@@ -115,6 +115,7 @@ public class JsonSchemaConfig {
     private boolean disableDefaultValues = false;
     private boolean disableIntEnums = false;
     private boolean addReferenceDescriptions = false;
+    private boolean useInlineMaps = false;
 
     public JsonSchemaConfig() {
         nodeMapper.setWhenMissingSetter(NodeMapper.WhenMissing.IGNORE);
@@ -478,5 +479,27 @@ public class JsonSchemaConfig {
      */
     public void setAddReferenceDescriptions(boolean addReferenceDescriptions) {
         this.addReferenceDescriptions = addReferenceDescriptions;
+    }
+
+    /**
+     * Whether to inline map shapes when creating JSON Schema object types
+     * from them.
+     *
+     * <p>Defaults to {@code false}.</p>
+     *
+     * @return Whether to inline map shapes in the resulting schema
+     */
+    public boolean getUseInlineMaps() {
+        return useInlineMaps;
+    }
+
+    /**
+     * Sets whether to inline map shapes when creating JSON schema object types
+     * from them.
+     *
+     * @param useInlineMaps Whether to inline map shapes in the resulting schema.
+     */
+    public void setUseInlineMaps(boolean useInlineMaps) {
+        this.useInlineMaps = useInlineMaps;
     }
 }


### PR DESCRIPTION
Resolves #2443 

This commit adds the `useInlineMaps` setting to allow users to configure JSON Schema conversion to inline converted `map` shapes instead of creating references.

This is distinct from the `mapStrategy` setting in that it's about the placement of the generated type and not how the type is generated. Combining the two would require two strategies for each type of map converted.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
