### PR TITLE
Expand allowed tagging arn member names

### DIFF
--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/tagging/TaggingShapeUtilsTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/tagging/TaggingShapeUtilsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.aws.traits.tagging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.smithy.utils.ListUtils;
+
+public class TaggingShapeUtilsTest {
+    public static List<Arguments> arnMembers() {
+        return ListUtils.of(
+                Arguments.of("", false),
+                Arguments.of("foo", false),
+                Arguments.of("fooArn", false),
+                Arguments.of("resourceFoo", false),
+                Arguments.of("arnResource", false),
+                Arguments.of("resourceResourceArn", false),
+                Arguments.of("resourceArnARN", false),
+                Arguments.of("resourceArn", true),
+                Arguments.of("resource", true),
+                Arguments.of("Resource", true),
+                Arguments.of("arn", true),
+                Arguments.of("Arn", true),
+                Arguments.of("ARN", true),
+                Arguments.of("ResourceARN", true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("arnMembers")
+    public void isArnMemberDesiredName(String arnMember, boolean expected) {
+        assertEquals(expected, TaggingShapeUtils.isArnMemberDesiredName(arnMember));
+    }
+}


### PR DESCRIPTION
Allows for the resource name component, the arn name component, or both name components to be specified. Empty names, non-matching names, or names that have repeat components will fail.

Other minor interface cleanup is included.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
