### PR TITLE
Add transform to mark required idempotency tokens client optional

### DIFF
--- a/docs/source-2.0/guides/smithy-build-json.rst
+++ b/docs/source-2.0/guides/smithy-build-json.rst
@@ -580,8 +580,8 @@ makeIdempotencyTokensClientOptional
 
 Makes required Idempotency token members as ``@clientOptional``.
 
-Idempotency tokens that are required should fail validation, but shouldn't be required to create a type,
-allowing for a default value to get injected when missing.
+Idempotency tokens that are required should fail validation, but shouldn't be required to create a type.
+This allows a default value to get injected when missing.
 
 .. code-block:: json
 

--- a/docs/source-2.0/guides/smithy-build-json.rst
+++ b/docs/source-2.0/guides/smithy-build-json.rst
@@ -575,10 +575,10 @@ applied.
 
 .. _markIdempotencyTokensClientOptional:
 
-markIdempotencyTokensClientOptional
+makeIdempotencyTokensClientOptional
 -----------------------------------
 
-Marks required Idempotency token members as ``@clientOptional``.
+Makes required Idempotency token members as ``@clientOptional``.
 
 Idempotency tokens that are required should fail validation, but shouldn't be required to create a type,
 allowing for a default value to get injected when missing.
@@ -591,7 +591,7 @@ allowing for a default value to get injected when missing.
             "exampleProjection": {
                 "transforms": [
                     {
-                        "name": "markIdempotencyTokensClientOptional"
+                        "name": "makeIdempotencyTokensClientOptional"
                     }
                 ]
             }

--- a/docs/source-2.0/guides/smithy-build-json.rst
+++ b/docs/source-2.0/guides/smithy-build-json.rst
@@ -578,7 +578,7 @@ applied.
 makeIdempotencyTokensClientOptional
 -----------------------------------
 
-Makes required Idempotency token members :ref:`@clientOptional <clientOptional-trait>`.
+Makes required :ref:`@idempotencyToken <idempotencyToken-trait>` members :ref:`@clientOptional <clientOptional-trait>`.
 
 Idempotency tokens that are required should fail validation, but shouldn't be required to create a type.
 This allows a default value to get injected when missing.

--- a/docs/source-2.0/guides/smithy-build-json.rst
+++ b/docs/source-2.0/guides/smithy-build-json.rst
@@ -573,12 +573,12 @@ applied.
     use an :ref:`enum shape <enum>` instead to avoid needing to use this
     transform.
 
-.. _markIdempotencyTokensClientOptional:
+.. _makeIdempotencyTokensClientOptional:
 
 makeIdempotencyTokensClientOptional
 -----------------------------------
 
-Makes required Idempotency token members as ``@clientOptional``.
+Makes required Idempotency token members :ref:`@clientOptional <clientOptional-trait>`.
 
 Idempotency tokens that are required should fail validation, but shouldn't be required to create a type.
 This allows a default value to get injected when missing.

--- a/docs/source-2.0/guides/smithy-build-json.rst
+++ b/docs/source-2.0/guides/smithy-build-json.rst
@@ -573,6 +573,31 @@ applied.
     use an :ref:`enum shape <enum>` instead to avoid needing to use this
     transform.
 
