### PR TITLE
Setup Java 17 to generate the docs

### DIFF
--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -20,6 +20,12 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
+    - name: Setup Java 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: 'corretto'
+
     - name: Checkout repo 
       uses: actions/checkout@v4
     - name: Setup


### PR DESCRIPTION
#### Background

The build docs workflow is failing with

```
* What went wrong:
Building this project requires Java 17 or later. You are currently running Java 11.
```

This change configures the Java version to use 17.

#### Testing

Validated using [`action-validator`](https://github.com/mpalmer/action-validator).

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
