### PR TITLE
Add a tool to create and render stageable changelog entries

### DIFF
--- a/.changes/README.md
+++ b/.changes/README.md
@@ -1,0 +1,50 @@
+# Changelog Tool
+
+This directory contains the changelog tool that is used to generate the changelog
+from a set of entry files that can be added to pull requests without risking
+merge conflicts.
+
+## Usage
+
+### When Writing a Pull Request
+
+Before submitting a pull request, run the `new-change` script. If called
+without arguments, it will prompt for all the information it needs. It will
+then store that information in a file in the `next-release` directory that you
+must commit.
+
+The tool will ask for an optional pull request number. If you haven't opened a
+pull request yet, this is fine. Simply do not fill in that line, and when you
+do open a pull request a bot will automatically add a pull request comment with
+a change suggestion that adds it.
+
+To get details about optional arguments to the command, run `new-change -h`.
+
+### When Releasing Smithy
+
+Before performing a release, ensure that every pull request since the last
+release has an associated changelog entry. If any entries are missing, use
+the `new-change` tool as described above to add them in.
+
+You may optionally edit or combine the entries as is necessary. If you combine
+entries, ensure that the combined entry contains all of the relevant pr links.
+
+Once the entries have been verified, use the `render` tool to combine the
+staged entries and generate the changelog file. From the root of the Smithy
+repository, run the following with the version being released:
+
+```sh
+> ./.changes/render --release-version RELEASE_VERSION > CHANGELOG.md
+```
+
+If the `VERSION` file has already been updated, this can be simplified:
+
+```sh
+> ./.changes/render --release-version "$(cat VERSION)" > CHANGELOG.md
+```
+
+Then commit the changelog and the `.changes` directory:
+
+```sh
+> git add CHANGELOG.md .changes
+```

