### PR TITLE
Fix issues in mixin examples

### DIFF
--- a/docs/source-2.0/spec/mixins.rst
+++ b/docs/source-2.0/spec/mixins.rst
@@ -492,7 +492,13 @@ example, in the following model:
 
 .. code-block:: smithy
 
-    operation OperationA {}
+    operation OperationA {
+        input: OperationAInput
+        output: OperationAOutput
+    }
+
+    structure OperationAInput {}
+    structure OperationAOutput {}
 
     @mixin
     service A {
@@ -500,14 +506,18 @@ example, in the following model:
         operations: [OperationA]
     }
 
-    operation OperationB {}
+    operation OperationB {
+        input: OperationBInput
+    }
+
+    structure OperationBInput {}
 
     @mixin
     service B with [A] {
         version: "B"
         rename: {
-            "smithy.example#OperationA": "OperA"
-            "smithy.example#OperationB": "OperB"
+            "smithy.example#OperationAInput": "OperationARequest"
+            "smithy.example#OperationAOutput": "OperationAResult"
         }
         operations: [OperationB]
     }
@@ -517,8 +527,8 @@ example, in the following model:
     service C with [B] {
         version: "C"
         rename: {
-            "smithy.example#OperationA": "OpA"
-            "smithy.example#OperationC": "OpC"
+            "smithy.example#OperationAOutput": "OperationAResponse"
+            "smithy.example#OperationBInput": "OperationBRequest"
         }
         operations: [OperationC]
     }
@@ -527,18 +537,28 @@ The flattened equivalent of ``C`` with no mixins is:
 
 .. code-block:: smithy
 
-    operation OperationA {}
+    operation OperationA {
+        input: OperationAInput
+        output: OperationAOutput
+    }
 
-    operation OperationB {}
+    structure OperationAInput {}
+    structure OperationAOutput {}
+
+    operation OperationB {
+        input: OperationBInput
+    }
+
+    structure OperationBInput {}
 
     operation OperationC {}
 
     service C {
         version: "C"
         rename: {
-            "smithy.example#OperationA": "OpA"
-            "smithy.example#OperationB": "OperB"
-            "smithy.example#OperationC": "OpC"
+            "smithy.example#OperationAInput": "OperationARequest"
+            "smithy.example#OperationAOutput": "OperationAResponse"
+            "smithy.example#OperationBInput": "OperationBRequest"
         }
         operations: [OperationA, OperationB, OperationC]
     }
@@ -588,7 +608,7 @@ Operation shapes with the :ref:`mixin-trait` MAY define errors.
         output := {
             name: String
         }
-        error: [NotFoundError]
+        errors: [NotFoundError]
     }
 
     @error("client")


### PR DESCRIPTION
This commit updates the service example to use renames for shapes that are not operations, as that is invalid. It also fixes a typo in the operation mixin example.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
