### PR TITLE
Fix unique smoke test id validation

### DIFF
--- a/.changes/next-release/bugfix-a4eb4361f200aabca46d06a5985bbd4ccc1fc60c.json
+++ b/.changes/next-release/bugfix-a4eb4361f200aabca46d06a5985bbd4ccc1fc60c.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Fixed a bug in smoke test validation where test case ids weren't checked for uniqueness if their operations were bound to a resource shape",
+  "pull_requests": [
+    "[#2482](https://github.com/smithy-lang/smithy/issues/2482)"
+  ]
+}

--- a/smithy-smoke-test-traits/src/test/resources/software/amazon/smithy/smoketests/traits/errorfiles/duplicate-ids.errors
+++ b/smithy-smoke-test-traits/src/test/resources/software/amazon/smithy/smoketests/traits/errorfiles/duplicate-ids.errors
@@ -1,3 +1,5 @@
 [ERROR] smithy.example#SayHello: Conflicting `smithy.test#smokeTests` test case IDs found for ID `say_hello`: `smithy.example#SayHello`, `smithy.example#SayHello`, `smithy.example#SayHello2` | UniqueSmokeTestCaseId
 [ERROR] smithy.example#SayHello2: Conflicting `smithy.test#smokeTests` test case IDs found for ID `say_hello`: `smithy.example#SayHello`, `smithy.example#SayHello`, `smithy.example#SayHello2` | UniqueSmokeTestCaseId
 [ERROR] smithy.example#SayHello3: Conflicting `smithy.test#smokeTests` test case IDs found for ID `say_hello`: `smithy.example#SayHello3`, `smithy.example#SayHello3` | UniqueSmokeTestCaseId
+[ERROR] smithy.example#SayHello6: Conflicting `smithy.test#smokeTests` test case IDs found for ID `not_say_hello`: `smithy.example#SayHello6`, `smithy.example#SayHello7` | UniqueSmokeTestCaseId
+[ERROR] smithy.example#SayHello7: Conflicting `smithy.test#smokeTests` test case IDs found for ID `not_say_hello`: `smithy.example#SayHello6`, `smithy.example#SayHello7` | UniqueSmokeTestCaseId

--- a/smithy-smoke-test-traits/src/test/resources/software/amazon/smithy/smoketests/traits/errorfiles/duplicate-ids.smithy
+++ b/smithy-smoke-test-traits/src/test/resources/software/amazon/smithy/smoketests/traits/errorfiles/duplicate-ids.smithy
@@ -94,7 +94,8 @@ operation SayHello4 {
 
 service OtherSayStuff {
     version: "2023-10-11"
-    operations: [SayHello5]
+    operations: [SayHello5, SayHello6]
+    resources: [SayHelloResource]
 }
 
 // Shouldn't conflict between services
@@ -110,4 +111,36 @@ service OtherSayStuff {
 operation SayHello5 {
    input := {}
    output := {}
+}
+
+@smokeTests([
+    {
+        id: "not_say_hello" // Conflicts with resource bound operation
+        params: {}
+        expect: {
+            success: {}
+        }
+    }
+])
+operation SayHello6 {
+    input := {}
+    output := {}
+}
+
+resource SayHelloResource {
+    operations: [SayHello7]
+}
+
+@smokeTests([
+    {
+        id: "not_say_hello"
+        params: {}
+        expect: {
+            success: {}
+        }
+    }
+])
+operation SayHello7 {
+    input := {}
+    output := {}
 }


### PR DESCRIPTION
The validator is supposed that all smoke test case ids are unique within a service's closure, but it was only checking operations directly bound to the service shape.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