--- a/.changes/amend
+++ b/.changes/amend
@@ -1,0 +1,61 @@
+#! /usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from argparse import ArgumentParser
+
+from tool.amend import amend
+
+
+def main() -> None:
+    parser = ArgumentParser(
+        description="""\
+            Amend recently-introduced changelog entries to include a pull request \
+            link. This is intended to be run in GitHub as an action, but can be run \
+            manually by specifying parameters GitHub would otherwise provide in \
+            environment variables.
+            
+            This only checks entries that have been staged in the current branch, \
+            using git to get a list of newly introduced files. If the entry already \
+            has one or more associated pull requests, it is not amended.""",
+    )
+    parser.add_argument(
+        "-n",
+        "--pull-request-number",
+        required=True,
+        help="The numeric identifier for the pull request.",
+    )
+    parser.add_argument(
+        "-r",
+        "--repository",
+        help="""\
+            The name of the repository, defaulting to 'smithy-lang/smithy'. This is \
+            provided by GitHub in the GITHUB_REPOSITORY environment variable.""",
+    )
+    parser.add_argument(
+        "-b",
+        "--base",
+        help="""\
+            The name of the base branch to diff against, defaulting to 'main'. This \
+            is provided by GitHub in the GITHUB_BASE_REF environment variable.""",
+    )
+    parser.add_argument(
+        "-c",
+        "--review-comment",
+        action="store_true",
+        default=False,
+        help="""\
+            Instead of amending the local files on disk, post a review comment on the \
+            PR. This will also post a normal comment if no changelog entry is found.""",
+    )
+
+    args = parser.parse_args()
+    amend(
+        base=args.base,
+        repository=args.repository,
+        pr_number=args.pull_request_number,
+        review_comment=args.review_comment,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.changes/new-change
+++ b/.changes/new-change
@@ -1,0 +1,47 @@
+#! /usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from argparse import ArgumentParser
+
+from tool import ChangeType
+from tool.new import new_change
+
+
+def main() -> None:
+    parser = ArgumentParser(
+        description="""\
+            Create a new changelog entry to be staged for the next release. Required \
+            values not provided on the command line will be prompted for.""",
+    )
+    parser.add_argument(
+        "-t",
+        "--type",
+        choices=[t.name.lower() for t in ChangeType],
+        help="The type of change being logged.",
+    )
+    parser.add_argument(
+        "-d", "--description", type=str, help="A concise description of the change."
+    )
+    parser.add_argument(
+        "-p",
+        "--pull-requests",
+        nargs="+",
+        help="The pull request that implements the change.",
+    )
+    parser.add_argument(
+        "-r",
+        "--repository",
+        help="The name of the repository, defaulting to 'smithy-lang/smithy'.",
+    )
+
+    args = parser.parse_args()
+    new_change(
+        change_type=ChangeType[args.type.upper()],
+        description=args.description,
+        pull_requests=args.pull_requests,
+        repository=args.repository,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.changes/next-release/documentation-7da019874732a62550914aa13b543b6e4de60a6e.json
+++ b/.changes/next-release/documentation-7da019874732a62550914aa13b543b6e4de60a6e.json
@@ -1,0 +1,7 @@
+{
+  "type": "documentation",
+  "description": "Added a tool to generate stageable, non-conflicting changelog entries and render a changelog based on staged entries.",
+  "pull_requests": [
+    "[#2462](https://github.com/smithy-lang/smithy/issues/2462)"
+  ]
+}

--- a/.changes/render
+++ b/.changes/render
@@ -1,0 +1,49 @@
+#! /usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from argparse import ArgumentParser
+
+from tool.release import release
+from tool.render import render
+
+
+def main() -> None:
+    parser = ArgumentParser(
+        description="""\
+            Render the changelog as markdown, optionally including pending features \
+            as a new release.""",
+    )
+    release_group = parser.add_argument_group(
+        "release",
+        description="""\
+            These arguments allow for releasing all pending features in the \
+            next-release folder as a new release. If not set, the exisiting releases \
+            will be re-rendered.""",
+    )
+    release_group.add_argument(
+        "-v",
+        "--release-version",
+        type=str,
+        help="""\
+            The version to use for the staged changelog release. If set, all pending \
+            features will be compiled into a release.""",
+    )
+    release_group.add_argument(
+        "-d",
+        "--release-date",
+        type=str,
+        help="""\
+            The date of the release in ISO format (e.g. 2024-11-13). If not set, \
+            today's date, according to your local time zone, will be used.""",
+    )
+
+    args = parser.parse_args()
+
+    if args.release_version:
+        release(args.release_version, args.release_date)
+
+    render()
+
+
+if __name__ == "__main__":
+    main()

--- a/.changes/tool/__init__.py
+++ b/.changes/tool/__init__.py
@@ -1,0 +1,96 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import datetime
+import json
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Self
+
+CHANGES_DIR = Path(__file__).absolute().parent.parent
+NEXT_RELEASE_DIR = CHANGES_DIR / "next-release"
+RELEASES_DIR = CHANGES_DIR / "releases"
+REPO_ROOT = CHANGES_DIR.parent
+
+
+class ChangeType(Enum):
+    FEATURE = "Features", 1
+    BUGFIX = "Bug Fixes", 2
+    DOCUMENTATION = "Documentation", 3
+    BREAK = "Breaking Changes", 0
+    OTHER = "Other", 4
+
+    def __init__(self, section_title: str, order: int) -> None:
+        self.section_title = section_title
+        self.order = order
+
+    def __str__(self) -> str:
+        return self.name.lower()
+
+    def __lt__(self, other: Self) -> bool:
+        return self.order < other.order
+
+
+@dataclass
+class Change:
+    type: ChangeType
+    description: str
+    pull_requests: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> Self:
+        return cls(
+            type=ChangeType[data["type"].upper()],
+            description=data["description"],
+            pull_requests=data.get("pull_requests") or [],
+        )
+
+    @classmethod
+    def read(cls, file: Path) -> Self:
+        return cls.from_json(json.loads(file.read_text()))
+
+    def write(self, file: Path | None = None) -> str:
+        contents = json.dumps(asdict(self), indent=2, default=str) + "\n"
+        if file is not None:
+            file.write_text(contents)
+        return contents
+
+
+def _today() -> str:
+    return datetime.date.today().isoformat()
+
+
+@dataclass
+class Release:
+    version: str
+    changes: list[Change]
+    date: str = field(default_factory=_today)
+
+    def change_map(self) -> dict[ChangeType, list[Change]]:
+        result: dict[ChangeType, list[Change]] = {}
+        for change in self.changes:
+            if change.type not in result:
+                result[change.type] = []
+            result[change.type].append(change)
+        return dict(sorted(result.items()))
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> Self:
+        return cls(
+            version=data["version"],
+            changes=[Change.from_json(c) for c in data["changes"]],
+            date=data["date"],
+        )
+
+    @classmethod
+    def read(cls, file: Path) -> Self:
+        return cls.from_json(json.loads(file.read_text()))
+
+    def write(self, file: Path | None = None) -> str:
+        contents = json.dumps(asdict(self), indent=2, default=str) + "\n"
+        if file is not None:
+            file.write_text(contents)
+        return contents
+
+    def __lt__(self, other: Self) -> bool:
+        return self.date < other.date

--- a/.changes/tool/amend.py
+++ b/.changes/tool/amend.py
@@ -1,0 +1,89 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import os
+import subprocess
+from pathlib import Path
+
+from . import REPO_ROOT, Change
+from .github import post_comment, post_review_comment
+
+DEFAULT_REPO = "smithy-lang/smithy"
+GITHUB_URL = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+
+
+def amend(
+    *,
+    pr_number: str,
+    repository: str | None = None,
+    base: str | None = None,
+    review_comment: bool = False,
+) -> None:
+    repository = repository or os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPO)
+    pr_ref = f"[#{pr_number}]({GITHUB_URL}/{repository}/pull/{pr_number})"
+
+    changes = get_new_changes(base)
+    if not changes and review_comment:
+        print("No changelog found, adding reminder comment.")
+        description = os.environ.get("PR_TITLE", "Example description").replace(
+            '"', '\\"'
+        )
+        comment = (
+            "This pull request does not contain a staged changelog entry. To create "
+            "one, use the `./.changes/new-change` command. For example:\n\n"
+            f'```\n./.changes/new-change --pull-requests "#{pr_number}" '
+            f'--type feature --description "{description}"\n```\n\n'
+            "Make sure that the description is appropriate for a changelog entry and "
+            "that the proper feature type is used. See [`./.changes/README`]("
+            f"{GITHUB_URL}/{repository}/tree/main/.changes/README) or run "
+            "`./.changes/new-change -h` for more information."
+        )
+        post_comment(
+            repository=repository,
+            pr_number=pr_number,
+            comment=comment,
+        )
+
+    for change_file, change in changes.items():
+        if not change.pull_requests:
+            print(f"Amending changelog entry without associated prs: {change_file}")
+            change.pull_requests = [pr_ref]
+
+            if review_comment:
+                print("Posting amended change as a review comment.")
+                comment = (
+                    "Staged changelog entries should have an associated pull request "
+                    "set. Commit this suggestion to associate this changelog entry "
+                    "with this PR.\n\n"
+                    f"```suggestion\n{change.write().strip()}\n```"
+                )
+                post_review_comment(
+                    repository=repository,
+                    pr_number=pr_number,
+                    comment=comment,
+                    file=change_file,
+                    start_line=1,
+                    end_line=len(change_file.read_text().splitlines()),
+                )
+            else:
+                print("Writing amended change to disk.")
+                change.write(change_file)
+
+
+def get_new_changes(base: str | None) -> dict[Path, Change]:
+    base = base or os.environ.get("GITHUB_BASE_REF", "main")
+    print(f"Running a diff against base branch: {base}")
+    result = subprocess.run(
+        f"git diff origin/{base} --name-only",
+        check=True,
+        shell=True,
+        capture_output=True,
+    )
+
+    new_changes: dict[Path, Change] = {}
+    for changed_file in result.stdout.decode("utf-8").splitlines():
+        stripped = changed_file.strip()
+        if stripped.startswith(".changes/next-release") and stripped.endswith(".json"):
+            file = REPO_ROOT / stripped
+            print(f"Discovered newly staged changelog entry: {file}")
+            new_changes[file] = Change.read(file)
+    return new_changes

--- a/.changes/tool/github.py
+++ b/.changes/tool/github.py
@@ -1,0 +1,221 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This module provides functions to interact with the GitHub API. No sort of
+# official client is used so that dependencies can be avoided. The standard
+# library's http modules are used instead of Requests for the same reason.
+import json
+import os
+import re
+import time
+from dataclasses import dataclass
+from http.client import HTTPResponse
+from pathlib import Path
+from typing import Generator, Literal, NotRequired, Required, Self, TypedDict
+from urllib import request
+from urllib.error import HTTPError
+
+from . import REPO_ROOT
+
+GITHUB_API_URL = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
+NEXT_PAGE = re.compile(r'(?<=<)([\S]*)(?=>; rel="next")', flags=re.IGNORECASE)
+
+type JSON = str | int | bool | None | list[JSON] | dict[str, JSON]
+
+
+def post_review_comment(
+    repository: str,
+    pr_number: str,
+    comment: str,
+    file: Path,
+    start_line: int | None = None,
+    end_line: int | None = None,
+    allow_duplicate: bool = False,
+) -> None:
+    commit_sha = os.environ.get("TARGET_SHA")
+    if not commit_sha:
+        raise ValueError(
+            "The TARGET_SHA environment variable must be set to post review comments."
+        )
+
+    path = str(file.relative_to(REPO_ROOT))
+
+    if not allow_duplicate:
+        for existing_comment in get_review_comments(repository, pr_number):
+            if existing_comment["path"] == path and existing_comment["body"] == comment:
+                print("Review comment already posted, skipping duplicate.")
+                return
+
+    request_body: CreateReviewCommentParams = {
+        "body": comment,
+        "commit_id": commit_sha,
+        "path": path,
+    }
+
+    if start_line is not None:
+        request_body["side"] = "RIGHT"
+        if end_line is not None:
+            request_body["start_side"] = "RIGHT"
+            request_body["start_line"] = start_line
+            request_body["line"] = end_line
+        else:
+            request_body["line"] = start_line
+    elif end_line is not None:
+        raise ValueError("If end_line is set, start_line must also be set.")
+
+    resolved_url = f"{GITHUB_API_URL}/repos/{repository}/pulls/{pr_number}/comments"
+    _request(
+        resolved_url,
+        # mypy is too dumb to realize a typeddict is a dict
+        request_body,  # type: ignore
+    )
+
+
+type ReviewSide = Literal["LEFT"] | Literal["RIGHT"]
+
+
+# https://docs.github.com/en/rest/pulls/comments?apiVersion=2022-11-28#create-a-review-comment-for-a-pull-request
+class CreateReviewCommentParams(TypedDict):
+    body: Required[str]
+    commit_id: Required[str]
+    path: Required[str]
+    start_line: NotRequired[int]
+    line: NotRequired[int]
+    start_side: NotRequired[ReviewSide]
+    side: NotRequired[ReviewSide]
+    subject_type: NotRequired[Literal["line"] | Literal["file"]]
+
+
+class User(TypedDict):
+    login: Required[str]
+
+
+class Comment(TypedDict):
+    user: Required[User]
+    body: str
+
+
+class ReviewComment(Comment):
+    path: Required[str]
+
+
+# https://docs.github.com/en/rest/pulls/comments?apiVersion=2022-11-28#list-review-comments-on-a-pull-request
+def get_review_comments(
+    repository: str,
+    pr_number: str,
+) -> Generator[ReviewComment]:
+    url = f"{GITHUB_API_URL}/repos/{repository}/pulls/{pr_number}/comments?per_page=100"
+    for response in _paginate(url):
+        if not isinstance(response.body, list):
+            raise ValueError(
+                f"Expected list body, but found {type(response.body)}: {response.body}"
+            )
+        for comment in response.body:
+            yield comment  # type: ignore
+
+
+# https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#create-an-issue-comment
+def post_comment(
+    repository: str,
+    pr_number: str,
+    comment: str,
+    allow_duplicate: bool = False,
+) -> None:
+    if not allow_duplicate:
+        for existing_comment in get_comments(repository, pr_number):
+            if existing_comment["body"] == comment:
+                print("Comment already posted, skipping duplicate.")
+                return
+
+    _request(
+        url=f"{GITHUB_API_URL}/repos/{repository}/issues/{pr_number}/comments",
+        body={"body": comment},
+    )
+
+
+# https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#list-issue-comments
+def get_comments(
+    repository: str,
+    pr_number: str,
+) -> Generator[Comment]:
+    url = (
+        f"{GITHUB_API_URL}/repos/{repository}/issues/{pr_number}/comments?per_page=100"
+    )
+    for response in _paginate(url):
+        if not isinstance(response.body, list):
+            raise ValueError(
+                f"Expected list body, but found {type(response.body)}: {response.body}"
+            )
+        for comment in response.body:
+            yield comment  # type: ignore
+
+
+@dataclass
+class JSONResponse:
+    headers: dict[str, str]
+    body: JSON
+    status: int
+
+    @classmethod
+    def from_http_response(cls, http_response: HTTPResponse) -> Self:
+        return cls(
+            headers={k.lower(): v for k, v in http_response.getheaders()},
+            body=json.loads(http_response.read()),
+            status=http_response.status,
+        )
+
+
+def _request(url: str, body: JSON = None) -> JSONResponse:
+    if not GITHUB_TOKEN:
+        raise ValueError(
+            "The GITHUB_TOKEN environment variable must be set to post review comments."
+        )
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {GITHUB_TOKEN}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    if body is not None:
+        req = request.Request(
+            url=url, headers=headers, data=json.dumps(body, indent=2).encode("utf-8")
+        )
+    else:
+        req = request.Request(url=url, headers=headers)
+
+    print(f"Sending GitHub API request to {url} with body: {body}")
+
+    try:
+        http_response = request.urlopen(req)
+    except HTTPError as e:
+        raise GitHubAPIError(e) from e
+
+    response = JSONResponse.from_http_response(http_response)
+    print(f"Received response: {response}")
+    return response
+
+
+# Use a generator so that callers can break out before pagination is complete.
+def _paginate(url: str) -> Generator[JSONResponse]:
+    print(f"Paginating GitHub api: {url}")
+    while True:
+        response = _request(url)
+        yield response
+
+        if match := NEXT_PAGE.search(response.headers.get("link", "")):
+            url = match.group()
+            print("Waiting one minute before requesting the next page.")
+            time.sleep(60)
+        else:
+            print("Done paginating.")
+            break
+
+
+class GitHubAPIError(Exception):
+    def __init__(self, response: HTTPError) -> None:
+        formatted_body = json.dumps(
+            json.loads(response.read().decode("utf-8")), indent=2
+        )
+        super().__init__(f"GitHub API request failed:\n\n{formatted_body}")

--- a/.changes/tool/new.py
+++ b/.changes/tool/new.py
@@ -1,0 +1,135 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import hashlib
+import os
+import re
+import string
+import subprocess
+import tempfile
+
+from . import NEXT_RELEASE_DIR, Change, ChangeType
+
+VALID_CHARS = set(string.ascii_letters + string.digits)
+TEMPLATE = """\
+# Type should be one of: "feature", "bugfix", "documentation", "break", or "other".
+#
+# feature:       A larger feature or change in behavior, usually resulting in a
+#                minor version bump.
+# bugfix:        Fixing a bug in an existing code path.
+# documentation: A documentation-only change.
+# break:         A breaking change, be it a break-fix or a breaking feature change.
+# other:         Any change that does not fit into another category.
+type: {change_type}
+
+# (Optional)
+# A link to the GitHub pull request that implments the feature. You can use GitHub
+# sytle references, which will automatically be replaced with the correct link.
+pull request: {pull_requests}
+
+# A brief description of the change. You can use GitHub style references to issues such
+# as "fixes #489", "smithy-lang/smithy#100", etc. These will get automatically replaced
+# with the correct link.
+description: {description}
+"""
+
+
+def new_change(
+    change_type: ChangeType | None = None,
+    description: str | None = None,
+    pull_requests: list[str] | None = None,
+    repository: str | None = None,
+):
+    if change_type is not None and description is not None:
+        change = Change(type=change_type, description=description)
+        if pull_requests:
+            change.pull_requests = pull_requests
+    else:
+        print("Missing required parameters, prompting for what remains")
+        parsed = get_values_from_editor(change_type, description, pull_requests)
+        if not parsed:
+            return
+        change = parsed
+
+    repository = repository or "smithy-lang/smithy"
+    write_new_change(change, repository)
+
+
+def get_values_from_editor(
+    change_type: ChangeType | None,
+    description: str | None,
+    pull_requests: list[str] | None,
+) -> Change | None:
+    with tempfile.NamedTemporaryFile("w") as f:
+        prs = pull_requests or []
+        contents = TEMPLATE.format(
+            change_type=change_type.name.lower() if change_type is not None else "",
+            description=description or "",
+            pull_requests=", ".join(prs),
+        )
+        f.write(contents)
+        f.flush()
+
+        env = os.environ
+        editor = env.get("VISUAL", env.get("EDITOR", "vim"))
+        p = subprocess.Popen(f"{editor} {f.name}", shell=True)
+        p.communicate()
+
+        with open(f.name) as f:
+            return parse_filled_in_contents(f.read())
+
+
+def replace_issue_references(change: Change, repo_name: str):
+    def linkify(match: re.Match[str]):
+        number = match.group()[1:]
+        return f"[{match.group()}](https://github.com/{repo_name}/issues/{number})"
+
+    new_description = re.sub(r"#\d+", linkify, change.description)
+    change.description = new_description
+
+    if change.pull_requests:
+        change.pull_requests = [
+            re.sub(r"#\d+", linkify, pr) for pr in change.pull_requests
+        ]
+
+
+def write_new_change(change: Change, repo_name: str):
+    if not NEXT_RELEASE_DIR.is_dir():
+        os.makedirs(NEXT_RELEASE_DIR)
+
+    replace_issue_references(change, repo_name)
+
+    contents = change.write()
+    contents_digest = hashlib.sha1(contents.encode("utf-8")).hexdigest()
+    filename = f"{change.type.name.lower()}-{contents_digest}.json"
+
+    file = NEXT_RELEASE_DIR / filename
+    file.write_text(contents)
+
+
+def parse_filled_in_contents(contents: str) -> Change | None:
+    if not contents.strip():
+        return
+
+    parsed = {}
+    lines = iter(contents.splitlines())
+    for line in lines:
+        line = line.strip()
+        if line.startswith("#"):
+            continue
+
+        if "type" not in parsed and line.startswith("type:"):
+            parsed["type"] = ChangeType[line.split(":")[1].strip().upper()]
+        if "pull_requests" not in parsed and line.startswith("pull requests:"):
+            parsed["pull_requests"] = [
+                pr.strip() for pr in line.split(":")[1].strip().split(",")
+            ]
+        elif "description" not in parsed and line.startswith("description:"):
+            # Assume that everything until the end of the file is part
+            # of the description, so we can break once we pull in the
+            # remaining lines.
+            first_line = line.split(":")[1].strip()
+            full_description = "\n".join([first_line] + list(lines))
+            parsed["description"] = full_description.strip()
+            break
+
+    return Change(**parsed)  # type: ignore

--- a/.changes/tool/release.py
+++ b/.changes/tool/release.py
@@ -1,0 +1,34 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import os
+from datetime import date
+
+from . import NEXT_RELEASE_DIR, RELEASES_DIR, Change, Release
+
+
+def release(version: str, release_date: str | None) -> None:
+    version = version.strip()
+    print("Gathering staged changes for release")
+    release_date = release_date or date.today().isoformat()
+    changes: list[Change] = []
+
+    for entry in NEXT_RELEASE_DIR.glob("*.json"):
+        print(f"Found staged changelog entry: {entry}")
+        changes.append(Change.read(entry))
+        entry.unlink()
+
+    if not changes:
+        raise ValueError(
+            """\
+            To conduct a release, there must be at least one staged changelog entry \
+            in the next-release folder."""
+        )
+
+    result = Release(version=version, date=release_date.strip(), changes=changes)
+
+    if not RELEASES_DIR.is_dir():
+        os.makedirs(RELEASES_DIR)
+
+    release_file = RELEASES_DIR / f"{version}.json"
+    print(f"Writing combined release to {release_file}")
+    result.write(release_file)

--- a/.changes/tool/render.py
+++ b/.changes/tool/render.py
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from . import RELEASES_DIR, Change, Release
+
+TITLE = "Changelog"
+
+
+def render() -> None:
+    rendered = f"# {TITLE}\n\n"
+    for release in get_releases():
+        rendered += f"## {release.version} ({release.date})\n\n"
+
+        for change_type, changes in release.change_map().items():
+            rendered += f"### {change_type.section_title}\n\n"
+
+            for change in changes:
+                rendered += render_change(change)
+
+            rendered += "\n"
+
+    print(rendered)
+
+
+def render_change(change: Change) -> str:
+    rendered = f"* {change.description}"
+    if prs := change.pull_requests:
+        rendered += f"({', '.join(prs)})"
+    return rendered + "\n"
+
+
+def get_releases() -> list[Release]:
+    releases: list[Release] = []
+    for release_file in RELEASES_DIR.glob("*.json"):
+        releases.append(Release.read(release_file))
+    return sorted(releases)

--- a/.github/workflows/changelog-ci.yml
+++ b/.github/workflows/changelog-ci.yml
@@ -1,0 +1,25 @@
+name: changelog
+on: pull_request_target
+permissions: write-all
+jobs:
+    amend:
+        name: "Validate staged changelogs"
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                ref: ${{ github.head_ref }}
+                repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+            - uses: actions/setup-python@v5
+              with:
+                python-version: "3.13"
+
+            - name: "Run validation script"
+              env:
+                GITHUB_TOKEN: ${{ github.token }}
+                TARGET_SHA: ${{ github.event.pull_request.head.sha }}
+                PR_TITLE: ${{ github.event.pull_request.title }}
+              run: |
+                git fetch origin ${{ github.base_ref }}
+                ./.changes/amend --review-comment -n ${{ github.event.pull_request.number }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,11 @@ To send us a pull request, please:
 3. Follow the same coding style as the rest of the project.
 4. Add new test cases that exercise the change and covers all non-trivial branches.
 5. Ensure that running `./gradlew clean build` completes successfully.
-6. Commit to your fork using clear commit messages by following the guidance at
+6. Write a changelog entry using [`./changes/new-change`](.changes/README.md).
+7. Commit to your fork using clear commit messages by following the guidance at
    [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/).
-7. Send us a pull request, answering any default questions in the pull request interface.
-8. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+8. Send us a pull request, answering any default questions in the pull request interface.
+9. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
 GitHub provides additional documentation on [forking a repository](https://help.github.com/articles/fork-a-repo/)
 and [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).


### PR DESCRIPTION
Writing changelog entries is not super fun. Writing them after the fact, especially when you didn't write the original feature, is even less fun. And merge conflicts because of synchronizing a changelog file are SUPER not-fun.

This PR solves those problems. It introduces a changelog tool similar to what many of the SDK teams use (and indeed cribs some code from them).

## Workflow

* When creating a pull request, you create a changelog entry by running `.changes/new-change`. This creates a JSON file in `.changes/next-release/` containing the changelog entry and its metadata (e.g. whether it's a documentation change, feature change, etc.)
* When the pull request is opened a GitHub action will automatically add a PR comment with a suggestion that you can click on to add the PR number.
* During a release, the changelog is updated by running `.changes/render --release-version 1.2.3`. This compiles all pending changes in `.changes/next-release/` into a single file in the `.changes/releases/` directory. It then renders all of the releases in `.changes/releases/` into a markdown file that can be written to `CHANGELOG.md`. If for some reason the changelog needs to be re-rendered out of band, `./change/render` can be called without a version to just do the rendering.

In effect, the canonical source for the changelog becomes the changelog JSON files, and the actual markdown representation is just a derived artifact.

## Why?

Using distinct files for changelog entries solves a major problem: merge conflicts. These are horribly annoying to deal with during development, especially on a file that is essentially documentation and semantically has no reason to ever conflict. This problem is less bad for Smithy itself than it is for SDKs that have daily releases, but it's a problem for us too with our relatively large team.

## What's different?

This differs from what other SDKs do in a few ways. Firstly, and most notably, we aren't deriving a version number from these. We could! It would not be hard! But I elected not to do that in this PR since it's not as big a problem for us.

We also have a habit of linking the PRs for all of our changes in the changelog. This is actually kinda annoying because it creates a bit of a chicken-egg scenario. This is why I added the github action to automatically add it. If the action is annoying we can always get rid of it and just stop relying on the links. But that would be a shame.

Mechanically there's also a change in that I used modern python to write this, and updated any borrowed code to also be modern python.

## Why not use jmeslog?

jmeslog is a standalone tool derived from the python team's changelog tool (which started it all). It is essentially exactly what they do and want, but there's a few things that prevent us from using it. Notably, we need the current date and pr links. jmeslog doesn't have that and doesn't currently allow for easy extension in that way.

It also has things we don't necessarily want, like a category. That's really mostly used in the sdks to indicate changes made for a particular service. With hundreds of services, that's an issue worthy of calling out. But smithy itself doesn't need it.

But also, it's a dependency, and it has dependencies. I'd rather not have dependencies if I can avoid it. And what we need is ultimately not that complex. And doing it ourselves gives us some flexibility.

All that said, there's definitely a world where jmeslog is updated to a place where we can more comfortably use it.

## Why not derive changelogs from commits?

The audience for changelogs and the audience for commit messages are two separate (though sometimes intersecting) audiences. Commits may contain conext about technical junk that only mattters to people working on the code itself.

There is also not necessarily a 1-1 relationship between a changelog entry and a commit. Large features are often broken up into logical commits that make reviewing and code diving easier, but aren't important to the changelog. You might also have commits that make changes unimportant to the changelog audience, such as formatting changes or changes to CI configurations.

Commits are also, critically, <ins>***immutable***</ins>. Did you make a typo in your commit? Now it's preserved forever in your changelog. With JSON files, you can just change them. Those changes are now part of the commit record!

Also, on a more subjective level, have you seen repos that have semantic commits? They're ugly. Having more than half your commits starting with `chore` just makes it look like your project is in maintenance mode and/or like you hate your job. And if you're following best practices for commit messages, that's eating into your 50 character limit for the title.

## Any unfortunate bits?

There's no line wrapping, so you better believe the changelog is gonna have some long lines. It doesn't really matter though, because it'll all be natural when you're seeing it fully rendered. The line boundary thing these days mostly helps with readability when you're editing a file, but you will never manually edit the file.

Also the automated commit will hide the status checks in GitHub's UI for some reason. That's why it's only added *after* all the other checks and isn't run if said checks fail. Also why you can do it manually.

## What's next?

Provided this goes through, the next step will be to backfill all the current changelog entries. That'll certainly be a task.

A github action to create the version bump pr would be sweet. We'd need to add the ability to derive a version number from the feature list, which isn't hard. Then the script could just aslo perform the version bump by writing that one file. Then it could be just a button press away in github. Maybe as a fully automated release?

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
