### PR TITLE
Don't make oneOf errors tagged unions

### DIFF
--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/error-code-collision-test-use-oneof.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/error-code-collision-test-use-oneof.openapi.json
@@ -154,104 +154,32 @@
       "GetCurrentTime404ErrorResponseContent": {
         "oneOf": [
           {
-            "type": "object",
-            "title": "Error7",
-            "properties": {
-              "Error7": {
-                "$ref": "#/components/schemas/Error7"
-              }
-            },
-            "required": [
-              "Error7"
-            ]
+            "$ref": "#/components/schemas/Error7"
           },
           {
-            "type": "object",
-            "title": "Error8",
-            "properties": {
-              "Error8": {
-                "$ref": "#/components/schemas/Error8"
-              }
-            },
-            "required": [
-              "Error8"
-            ]
+            "$ref": "#/components/schemas/Error8"
           }
         ]
       },
       "GetCurrentTime429ErrorResponseContent": {
         "oneOf": [
           {
-            "type": "object",
-            "title": "Error1",
-            "properties": {
-              "Error1": {
-                "$ref": "#/components/schemas/Error1"
-              }
-            },
-            "required": [
-              "Error1"
-            ]
+            "$ref": "#/components/schemas/Error1"
           },
           {
-            "type": "object",
-            "title": "Error2",
-            "properties": {
-              "Error2": {
-                "$ref": "#/components/schemas/Error2"
-              }
-            },
-            "required": [
-              "Error2"
-            ]
+            "$ref": "#/components/schemas/Error2"
           },
           {
-            "type": "object",
-            "title": "Error3",
-            "properties": {
-              "Error3": {
-                "$ref": "#/components/schemas/Error3"
-              }
-            },
-            "required": [
-              "Error3"
-            ]
+            "$ref": "#/components/schemas/Error3"
           },
           {
-            "type": "object",
-            "title": "Error4",
-            "properties": {
-              "Error4": {
-                "$ref": "#/components/schemas/Error4"
-              }
-            },
-            "required": [
-              "Error4"
-            ]
+            "$ref": "#/components/schemas/Error4"
           },
           {
-            "type": "object",
-            "title": "Error5",
-            "properties": {
-              "Error5": {
-                "$ref": "#/components/schemas/Error5"
-              }
-            },
-            "required": [
-              "Error5"
-            ]
+            "$ref": "#/components/schemas/Error5"
           },
           {
-            "type": "object",
-            "title": "Error6",
-            "properties": {
-              "Error6": {
-                "$ref": "#/components/schemas/Error6"
-              }
-            },
-            "required": [
-              "Error6"
-            ]
+            "$ref": "#/components/schemas/Error6"
           }
         ]
       },


### PR DESCRIPTION
OpenAPI only lets you have one error per HTTP response code. This is a problem when converting things because Smithy has no such limitation. To address that, we added a toggle that lets you disambiguate by making the body contents a `oneOf`, which is an untagged union. The problem is that we made this a tagged union by leaning on how Smithy converts Smithy's union shape, which is tagged.

To illustrate the problem, the OpenAPI modeled body technically now declares the following body valid:

```json
{
    "Error1" {
        "foo": "bar"
    }
}
```

But the model for the structure is:

```
@error("client")
@httpError(400)
structure Error1 {
    foo: String
}
```

And an actual valid body would be:

```json
{
    "foo": "bar"
}
```

This commit turns the OpenAPI body into an untagged union instead, which is how it should be.

The question is: is this a backwards compatibility concern somehow? I think not, but maybe it should be a new flag?

Resolves #2512

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
