### PR TITLE
Fixing documentation of cfnDefaultValue trait selector to match as defined in code.

### DIFF
--- a/docs/source-2.0/aws/aws-cloudformation.rst
+++ b/docs/source-2.0/aws/aws-cloudformation.rst
@@ -661,16 +661,16 @@ The following example defines a CloudFormation resource that has the
 Summary
     Indicates that the member annotated has a default value
     for that property of the CloudFormation resource. Thus,
-    when this trait annotates an ``@output`` structure member,
+    when this trait annotates an ``@input`` or ``@output`` structure member,
     it indicates that the CloudFormation property generated
     from that member has a default value in the CloudFormation
     schema. This trait can be used to indicate that an output
     field with a value may return a default value assigned
     by the service.
 Trait selector
-    ``resource > operation -[output]-> structure > member``
+    ``resource > operation -[input, output]-> structure > member``
 
-    *Only applicable to members of @output operations*
+    *Only applicable to members of @input or @output operations*
 Value type
     Annotation trait
 


### PR DESCRIPTION



#### Background
* What do these changes do? 
    * Updating documentation to correctly reflect the selector used for @cfnDefaultValue trait in code.

#### Testing
No need to test. Document update.

#### Links
* The code for @cfnDefaultValue defined [here](https://github.com/smithy-lang/smithy/blob/58753d00ba7a5c7d1ad69b6c510d8624cd0304b0/smithy-aws-cloudformation-traits/src/main/resources/META-INF/smithy/aws.cloudformation.smithy#L42) uses  a selector different than defined on our website: https://smithy.io/2.0/aws/aws-cloudformation.html#aws-cloudformation-cfndefaultvalue-trait


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
