### PR TITLE
Update IDL serializer to write metadata to a separate file

### DIFF
--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/alphabetical/after.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/alphabetical/after.smithy
@@ -1,8 +1,5 @@
 $version: "2.0"
 
-metadata foo = "hi"
-metadata zoo = "test"
-
 namespace com.example
 
 structure Abc {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/alphabetical/before.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/alphabetical/before.smithy
@@ -1,0 +1,21 @@
+$version: "2.0"
+
+metadata zoo = "test"
+metadata foo = "hi"
+
+namespace com.example
+
+service Hij {
+    version: "2006-03-01"
+}
+
+string Def
+
+structure Abc {
+    bar: String
+    @length(
+        min: 1
+    )
+    @required
+    baz: String
+}

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/alphabetical/metadata.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/alphabetical/metadata.smithy
@@ -1,0 +1,4 @@
+$version: "2.0"
+
+metadata foo = "hi"
+metadata zoo = "test"

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/metadata.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/metadata.smithy
@@ -1,0 +1,3 @@
+$version: "2.0"
+
+metadata shared = true

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/ns.primitives.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/ns.primitives.smithy
@@ -1,7 +1,5 @@
 $version: "2.0"
 
-metadata shared = true
-
 namespace ns.primitives
 
 list StringList {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/ns.structures.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/multiple-namespaces/output/ns.structures.smithy
@@ -1,7 +1,5 @@
 $version: "2.0"
 
-metadata shared = true
-
 namespace ns.structures
 
 use ns.primitives#StringList

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/out-of-order.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/shapes/idl-serialization/out-of-order.smithy
@@ -1,8 +1,5 @@
 $version: "2.0"
 
-metadata zoo = "test"
-metadata foo = "hi"
-
 namespace com.example
 
 string MyString


### PR DESCRIPTION
### Description
Updates the `SmithyIdlModelSerializer` to write all metadata to a separate `metadata.smithy` file rather than duplicating the metadata within each generated file. 

Generating a separate smithy metadata files avoids potentially duplicating array data.

### Detail on issue
For example the following files
```smithy
/// hello.smithy
$version: "2"

metadata hello = [1]
 
namespace test
 
structure Hello{}
```
and
```smithy
/// world.smithy
$version: "2"

metadata hello = [2]
 
namespace test
 
structure World{}
```

Were previously re-written as:
```smithy
/// hello.smithy
$version: "2"

metadata hello = [1, 2]
 
namespace test
 
structure Hello{}
```
and
```smithy
/// world.smithy
$version: "2"

metadata hello = [1, 2]
 
namespace test
 
structure World{}
```

This created a problem where, when using these models in a new model, the resulting metadata for `hello` 
would be an array containing `[1,2,1,2]` effectively duplicating all array data N times (N being number of smithy files generated).


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
