### PR TITLE
Infer defined condition key service

### DIFF
--- a/docs/source-2.0/aws/aws-iam.rst
+++ b/docs/source-2.0/aws/aws-iam.rst
@@ -402,10 +402,11 @@ Value type
     ``map`` of IAM identifiers to condition key ``structure``
 
 The ``aws.iam#defineConditionKeys`` trait defines additional condition keys
-that appear within a service. Keys in the map must be valid IAM identifiers,
-meaning they must adhere to the following regular expression:
-``"^([A-Za-z0-9][A-Za-z0-9-\\.]{0,62}:[^:]+)$"``.
-Each condition key structure supports the following members:
+that appear within a service. Keys in the map must be valid IAM identifiers
+or names of condition keys, meaning they must adhere to the following regular
+expression: ``"^(([A-Za-z0-9][A-Za-z0-9-\\.]{0,62}:)?[^:\\s]+)$"``. If only a
+condition key name is specified, the service is inferred to be the
+``arnNamespace``. Each condition key structure supports the following members:
 
 .. list-table::
     :header-rows: 1

--- a/smithy-aws-iam-traits/src/main/resources/META-INF/smithy/aws.iam.smithy
+++ b/smithy-aws-iam-traits/src/main/resources/META-INF/smithy/aws.iam.smithy
@@ -28,7 +28,7 @@ string conditionKeyValue
 /// inferred and global condition keys.
 @trait(selector: "service")
 map defineConditionKeys {
-    key: IamIdentifier
+    key: ConditionKeyName
     value: ConditionKeyDefinition
 }
 
@@ -155,6 +155,10 @@ list RequiredActionsList {
 list ResourceNameList {
     member: ResourceName
 }
+
+@private
+@pattern("^(([A-Za-z0-9][A-Za-z0-9-\\.]{0,62}:)?[^:\\s]+)$")
+string ConditionKeyName
 
 /// The IAM policy type of the value that will supplied for this context key
 @private

--- a/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/ConditionKeysIndexTest.java
+++ b/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/ConditionKeysIndexTest.java
@@ -40,9 +40,9 @@ public class ConditionKeysIndexTest {
 
         ConditionKeysIndex index = ConditionKeysIndex.of(model);
         assertThat(index.getConditionKeyNames(service), containsInAnyOrder(
-                "aws:accountId", "foo:baz", "myservice:Resource1Id1", "myservice:ResourceTwoId2"));
+                "aws:accountId", "foo:baz", "myservice:Resource1Id1", "myservice:ResourceTwoId2", "myservice:bar"));
         assertThat(index.getConditionKeyNames(service, ShapeId.from("smithy.example#Operation1")),
-                containsInAnyOrder("aws:accountId", "foo:baz"));
+                containsInAnyOrder("aws:accountId", "myservice:bar"));
         assertThat(index.getConditionKeyNames(service, ShapeId.from("smithy.example#Resource1")),
                 containsInAnyOrder("aws:accountId", "foo:baz", "myservice:Resource1Id1"));
         // Note that ID1 is not duplicated but rather reused on the child operation.

--- a/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/DefineConditionKeysTraitTest.java
+++ b/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/DefineConditionKeysTraitTest.java
@@ -32,7 +32,7 @@ public class DefineConditionKeysTraitTest {
         DefineConditionKeysTrait trait = shape.expectTrait(DefineConditionKeysTrait.class);
         assertEquals(3,trait.getConditionKeys().size());
         assertFalse(trait.getConditionKey("myservice:Bar").get().isRequired());
-        assertFalse(trait.getConditionKey("myservice:Foo").get().isRequired());
+        assertFalse(trait.getConditionKey("Foo").get().isRequired());
         assertTrue(trait.getConditionKey("myservice:Baz").get().isRequired());
     }
 }

--- a/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/define-condition-keys.smithy
+++ b/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/define-condition-keys.smithy
@@ -19,7 +19,7 @@ use aws.iam#serviceResolvedConditionKeys
         externalDocumentation: "http://baz.com"
         required: true
     }
-    "myservice:Foo": {
+    "Foo": {
         type: "String"
         documentation: "The Foo string"
         externalDocumentation: "http://foo.com"

--- a/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/successful-condition-keys.smithy
+++ b/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/successful-condition-keys.smithy
@@ -1,4 +1,4 @@
-$version: "1.0"
+$version: "2.0"
 namespace smithy.example
 
 use aws.api#arnReference
@@ -8,39 +8,44 @@ use aws.iam#defineConditionKeys
 use aws.iam#disableConditionKeyInference
 use aws.iam#iamResource
 
-@service(sdkId: "My")
+@service(sdkId: "My", arnNamespace: "myservice")
 @defineConditionKeys(
   "foo:baz": {
-    type: "String",
-    documentation: "Foo baz",
+    type: "String"
+    documentation: "Foo baz"
+    relativeDocumentation: "condition-keys.html"
+  }
+  "bar": {
+    type: "String"
+    documentation: "Foo bar"
     relativeDocumentation: "condition-keys.html"
   }
 )
 service MyService {
-  version: "2019-02-20",
-  operations: [Operation1],
+  version: "2019-02-20"
+  operations: [Operation1]
   resources: [Resource1]
 }
 
-@conditionKeys(["aws:accountId", "foo:baz"])
+@conditionKeys(["aws:accountId", "myservice:bar"])
 operation Operation1 {}
 
 @conditionKeys(["aws:accountId", "foo:baz"])
 resource Resource1 {
   identifiers: {
-    id1: ArnString,
-  },
+    id1: ArnString
+  }
   resources: [Resource2, Resource3, Resource4]
 }
 
 @iamResource(name: "ResourceTwo")
 resource Resource2 {
   identifiers: {
-    id1: ArnString,
-    id2: FooString,
-  },
-  read: GetResource2,
-  list: ListResource2,
+    id1: ArnString
+    id2: FooString
+  }
+  read: GetResource2
+  list: ListResource2
 }
 
 @disableConditionKeyInference
@@ -71,7 +76,7 @@ operation GetResource2 {
 
 structure GetResource2Input {
   @required
-  id1: ArnString,
+  id1: ArnString
 
   @required
   id2: FooString
@@ -82,13 +87,13 @@ string FooString
 
 @readonly
 operation ListResource2 {
-    input: ListResource2Input,
+    input: ListResource2Input
     output: ListResource2Output
 }
 
 structure ListResource2Input {
   @required
-  id1: ArnString,
+  id1: ArnString
 }
 
 structure ListResource2Output {}


### PR DESCRIPTION
This commit relaxes the pattern on the `@defineConditionKeys` trait's keys to enable inferring the `service` to be the service's `arnNamespace`.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