+.. _markIdempotencyTokensClientOptional:
+
+markIdempotencyTokensClientOptional
+-----------------------------------
+
+Marks required Idempotency token members as ``@clientOptional``.
+
+Idempotency tokens that are required should fail validation, but shouldn't be required to create a type,
+allowing for a default value to get injected when missing.
+
+.. code-block:: json
+
+    {
+        "version": "1.0",
+        "projections": {
+            "exampleProjection": {
+                "transforms": [
+                    {
+                        "name": "markIdempotencyTokensClientOptional"
+                    }
+                ]
+            }
+        }
+    }
+
 .. _changeTypes:
 
 changeTypes

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/MakeIdempotencyTokensClientOptional.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/MakeIdempotencyTokensClientOptional.java
@@ -10,7 +10,7 @@ import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
 
 /**
- * {@code makeIdempotencyTokensClientOptional} marks required idempotency token fields clientOptional.
+ * {@code makeIdempotencyTokensClientOptional} makes {@code @idempotencyToken} fields {@code @clientOptional}.
  */
 public final class MakeIdempotencyTokensClientOptional implements ProjectionTransformer {
 

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/MakeIdempotencyTokensClientOptional.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/MakeIdempotencyTokensClientOptional.java
@@ -10,18 +10,18 @@ import software.amazon.smithy.build.TransformContext;
 import software.amazon.smithy.model.Model;
 
 /**
- * {@code markIdempotencyTokensClientOptional} marks required idempotency token fields clientOptional.
+ * {@code makeIdempotencyTokensClientOptional} marks required idempotency token fields clientOptional.
  */
-public final class MarkIdempotencyTokensClientOptional implements ProjectionTransformer {
+public final class MakeIdempotencyTokensClientOptional implements ProjectionTransformer {
 
     @Override
     public String getName() {
-        return "markIdempotencyTokensClientOptional";
+        return "makeIdempotencyTokensClientOptional";
     }
 
     @Override
     public Model transform(TransformContext context) {
         Model model = context.getModel();
-        return context.getTransformer().markIdempotencyTokensClientOptional(model);
+        return context.getTransformer().makeIdempotencyTokensClientOptional(model);
     }
 }

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/MarkIdempotencyTokensClientOptional.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/MarkIdempotencyTokensClientOptional.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.build.transforms;
+
+import software.amazon.smithy.build.ProjectionTransformer;
+import software.amazon.smithy.build.TransformContext;
+import software.amazon.smithy.model.Model;
+
+/**
+ * {@code markIdempotencyTokensClientOptional} marks required idempotency token fields clientOptional.
+ */
+public final class MarkIdempotencyTokensClientOptional implements ProjectionTransformer {
+
+    @Override
+    public String getName() {
+        return "markIdempotencyTokensClientOptional";
+    }
+
+    @Override
+    public Model transform(TransformContext context) {
+        Model model = context.getModel();
+        return context.getTransformer().markIdempotencyTokensClientOptional(model);
+    }
+}

--- a/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
+++ b/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
@@ -18,7 +18,7 @@ software.amazon.smithy.build.transforms.IncludeShapesByTag
 software.amazon.smithy.build.transforms.IncludeTags
 software.amazon.smithy.build.transforms.IncludeTraits
 software.amazon.smithy.build.transforms.IncludeTraitsByTag
-software.amazon.smithy.build.transforms.MarkIdempotencyTokensClientOptional
+software.amazon.smithy.build.transforms.MakeIdempotencyTokensClientOptional
 software.amazon.smithy.build.transforms.RemoveDeprecatedShapes
 software.amazon.smithy.build.transforms.RemoveTraitDefinitions
 software.amazon.smithy.build.transforms.RemoveUnusedShapes

--- a/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
+++ b/smithy-build/src/main/resources/META-INF/services/software.amazon.smithy.build.ProjectionTransformer
@@ -18,6 +18,8 @@ software.amazon.smithy.build.transforms.IncludeShapesByTag
 software.amazon.smithy.build.transforms.IncludeTags
 software.amazon.smithy.build.transforms.IncludeTraits
 software.amazon.smithy.build.transforms.IncludeTraitsByTag
+software.amazon.smithy.build.transforms.MarkIdempotencyTokensClientOptional
+software.amazon.smithy.build.transforms.RemoveDeprecatedShapes
 software.amazon.smithy.build.transforms.RemoveTraitDefinitions
 software.amazon.smithy.build.transforms.RemoveUnusedShapes
 software.amazon.smithy.build.transforms.RenameShapes

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -316,14 +316,14 @@ public final class CodegenDirector<
     }
 
     /**
-     * Marks idempotency token fields {@code clientOptional}.
+     * Makes idempotency token fields {@code clientOptional}.
      *
-     * @see ModelTransformer#markIdempotencyTokensClientOptional(Model)
+     * @see ModelTransformer#makeIdempotencyTokensClientOptional(Model)
      */
     public void markIdempotencyTokensClientOptional() {
         transforms.add((model, transformer) -> {
-            LOGGER.finest("Marking Idempotency Token fields `@clientOptional`");
-            return transformer.markIdempotencyTokensClientOptional(model);
+            LOGGER.finest("Making Idempotency Token fields `@clientOptional`");
+            return transformer.makeIdempotencyTokensClientOptional(model);
         });
     }
 

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -316,7 +316,7 @@ public final class CodegenDirector<
     }
 
     /**
-     * Makes idempotency token fields {@code clientOptional}.
+     * Makes {@code idempotencyToken} fields {@code clientOptional}.
      *
      * @see ModelTransformer#makeIdempotencyTokensClientOptional(Model)
      */

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -316,6 +316,18 @@ public final class CodegenDirector<
     }
 
     /**
+     * Marks idempotency token fields {@code clientOptional}.
+     *
+     * @see ModelTransformer#markIdempotencyTokensClientOptional(Model)
+     */
+    public void markIdempotencyTokensClientOptional() {
+        transforms.add((model, transformer) -> {
+            LOGGER.finest("Marking Idempotency Token fields `@clientOptional`");
+            return transformer.markIdempotencyTokensClientOptional(model);
+        });
+    }
+
+    /**
      * Changes each compatible string shape with the enum trait to an enum shape.
      *
      * @param synthesizeEnumNames Whether enums without names should have names synthesized if possible.

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -320,7 +320,7 @@ public final class CodegenDirector<
      *
      * @see ModelTransformer#makeIdempotencyTokensClientOptional(Model)
      */
