### PR TITLE
Return an empty collection instead of null

### DIFF
--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/GetterGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/GetterGenerator.java
@@ -143,10 +143,10 @@ final class GetterGenerator implements Runnable {
                                 "}",
                                 symbolProvider.toSymbol(member),
                                 symbolProvider.toMemberName(member),
-                                () -> writer.write("return $1L == null ? $2T.empty$3L() : $1L;",
+                                () -> writer.write("return $1L == null ? $2T.$3L() : $1L;",
                                         symbolProvider.toMemberName(member),
                                         Collections.class,
-                                        isListShape ? "List" : "Map"));
+                                        isListShape ? "emptyList" : "emptyMap"));
                     }
                 } else {
                     writer.openBlock("public $T get$U() {",

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/GetterGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/GetterGenerator.java
@@ -4,6 +4,7 @@
  */
 package software.amazon.smithy.traitcodegen.generators;
 
+import java.util.Collections;
 import java.util.Optional;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
@@ -136,12 +137,16 @@ final class GetterGenerator implements Runnable {
                     // If the member targets a collection shape and is optional then generate an unwrapped
                     // getter as a convenience method as well.
                     Shape target = model.expectShape(member.getTarget());
-                    if (target.isListShape() || target.isMapShape()) {
+                    boolean isListShape = target.isListShape();
+                    if (isListShape || target.isMapShape()) {
                         writer.openBlock("public $T get$UOrEmpty() {",
                                 "}",
                                 symbolProvider.toSymbol(member),
                                 symbolProvider.toMemberName(member),
-                                () -> writer.write("return $L;", symbolProvider.toMemberName(member)));
+                                () -> writer.write("return $1L == null ? $2T.empty$3L() : $1L;",
+                                        symbolProvider.toMemberName(member),
+                                        Collections.class,
+                                        isListShape ? "List" : "Map"));
                     }
                 } else {
                     writer.openBlock("public $T get$U() {",


### PR DESCRIPTION
#### Background

The method `get<MemberName>OrEmpty()` for collections, either lists or maps, was supposed to return an empty collection when the collection was not set, instead of null, but somehow we missed to add this expected behavior. This change fixes this, if the collection was not set we return either `Collections.emptyList()` or
`Collections.emptyMap()` depending on the collection type instead of `null`. The user can still find whether the value was set by using the `Optional<...> get<MemberName>()` variant that returns en empty optional when the collection was not set.

#### Testing

Validated the generated code. We don't currently have asserts for the generated code but only tests that asserts that everything compiles as expected. Asserting on the expected generated code would be good but can be added in a different change.

For the `structure` trait in the tests now the code generated look like this for the members `fieldD` and `fieldE`.

```java
    public Optional<List<String>> getFieldD() {
        return Optional.ofNullable(fieldD);
    }

    public List<String> getFieldDOrEmpty() {
        return fieldD == null ? Collections.emptyList() : fieldD;
    }

    public Optional<Map<String, String>> getFieldE() {
        return Optional.ofNullable(fieldE);
    }

    public Map<String, String> getFieldEOrEmpty() {
        return fieldE == null ? Collections.emptyMap() : fieldE;
    }
```

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
