### PR TITLE
Adding missing getters to ResourceSchema

### DIFF
--- a/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/model/ResourceSchema.java
+++ b/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/model/ResourceSchema.java
@@ -199,6 +199,10 @@ public final class ResourceSchema implements ToNode, ToSmithyBuilder<ResourceSch
         return properties;
     }
 
+    public Set<String> getRequired() {
+        return required;
+    }
+
     public Set<String> getReadOnlyProperties() {
         return readOnlyProperties;
     }
@@ -233,6 +237,10 @@ public final class ResourceSchema implements ToNode, ToSmithyBuilder<ResourceSch
 
     public Tagging getTagging() {
         return tagging;
+    }
+
+    public Schema getAdditionalProperties() {
+        return additionalProperties;
     }
 
     public static final class Builder implements SmithyBuilder<ResourceSchema> {


### PR DESCRIPTION
#### Background
* When trying to get the `required` field from a CFN resourceSchema, I realized that the `required` and `additionalProperties` field do not have a getter making it impossible to retrieve the `required` field in CFN ResourceSchema via the ResourceSchema model.

#### Testing
* `gradle build`


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
