### PR TITLE
Clean up changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 * Fixed a typo in event stream content-type documentation ([#2458](https://github.com/smithy-lang/smithy/pull/2458))
 * Fixed a broken README link ([#2457](https://github.com/smithy-lang/smithy/pull/2457))
 
-## Other
+### Other
 
 * Updated blob defaults for protocol tests ([#2467](https://github.com/smithy-lang/smithy/pull/2467))
 * Downgraded a noisy log statement ([#2451](https://github.com/smithy-lang/smithy/pull/2451))
@@ -922,10 +922,9 @@
 
 ## 1.25.0 (2022-09-13)
 
-Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://github.com/awslabs/smithy/pull/1394))
-
 ### Features
 
+* Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://github.com/awslabs/smithy/pull/1394))
 * Default traits can now coexist with required trais. This indicates that a member should be serialized, but it is a
   protocol-specific decision if and how this is enforced. This was a pattern that occurred in Smithy 1.0 models when
   a member was required and targeted a shape with a zero value.
@@ -956,7 +955,7 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 * Added method to NumberNode to detect if it is set to zero. ([#1385](https://github.com/awslabs/smithy/pull/1385))
 * In ChangeShapeType transform, ignored types changes to same type. ([#1397](https://github.com/awslabs/smithy/pull/1397))
 
-## Bug fixes
+### Bug fixes
 
 * Updated smithy-diff to not emit events when diffing a 1.0 model against the 2.0 serialized version of the model.
   This means that changes to the box trait are ignored unless the change impacts the nullability of the shape.
@@ -966,7 +965,7 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 * smithy-diff is no longer reporting expected `set` shape to `list` shape transitions. Sets are deprecated and
   models are encouraged to migrate from sets to lists with the `@uniqueItems` trait. ([1383](https://github.com/awslabs/smithy/pull/1383))
 
-## Documentation
+### Documentation
 
 * Fix operationOutputSuffix in example code snippet ([#1393](https://github.com/awslabs/smithy/pull/1393))
 * Fix ABNF grammar of inlined structure ([1377](https://github.com/awslabs/smithy/pull/1377))
@@ -1220,7 +1219,7 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 * Clarified how `@length` interacts with UTF-8 encoding. ([#1089](https://github.com/awslabs/smithy/pull/1089))
 * Fixed an `@idRef` example. ([#1087](https://github.com/awslabs/smithy/pull/1087))
 
-## Other
+### Other
 
 * Migrated to using Gradle 7.3.3 to build Smithy. This should have no impactful downstream effects. ([#1085](https://github.com/awslabs/smithy/pull/1085))
 
@@ -1239,7 +1238,7 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 * Removed repeated words. ([#1063](https://github.com/awslabs/smithy/pull/1063))
 * Clarified server behavior for query parameter deserialization. ([#1080](https://github.com/awslabs/smithy/pull/1080))
 
-## Other
+### Other
 * Updated traits to preserve the original `Node` value from the model.
   ([#1047](https://github.com/awslabs/smithy/pull/1047))
 
@@ -1488,15 +1487,12 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 * Added and updated several `awsQuery` and `ec2Query` protocol tests. ([#815](https://github.com/awslabs/smithy/pull/815),
   [#833](https://github.com/awslabs/smithy/pull/833))
 * Added several `document` type protocol tests. ([#810](https://github.com/awslabs/smithy/pull/810))
+* Added `s3UnwrappedXmlOutput` trait, which defines when an S3 operation does not use the protocol standard XML wrapper.
+  ([#839](https://github.com/awslabs/smithy/pull/839))
 
 ### Bug Fixes
 
 * Fixed a `NullPointerException` when loading a config and no parent path is present. ([#814](https://github.com/awslabs/smithy/pull/814))
-
-### AWS Customizations
-
-* Added `s3UnwrappedXmlOutput` trait, which defines when an S3 operation does not use the protocol standard XML wrapper.
-  ([#839](https://github.com/awslabs/smithy/pull/839))
 
 ### Documentation
 
@@ -1541,15 +1537,13 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
   [#789](https://github.com/awslabs/smithy/pull/789))
 * Added and updated several `@restJson1` protocol test. ([#747](https://github.com/awslabs/smithy/pull/747), [#755](https://github.com/awslabs/smithy/pull/755),
   [#765](https://github.com/awslabs/smithy/pull/765), [#790](https://github.com/awslabs/smithy/pull/790))
+* Added missing `name` properties to `aws.iam#ConditionKeyType` enum. ([#759](https://github.com/awslabs/smithy/pull/759))
 
 ### Bug Fixes
 * Fixed number parsing in the IDL, using BigDecimal or BigInteger where needed. ([#766](https://github.com/awslabs/smithy/pull/766))
 * Fixed Gradle 7 builds. ([#758](https://github.com/awslabs/smithy/pull/758))
 * Added `Document` type to list of inherently boxed shapes. ([#749](https://github.com/awslabs/smithy/pull/749))
 * Reordered `TraitService` SPI entries for readability. ([#742](https://github.com/awslabs/smithy/pull/742))
-
-### AWS Customizations
-* Added missing `name` properties to `aws.iam#ConditionKeyType` enum. ([#759](https://github.com/awslabs/smithy/pull/759))
 
 ### Documentation
 * Fixed `selector_expression` and `comment` in ABNF for Smithy IDL. ([#771](https://github.com/awslabs/smithy/pull/771),
@@ -1590,9 +1584,7 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 
 * Added support for checking backwards compatibility for diffs of trait contents. ([#716](https://github.com/awslabs/smithy/pull/716))
 * Added support for adding CORS configurations to API Gateway HTTP APIs. ([#670](https://github.com/awslabs/smithy/pull/670))
-* Relaxed constraints on the `@httpPayload` trait, allowing it to target `list`, `set`, and `map` shapes. ([#679](https://github.com/awslabs/smithy/pull/679))
-  * Targeting these shapes is invalid for operations utilizing the `aws.protocols` traits. ([#679](https://github.com/awslabs/smithy/pull/679),
-    [#683](https://github.com/awslabs/smithy/pull/683))
+* Relaxed constraints on the `@httpPayload` trait, allowing it to target `list`, `set`, and `map` shapes except in AWS protocols. ([#679](https://github.com/awslabs/smithy/pull/679), [#683](https://github.com/awslabs/smithy/pull/683))
 * Added validation to ensure a `payloadFormatVersion` is set when generating an API Gateway HTTP API. ([#688](https://github.com/awslabs/smithy/pull/688))
 * Added `vendorParamsShape` to protocol test cases to support validating a test case's `vendorParams` values are
   configured properly. ([#702](https://github.com/awslabs/smithy/pull/702))
@@ -1602,6 +1594,11 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 * Added several protocol tests for the `endpoint` and `hostLabel` traits. ([#708](https://github.com/awslabs/smithy/pull/708))
 * Added several `@restXml` protocol tests. ([#689](https://github.com/awslabs/smithy/pull/689), [#690](https://github.com/awslabs/smithy/pull/690),
   [#678](https://github.com/awslabs/smithy/pull/678), [#694](https://github.com/awslabs/smithy/pull/694))
+* Added a configuration definition for use validating `vendorParams` in AWS protocol tests. ([#705](https://github.com/awslabs/smithy/pull/705))
+* Added tests and documentation for some required Amazon S3 customizations. ([#709](https://github.com/awslabs/smithy/pull/709))
+* Added tests and documentation for required Amazon Glacier customizations. ([#704](https://github.com/awslabs/smithy/pull/704))
+* Added a test and documentation for the required Amazon API Gateway customization. ([#706](https://github.com/awslabs/smithy/pull/706))
+* Added a test and documentation for the required Amazon Machine Learning customization. ([#707](https://github.com/awslabs/smithy/pull/707)) 
 
 ### Bug Fixes
 
@@ -1611,14 +1608,6 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 * Fixed several issues in protocol tests around serialization of empty contents. ([#692](https://github.com/awslabs/smithy/pull/692))
 * Fixed an issue where parameters in a diff error message were swapped. ([#713](https://github.com/awslabs/smithy/pull/713))
 * Fixed an issue in a `restXml` protocol test. ([#715](https://github.com/awslabs/smithy/pull/715))
-
-### AWS Customizations
-
-* Added a configuration definition for use validating `vendorParams` in AWS protocol tests. ([#705](https://github.com/awslabs/smithy/pull/705))
-* Added tests and documentation for some required Amazon S3 customizations. ([#709](https://github.com/awslabs/smithy/pull/709))
-* Added tests and documentation for required Amazon Glacier customizations. ([#704](https://github.com/awslabs/smithy/pull/704))
-* Added a test and documentation for the required Amazon API Gateway customization. ([#706](https://github.com/awslabs/smithy/pull/706))
-* Added a test and documentation for the required Amazon Machine Learning customization. ([#707](https://github.com/awslabs/smithy/pull/707)) 
 
 ### Documentation
 
@@ -1680,7 +1669,7 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 * Clarified that the `@pattern` trait does not implicitly match an entire string. ([#649](https://github.com/awslabs/smithy/pull/649))
 * Fixed various examples in the specification. ([#639](https://github.com/awslabs/smithy/pull/639))
 
-### Cleanup
+### Other
 
 * Sort `TopDownIndex` contents to provide deterministic results. ([#667](https://github.com/awslabs/smithy/pull/667))
 * Improved error messages when an unknown annotation trait is encountered. ([#644](https://github.com/awslabs/smithy/pull/644))
@@ -1690,8 +1679,6 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 
 ### Features
 
-#### New Packages
-
 * Added `smithy-jmespath`, a dependency-less, JMESPath parser with a rich AST that can be used in code generation, and
   performs static analysis of expressions. ([#621](https://github.com/awslabs/smithy/pull/621))
 * Added `smithy-waiters`, containing the `@waitable` trait. This provides information that clients can use to poll
@@ -1700,9 +1687,6 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
   and the additional metadata about their properties. ([#579](https://github.com/awslabs/smithy/pull/579))
 * Added `smithy-aws-cloudformation`, containing the (unstable) "cloudformation" build tool that, given a model
   decorated with traits from `aws.cloudformation`, will generate CloudFormation Resource Schemas. ([#622](https://github.com/awslabs/smithy/pull/622))
-
-#### Other Features
-
 * Added support for `patternProperties` when generating JSON Schema. ([#611](https://github.com/awslabs/smithy/pull/611))
 * Added more utility methods to the `CodeWriter`. ([#624](https://github.com/awslabs/smithy/pull/624))
 * Added validation for `@sensitive` trait when applied to members. ([#609](https://github.com/awslabs/smithy/pull/609))
@@ -1726,7 +1710,7 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 * Clarified that `@enum` values cannot be empty. ([#633](https://github.com/awslabs/smithy/pull/633))
 * Clarified binary data in protocol tests. ([#634](https://github.com/awslabs/smithy/pull/634))
 
-### Cleanup
+### Other
 
 * Lowered severity of validation that a `pageSize` member is marked `@required`. ([#612](https://github.com/awslabs/smithy/pull/612))
 
@@ -1745,11 +1729,6 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 
 * Fixed an issue where the `flattenNamespaces` build transform was not registered with the SPI. ([#593](https://github.com/awslabs/smithy/pull/593))
 
-### Optimizations
-
-* Optimized the reverse `NeighborProvider` for memory usage. ([#590](https://github.com/awslabs/smithy/pull/590))
-* Optimized model validation event aggregation for memory usage. ([#595](https://github.com/awslabs/smithy/pull/595))
-
 ### Documentation
 
 * Clarified that `map` keys, `set` values, and `union` members cannot be null. ([#596](https://github.com/awslabs/smithy/pull/596/))
@@ -1758,8 +1737,10 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 * Improve and clean up formatting. ([#585](https://github.com/awslabs/smithy/pull/585), [#597](https://github.com/awslabs/smithy/pull/597),
   [#598](https://github.com/awslabs/smithy/pull/598))
 
-### Cleanup
+### Other
 
+* Optimized the reverse `NeighborProvider` for memory usage. ([#590](https://github.com/awslabs/smithy/pull/590))
+* Optimized model validation event aggregation for memory usage. ([#595](https://github.com/awslabs/smithy/pull/595))
 * Updated `service`, `resource`, and `operation` shapes to maintain the order of bound `resource` and `operation`
   shapes. ([#602](https://github.com/awslabs/smithy/pull/602))
 * Updated the `sources` build plugin to create an empty manifest if there are no source models. ([#607](https://github.com/awslabs/smithy/pull/607))
@@ -1803,7 +1784,7 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 * Fixed an issue where some `StringListTrait` instances could lose `SourceLocation` information. ([#564](https://github.com/awslabs/smithy/pull/564))
 * Fixed some issues in protocol tests. ([#560](https://github.com/awslabs/smithy/pull/560), [#563](https://github.com/awslabs/smithy/pull/563))
 
-### Cleanup
+### Other
 
 * Model components are now deduplicated based on location and value. ([#565](https://github.com/awslabs/smithy/pull/565))
 * Normalize URL import filenames for better deduplication and reporting. ([#562](https://github.com/awslabs/smithy/pull/562))
@@ -1843,7 +1824,7 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 * Fixed a bug where forward reference resolution would use the incorrect namespace when resolving operation and
   resource bindings. ([#543](https://github.com/awslabs/smithy/pull/543))
 
-### Cleanup
+### Other
 
 * Deprecated the reflection-based creation pattern for `KnowledgeIndex` implementations. ([#541](https://github.com/awslabs/smithy/pull/541))
 
@@ -1867,7 +1848,7 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 * Fixed the selector for the `@httpPrefixHeaders` trait. ([#533](https://github.com/awslabs/smithy/pull/533))
 * Fixed some issues in protocol tests. ([#526](https://github.com/awslabs/smithy/pull/526))
 
-### Cleanup
+### Other
 
 * Removed the `abbreviation` property from the `@aws.api#service` trait. ([#532](https://github.com/awslabs/smithy/pull/532))
 * Simplified prelude model loading. ([#524](https://github.com/awslabs/smithy/pull/524))
@@ -1886,7 +1867,7 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 
 * Fixed several issues in protocol tests. ([#502](https://github.com/awslabs/smithy/pull/502), [#507](https://github.com/awslabs/smithy/pull/507))
 
-### Cleanup
+### Other
 
 * Stopped raising validation errors and running validation with `RenameShapes` transformer. ([#512](https://github.com/awslabs/smithy/pull/512))
 * Simplified conflict handling for shapes. ([#514](https://github.com/awslabs/smithy/pull/514))
@@ -1918,7 +1899,7 @@ Made many improvements for Smithy 1.0 and 2.0 interoperability. ([1394](https://
 * Removed outdated namespace guidance. ([#487](https://github.com/awslabs/smithy/pull/487))
 * Fixed several minor issues. ([#494](https://github.com/awslabs/smithy/pull/494))
 
-### Cleanup
+### Other
 
 * Disallowed problematic identifiers misusing `_`. ([#499](https://github.com/awslabs/smithy/pull/499))
 * Moved validation of members with the `@httpLabel` trait being marked required to the selector. ([#480](https://github.com/awslabs/smithy/pull/480))
@@ -2147,8 +2128,6 @@ reference lookups. ([#287](https://github.com/awslabs/smithy/pull/287))
 
 ### Breaking changes
 
-All changes listed in this heading and any sub-headings are breaking changes.
-
 * The `BooleanTrait` abstract class in `smithy-model` was renamed `AnnotationTrait`. ([#381](https://github.com/awslabs/smithy/pull/381))
 * The traits in the `aws.apigateway` namespace have moved from `smithy-aws-traits` to the
 `smithy-aws-apigateway-traits` package for more granular use. ([#322](https://github.com/awslabs/smithy/pull/322))
@@ -2217,13 +2196,10 @@ complete redesign. Many direct links to components of the documentation will hav
 * Properly format test case results ([#271](https://github.com/awslabs/smithy/pull/271))
 * Fix dropping one character text block lines ([#285](https://github.com/awslabs/smithy/pull/285))
 
-### Optimizations
+### Other
 
 * Builds run parallel projections in parallel only if there are more than one ([#263](https://github.com/awslabs/smithy/pull/263))
 * Run Smithy test suites as parameterized tests ([#263](https://github.com/awslabs/smithy/pull/263))
-
-### Cleanup
-
 * Migrate protocol tests to new operation syntax ([#260](https://github.com/awslabs/smithy/pull/260))
 * Build protocol tests with the Smithy Gradle plugin ([#263](https://github.com/awslabs/smithy/pull/263))
 * Deprecate using explicitly `smithy.api` for trait removal ([#306](https://github.com/awslabs/smithy/pull/306))
@@ -2239,7 +2215,7 @@ complete redesign. Many direct links to components of the documentation will hav
   [#250](https://github.com/awslabs/smithy/pull/250), [#255](https://github.com/awslabs/smithy/pull/255),
   and [#258](https://github.com/awslabs/smithy/pull/258))
 
-### Optimizations
+### Other
 
 * Use URLConnection cache setting in ModelAssembler ([#244](https://github.com/awslabs/smithy/pull/244))
 
@@ -2265,7 +2241,7 @@ complete redesign. Many direct links to components of the documentation will hav
 * Added `BoxIndex` ([#234](https://github.com/awslabs/smithy/pull/234))
 * Added more expect methods to `Shape` and `Model` ([#237](https://github.com/awslabs/smithy/pull/237))
 
-### Optimizations
+### Other
 
 * Update smithy-build to be streaming ([#211](https://github.com/awslabs/smithy/pull/211))
 
@@ -2307,7 +2283,7 @@ complete redesign. Many direct links to components of the documentation will hav
 * Improve the usability of `CodeWroter#openBlock` ([#175](https://github.com/awslabs/smithy/pull/175))
 * Improve the usability of `PluginContext` ([#181](https://github.com/awslabs/smithy/pull/181))
 
-### Optimizations
+### Other
 
 * Disable URLConnection cache in CLI ([#180](https://github.com/awslabs/smithy/pull/180))
 


### PR DESCRIPTION
This cleans up the changelog, fixing some inconsistency issues and a few incorrect headings levels. The one section that was allowed to be special was the 1.0 release section. Major version bumps are in fact special enough.

These issues were discovered when attempting to backfill changes for the changelog tool.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