-    public void markIdempotencyTokensClientOptional() {
+    public void makeIdempotencyTokensClientOptional() {
         transforms.add((model, transformer) -> {
             LOGGER.finest("Making `@idempotencyToken` fields `@clientOptional`");
             return transformer.makeIdempotencyTokensClientOptional(model);

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -322,7 +322,7 @@ public final class CodegenDirector<
      */
     public void markIdempotencyTokensClientOptional() {
         transforms.add((model, transformer) -> {
-            LOGGER.finest("Making Idempotency Token fields `@clientOptional`");
+            LOGGER.finest("Making `@idempotencyToken` fields `@clientOptional`");
             return transformer.makeIdempotencyTokensClientOptional(model);
         });
     }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptional.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptional.java
@@ -8,9 +8,9 @@ import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 
 /**
- * Mark Idempotency token members as clientOptional so they can be injected if missing.
+ * Makes Idempotency token members as clientOptional so they can be injected if missing.
  */
-final class MarkIdempotencyTokenClientOptional {
+final class MakeIdempotencyTokenClientOptional {
     public static Model transform(Model model) {
         return ModelTransformer.create().mapShapes(model, shape -> {
             if (shape.isMemberShape()

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptional.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptional.java
@@ -1,5 +1,9 @@
-package software.amazon.smithy.model.transform;
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
+package software.amazon.smithy.model.transform;
 
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.Shape;
@@ -8,9 +12,11 @@ import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 
 /**
- * Makes Idempotency token members as clientOptional so they can be injected if missing.
+ * Makes Idempotency token members as clientOptional, so they can be injected if missing.
  */
 final class MakeIdempotencyTokenClientOptional {
+    private MakeIdempotencyTokenClientOptional() {}
+
     public static Model transform(Model model) {
         return ModelTransformer.create().mapShapes(model, shape -> {
             if (shape.isMemberShape()

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptional.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptional.java
@@ -1,0 +1,25 @@
+package software.amazon.smithy.model.transform;
+
+
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.ClientOptionalTrait;
+import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
+import software.amazon.smithy.model.traits.RequiredTrait;
+
+/**
+ * Mark Idempotency token members as clientOptional so they can be injected if missing.
+ */
+final class MarkIdempotencyTokenClientOptional {
+    public static Model transform(Model model) {
+        return ModelTransformer.create().mapShapes(model, shape -> {
+            if (shape.isMemberShape()
+                    && shape.hasTrait(RequiredTrait.class)
+                    && shape.hasTrait(IdempotencyTokenTrait.class)
+                    && !shape.hasTrait(ClientOptionalTrait.class)) {
+                return Shape.shapeToBuilder(shape).addTrait(new ClientOptionalTrait()).build();
+            }
+            return shape;
+        });
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptional.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptional.java
@@ -12,7 +12,7 @@ import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 
 /**
- * Makes Idempotency token members as clientOptional, so they can be injected if missing.
+ * Makes {@code idempotencyToken} members {@code clientOptional}, so they can be injected if missing.
  */
 final class MakeIdempotencyTokenClientOptional {
     private MakeIdempotencyTokenClientOptional() {}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -722,10 +722,10 @@ public final class ModelTransformer {
     }
 
     /**
-     * Makes any Idempotency token fields {@code @clientOptional} so that missing tokens can be injected.
+     * Makes any {@code @idempotencyToken fields {@code @clientOptional} so that missing tokens can be injected.
      *
      * <p>Idempotency tokens that are required should fail validation, but shouldn't be required to create a type,
-     * allowing for a default value to get injected when missing.
+     * allowing for a default value to be injected when missing.
      *
      * @param model Model to transform.
      * @return Returns the transformed model.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -722,7 +722,7 @@ public final class ModelTransformer {
     }
 
     /**
-     * Makes any {@code @idempotencyToken fields {@code @clientOptional} so that missing tokens can be injected.
+     * Makes any {@code @idempotencyToken} fields {@code @clientOptional} so that missing tokens can be injected.
      *
      * <p>Idempotency tokens that are required should fail validation, but shouldn't be required to create a type,
      * allowing for a default value to be injected when missing.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -723,7 +723,7 @@ public final class ModelTransformer {
     }
 
     /**
-     * Marks any Idempotency token fields {@code @clientOptional} so that missing tokens can be injected.
+     * Makes any Idempotency token fields {@code @clientOptional} so that missing tokens can be injected.
      *
      * <p>Idempotency tokens that are required should fail validation, but shouldn't be required to create a type,
      * allowing for a default value to get injected when missing.
@@ -731,7 +731,7 @@ public final class ModelTransformer {
      * @param model Model to transform.
      * @return Returns the transformed model.
      */
-    public Model markIdempotencyTokensClientOptional(Model model) {
-        return MarkIdempotencyTokenClientOptional.transform(model);
+    public Model makeIdempotencyTokensClientOptional(Model model) {
+        return MakeIdempotencyTokenClientOptional.transform(model);
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -43,7 +43,6 @@ import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.model.traits.synthetic.OriginalShapeIdTrait;
 import software.amazon.smithy.utils.FunctionalUtils;
 import software.amazon.smithy.utils.ListUtils;
-import sun.awt.ModalityListener;
 
 /**
  * Class used to transform {@link Model}s.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ModelTransformer.java
@@ -43,6 +43,7 @@ import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.model.traits.synthetic.OriginalShapeIdTrait;
 import software.amazon.smithy.utils.FunctionalUtils;
 import software.amazon.smithy.utils.ListUtils;
+import sun.awt.ModalityListener;
 
 /**
  * Class used to transform {@link Model}s.
@@ -719,5 +720,18 @@ public final class ModelTransformer {
      */
     public Model filterDeprecatedRelativeVersion(Model model, String relativeVersion) {
         return new FilterDeprecatedRelativeVersion(relativeVersion).transform(this, model);
+    }
+
+    /**
+     * Marks any Idempotency token fields {@code @clientOptional} so that missing tokens can be injected.
+     *
+     * <p>Idempotency tokens that are required should fail validation, but shouldn't be required to create a type,
+     * allowing for a default value to get injected when missing.
+     *
+     * @param model Model to transform.
+     * @return Returns the transformed model.
+     */
+    public Model markIdempotencyTokensClientOptional(Model model) {
+        return MarkIdempotencyTokenClientOptional.transform(model);
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptionalTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptionalTest.java
@@ -19,7 +19,7 @@ public class MakeIdempotencyTokenClientOptionalTest {
                 .addImport(FlattenPaginationInfoTest.class.getResource("idempotency-token.smithy"))
                 .assemble()
                 .unwrap();
-        Model result = ModelTransformer.create().markIdempotencyTokensClientOptional(before);
+        Model result = ModelTransformer.create().makeIdempotencyTokensClientOptional(before);
 
         Shape input = result.expectShape(operationInput);
         Shape member = result.expectShape(input.getMember("token").get().getId());

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptionalTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptionalTest.java
@@ -1,0 +1,31 @@
+package software.amazon.smithy.model.transform;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.ClientOptionalTrait;
+import software.amazon.smithy.model.traits.IdempotencyTokenTrait;
+import software.amazon.smithy.model.traits.RequiredTrait;
+
+public class MakeIdempotencyTokenClientOptionalTest {
+    private static final ShapeId operationInput = ShapeId.from("smithy.example#IdempotencyTokenRequiredInput");
+
+    @Test
+    void compareTransform() {
+        Model before = Model.assembler()
+                .addImport(FlattenPaginationInfoTest.class.getResource("idempotency-token.smithy"))
+                .assemble()
+                .unwrap();
+        Model result = ModelTransformer.create().markIdempotencyTokensClientOptional(before);
+
+        Shape input = result.expectShape(operationInput);
+        Shape member = result.expectShape(input.getMember("token").get().getId());
+
+        assertTrue(member.hasTrait(ClientOptionalTrait.class));
+        assertTrue(member.hasTrait(RequiredTrait.class));
+        assertTrue(member.hasTrait(IdempotencyTokenTrait.class));
+    }
+}

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptionalTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptionalTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package software.amazon.smithy.model.transform;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/transform/idempotency-token.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/transform/idempotency-token.smithy
@@ -1,0 +1,11 @@
+$version: "2.0"
+
+namespace smithy.example
+
+operation IdempotencyTokenRequired {
+    input := {
+        @idempotencyToken
+        @required
+        token: String
+    }
+}


### PR DESCRIPTION
### Description
Adds a transform that marks required Idempotency tokens `@clientOptional`. This is important because it changes the nullability of idempotency tokens for code generators, allow customers to leave the field unset and have their client inject the value.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
