### PR TITLE
Add support for json schema oneOf enumStrategy

### DIFF
--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
@@ -85,11 +85,42 @@ public class JsonSchemaConfig {
         }
     }
 
+    /**
+     * Configures how Smithy enum shapes are converted to JSON Schema
+     */
+    public enum EnumStrategy {
+
+        /**
+         * Converts to a schema that uses enum, which contains an array of strings
+         *
+         * <p>This is the default setting used if not configured.
+         */
+        ENUM("enum"),
+
+        /**
+         * Converts to a schema that uses oneOf, with an array of const strings and optional
+         * descriptions for documentation purposes
+         */
+        ONE_OF("oneOf");
+
+        private final String stringValue;
+
+        EnumStrategy(String stringValue) {
+            this.stringValue = stringValue;
+        }
+
+        @Override
+        public String toString() {
+            return stringValue;
+        }
+    }
+
     private boolean alphanumericOnlyRefs;
     private boolean useJsonName;
     private TimestampFormatTrait.Format defaultTimestampFormat = TimestampFormatTrait.Format.DATE_TIME;
     private UnionStrategy unionStrategy = UnionStrategy.ONE_OF;
     private MapStrategy mapStrategy = MapStrategy.PROPERTY_NAMES;
+    private EnumStrategy enumStrategy = EnumStrategy.ENUM;
     private String definitionPointer;
     private ObjectNode schemaDocumentExtensions = Node.objectNode();
     private ObjectNode extensions = Node.objectNode();
@@ -184,6 +215,18 @@ public class JsonSchemaConfig {
      */
     public void setMapStrategy(MapStrategy mapStrategy) {
         this.mapStrategy = mapStrategy;
+    }
+
+    public EnumStrategy getEnumStrategy() {
+        return enumStrategy;
+    }
+
+    /**
+     * Configures how Smithy enum shapes ae converted to JSON Schema
+     * @param enumStrategy The enum strategy to use
+     */
+    public void setEnumStrategy(EnumStrategy enumStrategy) {
+        this.enumStrategy = enumStrategy;
     }
 
     public String getDefinitionPointer() {

--- a/smithy-jsonschema/src/test/java/software/amazon/smithy/jsonschema/JsonSchemaConverterTest.java
+++ b/smithy-jsonschema/src/test/java/software/amazon/smithy/jsonschema/JsonSchemaConverterTest.java
@@ -818,6 +818,43 @@ public class JsonSchemaConverterTest {
     }
 
     @Test
+    public void supportsDefaultEnumStrategy() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("string-enums.smithy"))
+                .assemble()
+                .unwrap();
+
+        SchemaDocument document = JsonSchemaConverter.builder()
+                .model(model)
+                .build()
+                .convert();
+
+        Node expected = Node.parse(
+                IoUtils.toUtf8String(getClass().getResourceAsStream("string-enums.jsonschema.v07.json")));
+        Node.assertEquals(document.toNode(), expected);
+    }
+
+    @Test
+    public void supportsOneOfEnumStrategy() {
+        Model model = Model.assembler()
+                .addImport(getClass().getResource("string-enums.smithy"))
+                .assemble()
+                .unwrap();
+
+        JsonSchemaConfig config = new JsonSchemaConfig();
+        config.setEnumStrategy(JsonSchemaConfig.EnumStrategy.ONE_OF);
+        SchemaDocument document = JsonSchemaConverter.builder()
+                .model(model)
+                .config(config)
+                .build()
+                .convert();
+
+        Node expected = Node.parse(
+                IoUtils.toUtf8String(getClass().getResourceAsStream("string-enums-one-of.jsonschema.v07.json")));
+        Node.assertEquals(document.toNode(), expected);
+    }
+
+    @Test
     public void intEnumsCanBeDisabled() {
         Model model = Model.assembler()
                 .addImport(getClass().getResource("int-enums.smithy"))

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/string-enums-one-of.jsonschema.v07.json
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/string-enums-one-of.jsonschema.v07.json
@@ -1,0 +1,25 @@
+{
+  "definitions": {
+    "Foo": {
+      "type": "object",
+      "properties": {
+        "bar": {
+          "$ref": "#/definitions/TestEnum"
+        }
+      }
+    },
+    "TestEnum": {
+      "type": "string",
+      "description": "This is a test enum",
+      "oneOf": [
+        {
+          "const": "Foo",
+          "description": "it really does foo"
+        },
+        {
+          "const": "Bar"
+        }
+      ]
+    }
+  }
+}

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/string-enums.jsonschema.v07.json
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/string-enums.jsonschema.v07.json
@@ -1,0 +1,20 @@
+{
+    "definitions": {
+        "Foo": {
+            "type": "object",
+            "properties": {
+                "bar": {
+                    "$ref": "#/definitions/TestEnum"
+                }
+            }
+        },
+        "TestEnum": {
+            "type": "string",
+            "enum": [
+                "Foo",
+                "Bar"
+            ],
+            "description": "This is a test enum"
+        }
+    }
+}

--- a/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/string-enums.smithy
+++ b/smithy-jsonschema/src/test/resources/software/amazon/smithy/jsonschema/string-enums.smithy
@@ -1,0 +1,14 @@
+$version: "2.0"
+
+namespace smithy.example
+
+structure Foo {
+    bar: TestEnum
+}
+
+@documentation("This is a test enum")
+enum TestEnum {
+    @documentation("it really does foo")
+    FOO = "Foo"
+    BAR = "Bar"
+}


### PR DESCRIPTION
#### Background
* What do these changes do? 

This adds support for a new json schema setting, `enumStrategy`, that allows for variants `enum` (current behaviour, and default) and `oneOf` (gets converted to a oneOf with const string values, allowing for documentation of individual enum variants.)

I'm new to this codebase, let me know if there are other considerations I may have missed here

* Why are they important?

Allows for documentation on enum variants in an open-api schema for example.  The current behaviour (which will remain the default), doesn't allow documentation at the variant level

#### Testing
* How did you test these changes?

Added unit test cases to `JsonSchemaConverterTest`.

ran `./gradlew build`

#### Links
* Links to additional context, if necessary

For: #2481

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
