### PR TITLE
Expand usage of title trait

### DIFF
--- a/docs/source-2.0/spec/documentation-traits.rst
+++ b/docs/source-2.0/spec/documentation-traits.rst
@@ -388,9 +388,9 @@ tags trait are arbitrary and up to the model author.
 Summary
     Defines a proper name for a service or resource shape. This title can be
     used in automatically generated documentation and other contexts to
-    provide a user friendly name for services and resources.
+    provide a user friendly name for a shape.
 Trait selector
-    ``:is(service, resource)``
+    ``:not(member)``
 
     *Any service or resource*
 Value type

--- a/smithy-jsonschema/src/test/java/software/amazon/smithy/jsonschema/JsonSchemaConverterTest.java
+++ b/smithy-jsonschema/src/test/java/software/amazon/smithy/jsonschema/JsonSchemaConverterTest.java
@@ -962,4 +962,20 @@ public class JsonSchemaConverterTest {
                 IoUtils.toUtf8String(getClass().getResourceAsStream("member-documentation.jsonschema.json")));
         Node.assertEquals(document.toNode(), expected);
     }
+
+    @Test
+    public void appliesTitlesCorrectly() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("title-added.smithy"))
+                .assemble()
+                .unwrap();
+        SchemaDocument document = JsonSchemaConverter.builder()
+                .model(model)
+                .build()
+                .convert();
+
+        Node expected = Node.parse(
+                IoUtils.toUtf8String(getClass().getResourceAsStream("title-added.jsonschema.v07.json")));
+        Node.assertEquals(document.toNode(), expected);
+    }
 }

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/title-added.jsonschema.v07.json
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/title-added.jsonschema.v07.json
@@ -1,0 +1,44 @@
+{
+    "definitions": {
+        "Foo": {
+            "type": "object",
+            "properties": {
+                "bam": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "A list of strings",
+                    "default": []
+                },
+                "bar": {
+                    "type": "number",
+                    "default": 0
+                },
+                "bat": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/TestEnum"
+                        },
+                        {
+                            "default": "FOO"
+                        }
+                    ]
+                },
+                "baz": {
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "title": "A structure"
+        },
+        "TestEnum": {
+            "type": "string",
+            "enum": [
+                "FOO",
+                "BAR"
+            ],
+            "title": "A Test Enum!"
+        }
+    }
+}

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/title-added.smithy
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/title-added.smithy
@@ -1,0 +1,22 @@
+$version: "2.0"
+
+namespace smithy.example
+
+@title("A structure")
+structure Foo {
+    bar: Integer = 0
+    baz: String = ""
+    bam: StringList = [],
+    bat: TestEnum = "FOO"
+}
+
+@title("A list of strings")
+list StringList {
+    member: String
+}
+
+@title("A Test Enum!")
+enum TestEnum {
+    FOO
+    BAR
+}

--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -668,9 +668,8 @@ list tags {
 /// Defines a proper name for a service or resource shape.
 ///
 /// This title can be used in automatically generated documentation
-/// and other contexts to provide a user friendly name for services
-/// and resources.
-@trait(selector: ":is(service, resource)")
+/// and other contexts to provide a user friendly for shapes.
+@trait(selector: ":not(member)")
 string title
 
 /// Constrains the acceptable values of a string to a fixed set


### PR DESCRIPTION
Closes: #2406

### Description 
Expands the selector of the title trait to allow it to be applied to any non-member shape. 

The title trait provides a simple name or description that can be used when referencing the shape from another context.

In a code generator this can be used to provide helpful documentation For example you could use the title trait on the following error:
```smithy
@title("Indicates a failed doodad.") 
@error("client")
structure OopsieDaisyError {...}
```

Which could then referenced in a generated operation (notional java): 
```java
/**
  * My Cool operation that does stuff.
  * 
  * @throws OopsieDaisyError - Indicates a failed doodad.
  */
  public MyOuput myOperation(MyInput input) {...}
```
Notice how the title trait provides the user-friendly description to use in the operation context


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
