### PR TITLE
fix: Convert blob default values to Base64

### DIFF
--- a/.changes/next-release/feature-f1decfa17cc23bd6a2718e7dddfeb8d5eb252163.json
+++ b/.changes/next-release/feature-f1decfa17cc23bd6a2718e7dddfeb8d5eb252163.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "fix: Convert blob default values to Base64",
+  "pull_requests": [
+    "[#2474](https://github.com/smithy-lang/smithy/issues/2474)"
+  ]
+}

--- a/smithy-aws-protocol-tests/model/awsJson1_0/defaults.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/defaults.smithy
@@ -417,7 +417,7 @@ structure DefaultsMixin {
     defaultDocumentList: Document = []
     defaultNullDocument: Document = null
     defaultTimestamp: Timestamp = 0
-    defaultBlob: Blob = "abc"
+    defaultBlob: Blob = "YWJj"
     defaultByte: Byte = 1
     defaultShort: Short = 1
     defaultInteger: Integer = 10

--- a/smithy-aws-protocol-tests/model/restJson1/defaults.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/defaults.smithy
@@ -418,7 +418,7 @@ structure DefaultsMixin {
     defaultDocumentList: Document = []
     defaultNullDocument: Document = null
     defaultTimestamp: Timestamp = 0
-    defaultBlob: Blob = "abc"
+    defaultBlob: Blob = "YWJj"
     defaultByte: Byte = 1
     defaultShort: Short = 1
     defaultInteger: Integer = 10


### PR DESCRIPTION
#### Background
Convert blob default values to Base64 in `awsJson1_0` & `restJson1` protocol tests.

#### Testing
* Generated to Swift SDK protocol tests.

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
