### PR TITLE
Checkout base repo for changelog

### DIFF
--- a/.changes/tool/amend.py
+++ b/.changes/tool/amend.py
@@ -71,13 +71,20 @@ def amend(
 
 def get_new_changes(base: str | None) -> dict[Path, Change]:
     base = base or os.environ.get("GITHUB_BASE_REF", "main")
-    print(f"Running a diff against base branch: {base}")
-    result = subprocess.run(
-        f"git diff origin/{base} --name-only",
-        check=True,
-        shell=True,
-        capture_output=True,
-    )
+    print(f"Running a diff against base branch: `{base}`")
+
+    try:
+        result = subprocess.run(
+            f"git diff --name-only origin/{base}",
+            check=True,
+            shell=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"stdout: {e.stdout.decode("utf-8")}\n\nstderr: {e.stderr.decode("utf-i")}")
+        raise
+
+    print(f"Changed files:\n{result.stdout.decode("utf-8")}")
 
     new_changes: dict[Path, Change] = {}
     for changed_file in result.stdout.decode("utf-8").splitlines():

--- a/.github/workflows/changelog-ci.yml
+++ b/.github/workflows/changelog-ci.yml
@@ -7,9 +7,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-              with:
-                ref: ${{ github.head_ref }}
-                repository: ${{ github.event.pull_request.head.repo.full_name }}
 
             - uses: actions/setup-python@v5
               with:


### PR DESCRIPTION
The changelog tool was checking out the branch repo. This was done to enable pushing, but since the tool no longer pushes, it's not necessary.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
