### PR TITLE
Update readme to use non-favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img alt="Smithy" src="docs/_static/favicon.svg" width="28"> Smithy
+# <img alt="Smithy" src="docs/_static/smithy-anvil.svg" width="32"> Smithy
 [![Build Status](https://github.com/smithy-lang/smithy/workflows/ci/badge.svg)](https://github.com/smithy-lang/smithy/actions/workflows/ci.yml)
 
 Smithy defines and generates clients, services, and documentation for

--- a/docs/_static/smithy-anvil.svg
+++ b/docs/_static/smithy-anvil.svg
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 51.82"><defs><style>.cls-1{fill:#df231d;}</style></defs><path class="cls-1" d="M82,51.82s0,0,0,0H16.3s0,0,0,0v-7.53l19.23-8.99s0,0,0,0v-6.44L0,11.8V0s0,0,0,0h69.03v35.29l12.97,16.53ZM100,4.08h-24.45v24.77l24.45-24.77Z"/></svg>


### PR DESCRIPTION
#### Background
Updates readme to use anvil svg directly rather than anvil favicon as it looks a little better in a header.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
