### PR TITLE
Fix typo in event stream content-type

### DIFF
--- a/docs/source-2.0/guides/building-codegen/using-the-semantic-model.rst
+++ b/docs/source-2.0/guides/building-codegen/using-the-semantic-model.rst
@@ -284,7 +284,7 @@ the model and might rely on protocol-specific information.
     HttpBindingIndex index = HttpBindingIndex.of(model);
 
     String defaultPayloadType = "application/json";
-    String eventStreamType = "application/vnd.amazon.event-stream");
+    String eventStreamType = "application/vnd.amazon.eventstream");
     String contentType = index
         .determineRequestContentType(operation, defaultPayloadType, eventStreamType)
         .orElseNull();
@@ -302,7 +302,7 @@ the model and might rely on protocol-specific information.
    HttpBindingIndex index = HttpBindingIndex.of(model);
 
    String defaultPayloadType = "application/json";
-   String eventStreamType = "application/vnd.amazon.event-stream");
+   String eventStreamType = "application/vnd.amazon.eventstream");
    String contentType = index
        .determineResponseContentType(operation, defaultPayloadType, eventStreamType)
        .orElseNull();


### PR DESCRIPTION
Cleans up guide miss called out in #1287 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
