### PR TITLE
Add explicit junit launcher dependency

### DIFF
--- a/buildSrc/src/main/kotlin/smithy.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy.java-conventions.gradle.kts
@@ -85,6 +85,7 @@ tasks {
 dependencies {
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(libs.junit.jupiter.params)
     testImplementation(libs.hamcrest)
     testCompileOnly(libs.apiguardian.api)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ junit-bom = { module = "org.junit:junit-bom", version.ref = "junit5" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 mockserver = { module = "org.mock-server:mockserver-netty", version.ref = "mockserver" }


### PR DESCRIPTION
This is needed as of gradle 8, but has incidentally kept working. Without this, a bump to JUnit 5.12 will fail though (see https://github.com/smithy-lang/smithy-python/pull/388)

see: https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#test_framework_implementation_dependencies

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
