### PR TITLE
Require JDK17+ for development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,15 @@ jobs:
           distribution: 'corretto'
 
       - name: Clean, build, test, and javadoc
-        run: ./gradlew clean build javadoc -PresolveImageJre -Plog-tests --stacktrace
+        run: ./gradlew clean build javadoc -Plog-tests --stacktrace
 
       - name: Allow long file names in git for windows
         if: matrix.os == 'windows-latest'
         run: git config --system core.longpaths true
 
       - name: Integration tests
-        run: ./gradlew integ -PresolveImageJre -Plog-tests --stacktrace
+        if: matrix.java == 17
+        run: ./gradlew integ -Plog-tests --stacktrace
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Java ${{ matrix.java }} ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11, 17, 21]
+        java: [17, 21]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
@@ -33,8 +33,7 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Integration tests
-        if: matrix.java == 17
-        run: ./gradlew integ -Plog-tests --stacktrace
+        run: ./gradlew integ -PresolveImageJre -Plog-tests --stacktrace
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           distribution: 'corretto'
 
       - name: Clean, build, test, and javadoc
-        run: ./gradlew clean build javadoc -Plog-tests --stacktrace
+        run: ./gradlew clean build javadoc -PresolveImageJre -Plog-tests --stacktrace
 
       - name: Allow long file names in git for windows
         if: matrix.os == 'windows-latest'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,11 @@ Please read through this document before submitting any issues or pull requests 
 information to effectively respond to your bug report or contribution.
 
 
+## Building the Project
+
+Building this project **requires having a JDK17+ installation**. However, for the time being, most modules will still 
+produce artifacts targeting JDK8, unless explicitly noted otherwise. 
+
 ## Reporting Bugs/Feature Requests
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,14 @@ plugins {
 val libraryVersion = project.file("VERSION").readText().trim()
 println("Smithy version: '$libraryVersion'")
 
+// Verify Java version is 17+
+// Since most plugins are not toolchain-aware, we can't rely on gradle toolchains, which means we'll have to enforce
+// that the global java version (i.e. whatever JAVA_HOME is set to and what Gradle uses) is set to 17+
+val javaVersion = JavaVersion.current()
+check(javaVersion.isCompatibleWith(JavaVersion.VERSION_17)) {
+    "Building this project requires Java 17 or later. You are currently running Java ${javaVersion.majorVersion}."
+}
+
 allprojects {
     group = "software.amazon.smithy"
     version = libraryVersion
@@ -40,11 +48,6 @@ afterEvaluate {
             classpath = files(subprojects.map { project(it.path).sourceSets.main.get().compileClasspath })
             (options as StandardJavadocDocletOptions).apply {
                 addStringOption("Xdoclint:-html", "-quiet")
-                // Fixed in JDK 12: https://bugs.openjdk.java.net/browse/JDK-8215291
-                // --no-module-directories does not exist in JDK 8 and is removed in 13
-                if (JavaVersion.current().run { isJava9 || isJava10 || isJava11 }) {
-                    addBooleanOption("-no-module-directories", true)
-                }
             }
         }
     }

--- a/smithy-cli/build.gradle.kts
+++ b/smithy-cli/build.gradle.kts
@@ -25,14 +25,7 @@ description = "This module implements the Smithy command line interface."
 extra["displayName"] = "Smithy :: CLI"
 extra["moduleName"] = "software.amazon.smithy.cli"
 
-// If `resolveImageJre` is set, detect the current JVM version and use the same version for generating the runtime
-// This is mainly used in CI to generate a valid runtime image for integration tests
-val imageJreVersion = if (project.hasProperty("resolveImageJre")) {
-    JavaVersion.current().majorVersion
-} else {
-    // Otherwise, just use 17
-    "17"
-}
+val imageJreVersion = "17"
 val correttoRoot = "https://corretto.aws/downloads/latest/amazon-corretto-$imageJreVersion"
 
 dependencies {
@@ -146,6 +139,13 @@ runtime {
 
     // Because we're using target-platforms, it will use this property as a prefix for each target zip
     imageZip = layout.buildDirectory.file("image/smithy-cli.zip")
+
+    // This is needed to ensure that jlink is available (jlink is Java 9+), we should use the JDK that
+    // is configured for the runtime
+    // NOTE: For the runtime task, you *must* have the right JDK set up in your environment (17 at the time of writing)
+    javaHome = javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(imageJreVersion))
+    }.map { it.metadata.installationPath.asFile.path }
 }
 
 tasks {

--- a/smithy-cli/build.gradle.kts
+++ b/smithy-cli/build.gradle.kts
@@ -25,7 +25,14 @@ description = "This module implements the Smithy command line interface."
 extra["displayName"] = "Smithy :: CLI"
 extra["moduleName"] = "software.amazon.smithy.cli"
 
-val imageJreVersion = "17"
+// If `resolveImageJre` is set, detect the current JVM version and use the same version for generating the runtime
+// This is mainly used in CI to generate a valid runtime image for integration tests
+val imageJreVersion = if (project.hasProperty("resolveImageJre")) {
+    JavaVersion.current().majorVersion
+} else {
+    // Otherwise, just use 17
+    "17"
+}
 val correttoRoot = "https://corretto.aws/downloads/latest/amazon-corretto-$imageJreVersion"
 
 dependencies {
@@ -139,13 +146,6 @@ runtime {
 
     // Because we're using target-platforms, it will use this property as a prefix for each target zip
     imageZip = layout.buildDirectory.file("image/smithy-cli.zip")
-
-    // This is needed to ensure that jlink is available (jlink is Java 9+), we should use the JDK that
-    // is configured for the runtime
-    // NOTE: For the runtime task, you *must* have the right JDK set up in your environment (17 at the time of writing)
-    javaHome = javaToolchains.launcherFor {
-        languageVersion.set(JavaLanguageVersion.of(imageJreVersion))
-    }.map { it.metadata.installationPath.asFile.path }
 }
 
 tasks {


### PR DESCRIPTION
#### Background
- Given JDK8 is largely being moved away from, this is a good first step in that direction
- However, for backwards compatibility, we will still target 8 for all current modules
  - This means **existing modules cannot use newer features**, but new modules (like docgen) *can* use newer language versions
  - Speaking _optimistically_, some day we can remove explicit compatibility and just rely on the toolchain

#### Testing
- `./gradlew clean build integ publish`
- Set global Java to <17, and run again, does not build and shows error

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
