### PR TITLE
Add a tool to generate changelogs based on staged entries

### DIFF
--- a/.changes/amend
+++ b/.changes/amend
@@ -1,0 +1,70 @@
+#! /usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from argparse import ArgumentParser
+
+from tool.amend import amend
+
+
+def main() -> None:
+    parser = ArgumentParser(
+        description="""\
+            Amend recently-introduced changelog entries to include a pull request \
+            link. This is intended to be run in GitHub as an action, but can be run \
+            manually by specifying parameters GitHub would otherwise provide in \
+            environment variables.
+            
+            This only checks entries that have been staged in the current branch, \
+            using git to get a list of newly introduced files. If the entry already \
+            has one or more associated pull requests, it is not amended.""",
+    )
+    parser.add_argument(
+        "-n",
+        "--pull-request-number",
+        type=int,
+        help="""\
+            The numeric identifier for the pull request. This is provided by GitHub \
+            in the GITHUB_REF_NAME environment variable in the form \
+            '<pr_number>/merge'.""",
+    )
+    parser.add_argument(
+        "-r",
+        "--repository",
+        type=str,
+        help="""\
+            The name of the repository, defaulting to 'smithy-lang/smithy'. This is \
+            provided by GitHub in the GITHUB_REPOSITORY environment variable.""",
+    )
+    parser.add_argument(
+        "-b",
+        "--base",
+        type=str,
+        help="""\
+            The name of the base branch to diff against, defaulting to 'main'. This \
+            is provided by GitHub in the GITHUB_BASE_REF environment variable.""",
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        default=False,
+        help="""Commit any changes made.""",
+    )
+    parser.add_argument(
+        "--push",
+        action="store_true",
+        default=False,
+        help="""Commit and push any changes made.""",
+    )
+
+    args = parser.parse_args()
+    amend(
+        base=args.base,
+        repository=args.repository,
+        pr_number=args.pull_request_number,
+        commit=args.commit,
+        push=args.push,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.changes/new-change
+++ b/.changes/new-change
@@ -1,0 +1,39 @@
+#! /usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from argparse import ArgumentParser
+
+from tool import ChangeType
+from tool.new import new_change
+
+
+def main() -> None:
+    parser = ArgumentParser(
+        description="""\
+            Create a new changelog entry to be staged for the next release. Required \
+            values not provided on the command line will be prompted for.""",
+    )
+    parser.add_argument(
+        "-t",
+        "--type",
+        type=str,
+        choices=[t.name.lower() for t in ChangeType],
+        help="The type of change being logged.",
+    )
+    parser.add_argument(
+        "-d", "--description", type=str, help="A concise description of the change."
+    )
+    parser.add_argument(
+        "-p",
+        "--pull-requests",
+        type=str,
+        nargs="*",
+        help="The pull request that implements the change.",
+    )
+
+    args = parser.parse_args()
+    new_change(ChangeType[args.type.upper()], args.description, args.pull_requests)
+
+
+if __name__ == "__main__":
+    main()

--- a/.changes/next-release/documentation-b1f9dba71fb0e7538b4b526ba9a872489ce79be9.json
+++ b/.changes/next-release/documentation-b1f9dba71fb0e7538b4b526ba9a872489ce79be9.json
@@ -1,0 +1,4 @@
+{
+  "type": "ChangeType.DOCUMENTATION",
+  "description": "Added a tool to generate stageable, non-conflicting changelog entries and render a changelog based on staged entries."
+}

--- a/.changes/next-release/documentation-b1f9dba71fb0e7538b4b526ba9a872489ce79be9.json
+++ b/.changes/next-release/documentation-b1f9dba71fb0e7538b4b526ba9a872489ce79be9.json
@@ -1,4 +1,4 @@
 {
-  "type": "ChangeType.DOCUMENTATION",
+  "type": "documentation",
   "description": "Added a tool to generate stageable, non-conflicting changelog entries and render a changelog based on staged entries."
 }

--- a/.changes/render
+++ b/.changes/render
@@ -1,0 +1,49 @@
+#! /usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from argparse import ArgumentParser
+
+from tool.release import release
+from tool.render import render
+
+
+def main() -> None:
+    parser = ArgumentParser(
+        description="""\
+            Render the changelog as markdown, optionally including pending features \
+            as a new release.""",
+    )
+    release_group = parser.add_argument_group(
+        "release",
+        description="""\
+            These arguments allow for releasing all pending features in the \
+            next-release folder as a new release. If not set, the exisiting releases \
+            will be re-rendered.""",
+    )
+    release_group.add_argument(
+        "-v",
+        "--release-version",
+        type=str,
+        help="""\
+            The version to use for the staged changelog release. If set, all pending \
+            features will be compiled into a release.""",
+    )
+    release_group.add_argument(
+        "-d",
+        "--release-date",
+        type=str,
+        help="""\
+            The date of the release in ISO format (e.g. 2024-11-13). If not set, \
+            today's date, according to your local time zone, will be used.""",
+    )
+
+    args = parser.parse_args()
+
+    if args.release_version:
+        release(args.release_version, args.release_date)
+
+    render()
+
+
+if __name__ == "__main__":
+    main()

--- a/.changes/tool/__init__.py
+++ b/.changes/tool/__init__.py
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from enum import Enum
+from typing import TypedDict, Required, NotRequired
+
+
+class ChangeType(Enum):
+    FEATURE = "Features"
+    BUGFIX = "Bug Fixes"
+    DOCUMENTATION = "Documentation"
+    BREAK = "Breaking Changes"
+    OTHER = "Other"
+
+
+class Change(TypedDict):
+    type: Required[ChangeType]
+    description: Required[str]
+    pull_requests: NotRequired[list[str]]
+
+
+class Release(TypedDict):
+    version: Required[str]
+    date: Required[str]
+    changes: Required[list[Change]]

--- a/.changes/tool/__init__.py
+++ b/.changes/tool/__init__.py
@@ -2,6 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 from enum import Enum
 from typing import TypedDict, Required, NotRequired
+from pathlib import Path
+
+
+CHANGES_DIR = Path(__file__).absolute().parent.parent
+NEXT_RELEASE_DIR = CHANGES_DIR / "next-release"
+RELEASES_DIR = CHANGES_DIR / "releases"
 
 
 class ChangeType(Enum):

--- a/.changes/tool/__init__.py
+++ b/.changes/tool/__init__.py
@@ -1,9 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+import datetime
+from dataclasses import dataclass, field
 from enum import Enum
-from typing import TypedDict, Required, NotRequired
 from pathlib import Path
-
+from typing import Any, Self
 
 CHANGES_DIR = Path(__file__).absolute().parent.parent
 NEXT_RELEASE_DIR = CHANGES_DIR / "next-release"
@@ -17,14 +18,50 @@ class ChangeType(Enum):
     BREAK = "Breaking Changes"
     OTHER = "Other"
 
-
-class Change(TypedDict):
-    type: Required[ChangeType]
-    description: Required[str]
-    pull_requests: NotRequired[list[str]]
+    def __str__(self) -> str:
+        return self.name.lower()
 
 
-class Release(TypedDict):
-    version: Required[str]
-    date: Required[str]
-    changes: Required[list[Change]]
+@dataclass
+class Change:
+    type: ChangeType
+    description: str
+    pull_requests: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> Self:
+        return cls(
+            type=ChangeType[data["type"].upper()],
+            description=data["description"],
+            pull_requests=data.get("pull_requests") or [],
+        )
+
+
+def _today() -> str:
+    return datetime.date.today().isoformat()
+
+
+@dataclass
+class Release:
+    version: str
+    changes: list[Change]
+    date: str = field(default_factory=_today)
+
+    def change_map(self) -> dict[ChangeType, list[Change]]:
+        result: dict[ChangeType, list[Change]] = {}
+        for change in self.changes:
+            if change.type not in result:
+                result[change.type] = []
+            result[change.type].append(change)
+        return result
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> Self:
+        return cls(
+            version=data["version"],
+            changes=[Change.from_json(c) for c in data["changes"]],
+            date=data["date"],
+        )
+
+    def __lt__(self, other: Self) -> bool:
+        return self.date < other.date

--- a/.changes/tool/amend.py
+++ b/.changes/tool/amend.py
@@ -1,0 +1,80 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import json
+import os
+import subprocess
+from dataclasses import asdict
+from pathlib import Path
+
+from . import CHANGES_DIR, Change
+
+REPO_ROOT = CHANGES_DIR.parent
+
+
+def amend(
+    *,
+    pr_number: str | None = None,
+    repository: str | None = None,
+    base: str | None = None,
+    commit: bool = False,
+    push: bool = False,
+) -> None:
+    commit = commit or push
+    pr_ref = get_pr_ref(pr_number=pr_number, repository=repository)
+
+    amended_files = False
+    for change_file, change in get_new_changes(base).items():
+        if not change.pull_requests:
+            change.pull_requests = [pr_ref]
+            change_file.write_text(
+                json.dumps(asdict(change), indent=2, default=str) + "\n"
+            )
+
+            amended_files = True
+            if commit:
+                subprocess.run(f"git add {change_file}", check=True, shell=True)
+
+    if commit and amended_files:
+        subprocess.run(
+            f'git commit -m "Add PR link to changelog for #{pr_number}"',
+            check=True,
+            shell=True,
+        )
+
+        if push:
+            subprocess.run(f"git push", check=True, shell=True)
+
+
+def get_pr_ref(pr_number: str | None, repository: str | None):
+    repository = repository or os.environ.get("GITHUB_REPOSITORY", "smithy-lang/smithy")
+
+    if not pr_number:
+        pr_number = os.environ.get("GITHUB_REF_NAME")
+        if pr_number is None:
+            raise ValueError(
+                """\
+                The pr number to amend onto entries MUST be set. This can be done as \
+                an argument to the command, or via the GITHUB_REF_NAME environment \
+                varaible as set by GitHub actions."""
+            )
+
+        # The GitHub environment variable is in the form "<pr_number>/merge", but
+        # we only want the pr number.
+        pr_number = pr_number.split("/")[0]
+
+    base_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    return f"[#{pr_number}]({base_url}/{repository}/pull/{pr_number})"
+
+
+def get_new_changes(base: str | None) -> dict[Path, Change]:
+    base = base or os.environ.get("GITHUB_HEAD_REF", "main")
+    result = subprocess.run(
+        f"git diff {base} --name-only", check=True, shell=True, capture_output=True
+    )
+    new_changes: dict[Path, Change] = {}
+    for changed_file in result.stdout.decode("utf-8").splitlines():
+        stripped = changed_file.strip()
+        if stripped.startswith(".changes/next-release") and stripped.endswith(".json"):
+            file = REPO_ROOT / stripped
+            new_changes[file] = Change.from_json(json.loads(file.read_text()))
+    return new_changes

--- a/.changes/tool/new.py
+++ b/.changes/tool/new.py
@@ -2,20 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 import tempfile
 import string
-from pathlib import Path
 import os
 import subprocess
 import re
 import hashlib
 import json
 
-from . import ChangeType, Change
+from . import ChangeType, Change, NEXT_RELEASE_DIR
 
 
 VALID_CHARS = set(string.ascii_letters + string.digits)
-CURRENT_DIR = Path(__file__).absolute()
-CHANGES_DIR = CURRENT_DIR.parent.parent
-NEXT_RELEASE_DIR = CHANGES_DIR / "next-release"
 TEMPLATE = """\
 # Type should be one of: "feature", "bugfix", "documentation", "break", or "other".
 #

--- a/.changes/tool/new.py
+++ b/.changes/tool/new.py
@@ -1,0 +1,139 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import tempfile
+import string
+from pathlib import Path
+import os
+import subprocess
+import re
+import hashlib
+import json
+
+from . import ChangeType, Change
+
+
+VALID_CHARS = set(string.ascii_letters + string.digits)
+CURRENT_DIR = Path(__file__).absolute()
+CHANGES_DIR = CURRENT_DIR.parent.parent
+NEXT_RELEASE_DIR = CHANGES_DIR / "next-release"
+TEMPLATE = """\
+# Type should be one of: "feature", "bugfix", "documentation", "break", or "other".
+#
+# feature:       A larger feature or change in behavior, usually resulting in a
+#                minor version bump.
+# bugfix:        Fixing a bug in an existing code path.
+# documentation: A documentation-only change.
+# break:         A breaking change, be it a break-fix or a breaking feature change.
+# other:         Any change that does not fit into another category.
+type: {change_type}
+
+# (Optional)
+# A link to the GitHub pull request that implments the feature. You can use GitHub
+# sytle references, which will automatically be replaced with the correct link.
+pull request: {pull_requests}
+
+# A brief description of the change. You can use GitHub style references to issues such
+# as "fixes #489", "boto/boto3#100", etc. These will get automatically replaced with
+# the correct link.
+description: {description}
+"""
+
+
+def new_change(
+    change_type: ChangeType | None,
+    description: str | None,
+    pull_requests: list[str] | None,
+):
+    if change_type is not None and description is not None:
+        change: Change = {"type": change_type, "description": description}
+        if pull_requests:
+            change["pull_requests"] = pull_requests
+    else:
+        parsed = get_values_from_editor(change_type, description, pull_requests)
+        if not parsed:
+            return
+        change = parsed
+
+    write_new_change(change)
+
+
+def get_values_from_editor(
+    change_type: ChangeType | None,
+    description: str | None,
+    pull_requests: list[str] | None,
+) -> Change | None:
+    with tempfile.NamedTemporaryFile("w") as f:
+        prs = pull_requests or []
+        contents = TEMPLATE.format(
+            change_type=change_type.name.lower() if change_type is not None else "",
+            description=description or "",
+            pull_requests=", ".join(prs),
+        )
+        f.write(contents)
+        f.flush()
+
+        env = os.environ
+        editor = env.get("VISUAL", env.get("EDITOR", "vim"))
+        p = subprocess.Popen(f"{editor} {f.name}", shell=True)
+        p.communicate()
+
+        with open(f.name) as f:
+            return parse_filled_in_contents(f.read())
+
+
+def replace_issue_references(change: Change, repo_name: str):
+    description = change["description"]
+
+    def linkify(match: re.Match[str]):
+        number = match.group()[1:]
+        return f"[{match.group()}](https://github.com/{repo_name}/issues/{number})"
+
+    new_description = re.sub(r"#\d+", linkify, description)
+    change["description"] = new_description
+
+    if "pull_requests" in change:
+        change["pull_requests"] = [
+            re.sub(r"#\d+", linkify, pr) for pr in change["pull_requests"]
+        ]
+
+
+def write_new_change(change: Change):
+    if not NEXT_RELEASE_DIR.is_dir():
+        os.makedirs(NEXT_RELEASE_DIR)
+
+    contents = json.dumps(change, indent=2, default=str) + "\n"
+    contents_digest = hashlib.sha1(contents.encode("utf-8")).hexdigest()
+    filename = f"{change['type'].name.lower()}-{contents_digest}.json"
+
+    with open(NEXT_RELEASE_DIR / filename, "w") as f:
+        f.write(contents)
+
+
+def parse_filled_in_contents(contents: str) -> Change | None:
+    """Parse filled in file contents and returns parsed dict."""
+    if not contents.strip():
+        return
+
+    parsed = {}
+    lines = iter(contents.splitlines())
+    for line in lines:
+        line = line.strip()
+        if line.startswith("#"):
+            continue
+
+        if "type" not in parsed and line.startswith("type:"):
+            parsed["type"] = ChangeType[line.split(":")[1].strip().upper()]
+        if "pull_requests" not in parsed and line.startswith("pull requests:"):
+            parsed["pull_requests"] = [
+                pr.strip() for pr in line.split(":")[1].strip().split(",")
+            ]
+        elif "description" not in parsed and line.startswith("description:"):
+            # Assume that everything until the end of the file is part
+            # of the description, so we can break once we pull in the
+            # remaining lines.
+            first_line = line.split(":")[1].strip()
+            full_description = "\n".join([first_line] + list(lines))
+            parsed["description"] = full_description.strip()
+            break
+
+    return Change(parsed)  # type: ignore

--- a/.changes/tool/release.py
+++ b/.changes/tool/release.py
@@ -1,0 +1,28 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import json
+from datetime import date
+import os
+
+from . import NEXT_RELEASE_DIR, Change, Release, RELEASES_DIR
+
+
+def release(version: str, release_date: str | None) -> None:
+    release_date = release_date or date.today().isoformat()
+    entries: list[Change] = []
+    for entry in NEXT_RELEASE_DIR.glob("*.json"):
+        entries.append(Change(json.loads(entry.read_text())))
+        entry.unlink()
+
+    if not entries:
+        raise ValueError(
+            "To conduct a release, there must be at least one changelog entry."
+        )
+
+    result: Release = {"version": version, "date": release_date, "changes": entries}
+
+    if not RELEASES_DIR.is_dir():
+        os.makedirs(RELEASES_DIR)
+
+    release_file = RELEASES_DIR / f"{version}.json"
+    release_file.write_text(json.dumps(result, indent=2, default=str) + "\n")

--- a/.changes/tool/release.py
+++ b/.changes/tool/release.py
@@ -1,17 +1,18 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import json
-from datetime import date
 import os
+from dataclasses import asdict
+from datetime import date
 
-from . import NEXT_RELEASE_DIR, Change, Release, RELEASES_DIR
+from . import NEXT_RELEASE_DIR, RELEASES_DIR, Change, Release
 
 
 def release(version: str, release_date: str | None) -> None:
     release_date = release_date or date.today().isoformat()
     entries: list[Change] = []
     for entry in NEXT_RELEASE_DIR.glob("*.json"):
-        entries.append(Change(json.loads(entry.read_text())))
+        entries.append(Change.from_json(json.loads(entry.read_text())))
         entry.unlink()
 
     if not entries:
@@ -19,10 +20,10 @@ def release(version: str, release_date: str | None) -> None:
             "To conduct a release, there must be at least one changelog entry."
         )
 
-    result: Release = {"version": version, "date": release_date, "changes": entries}
+    result = Release(version=version, date=release_date, changes=entries)
 
     if not RELEASES_DIR.is_dir():
         os.makedirs(RELEASES_DIR)
 
     release_file = RELEASES_DIR / f"{version}.json"
-    release_file.write_text(json.dumps(result, indent=2, default=str) + "\n")
+    release_file.write_text(json.dumps(asdict(result), indent=2, default=str) + "\n")

--- a/.changes/tool/render.py
+++ b/.changes/tool/render.py
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from . import RELEASES_DIR, Release, ChangeType, Change
+import json
+
+TITLE = "Smithy Changelog"
+
+
+def render() -> None:
+    rendered = f"# {TITLE}\n\n"
+    for release in get_releases():
+        rendered += f"## {release['version']} ({release['date']})\n\n"
+        entries = collect_entries(release)
+
+        for change_type, changes in entries.items():
+            rendered += f"### {change_type.value}\n\n"
+
+            for change in changes:
+                rendered += render_change(change)
+
+    print(rendered)
+
+
+def render_change(change: Change) -> str:
+    rendered = f"* {change['description']}"
+    if prs := change.get("pull_requests"):
+        rendered += f"({', '.join(prs)})"
+    return rendered
+
+
+def collect_entries(release: Release) -> dict[ChangeType, list[Change]]:
+    result: dict[ChangeType, list[Change]] = {}
+    for change in release["changes"]:
+        if change["type"] not in result:
+            result[change["type"]] = []
+        result[change["type"]].append(change)
+    return result
+
+
+def get_releases() -> list[Release]:
+    releases: list[Release] = []
+    for release_file in RELEASES_DIR.glob("*.json"):
+        releases.append(json.loads(release_file.read_text()))
+    return sorted(releases, key=lambda r: r["date"])

--- a/.github/workflows/amend-changelog.yml
+++ b/.github/workflows/amend-changelog.yml
@@ -1,0 +1,24 @@
+name: amend-changelog
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+    amend:
+        name: "Add PR links to staged changelogs"
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                ref: ${{ github.head_ref }}
+            - uses: actions/setup-python@v5
+              with:
+                python-version: "3.13"
+
+            - name: "Amend and push any staged changelogs"
+              run: |
+                git config user.name "github-actions[bot]"
+                git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                ./.changes/amend --push


### PR DESCRIPTION
This adds a tool that generates changelogs based on staged entries. I had intended to make this pr to my own fork, so hold tight.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
