### PR TITLE
Skip serializing default boolean values

### DIFF
--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeyDefinition.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeyDefinition.java
@@ -112,13 +112,15 @@ public final class ConditionKeyDefinition implements ToNode, ToSmithyBuilder<Con
 
     @Override
     public Node toNode() {
-        return Node.objectNodeBuilder()
+        ObjectNode.Builder builder = ObjectNode.builder()
                 .withMember(TYPE, Node.from(type))
                 .withOptionalMember(DOCUMENTATION, getDocumentation().map(Node::from))
                 .withOptionalMember(EXTERNAL_DOCUMENTATION, getExternalDocumentation().map(Node::from))
-                .withOptionalMember(RELATIVE_DOCUMENTATION, getRelativeDocumentation().map(Node::from))
-                .withMember(REQUIRED, isRequired())
-                .build();
+                .withOptionalMember(RELATIVE_DOCUMENTATION, getRelativeDocumentation().map(Node::from));
+        if (required) {
+            builder.withMember(REQUIRED, true);
+        }
+        return builder.build();
     }
 
     @Override

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/IamResourceTrait.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/IamResourceTrait.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.aws.iam.traits;
 import java.util.Optional;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.NodeMapper;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
@@ -85,10 +86,14 @@ public final class IamResourceTrait extends AbstractTrait
 
     @Override
     protected Node createNode() {
-        NodeMapper mapper = new NodeMapper();
-        mapper.disableToNodeForClass(IamResourceTrait.class);
-        mapper.setOmitEmptyValues(true);
-        return mapper.serialize(this).expectObjectNode();
+        ObjectNode.Builder builder = ObjectNode.builder()
+                .sourceLocation(getSourceLocation())
+                .withOptionalMember("name", getName().map(Node::from))
+                .withOptionalMember("relativeDocumentation", getRelativeDocumentation().map(Node::from));
+        if (disableConditionKeyInheritance) {
+            builder.withMember("disableConditionKeyInheritance", true);
+        }
+        return builder.build();
     }
 
     @Override

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnTrait.java
@@ -149,15 +149,23 @@ public final class ArnTrait extends AbstractTrait implements ToSmithyBuilder<Arn
 
     @Override
     protected Node createNode() {
-        return Node.objectNodeBuilder()
+        ObjectNode.Builder builder = ObjectNode.builder()
                 .sourceLocation(getSourceLocation())
                 .withMember(TEMPLATE, Node.from(getTemplate()))
-                .withMember(ABSOLUTE, Node.from(isAbsolute()))
-                .withMember(NO_ACCOUNT, Node.from(isNoAccount()))
-                .withMember(NO_REGION, Node.from(isNoRegion()))
-                .withOptionalMember(RESOURCE_DELIMITER, getResourceDelimiter())
-                .withMember(REUSABLE, Node.from(isReusable()))
-                .build();
+                .withOptionalMember(RESOURCE_DELIMITER, getResourceDelimiter());
+        if (absolute) {
+            builder.withMember(ABSOLUTE, true);
+        }
+        if (noRegion) {
+            builder.withMember(NO_REGION, true);
+        }
+        if (noAccount) {
+            builder.withMember(NO_ACCOUNT, true);
+        }
+        if (reusable) {
+            builder.withMember(REUSABLE, true);
+        }
+        return builder.build();
     }
 
     @Override

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TagEnabledTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TagEnabledTrait.java
@@ -10,7 +10,6 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.TraitService;
-import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -28,8 +27,12 @@ public final class TagEnabledTrait extends AbstractTrait implements ToSmithyBuil
 
     @Override
     protected Node createNode() {
-        return new ObjectNode(MapUtils.of(), getSourceLocation())
-                .withMember("disableDefaultOperations", getDisableDefaultOperations());
+        ObjectNode.Builder builder = ObjectNode.builder()
+                .sourceLocation(getSourceLocation());
+        if (disableDefaultOperations) {
+            builder.withMember("disableDefaultOperations", true);
+        }
+        return builder.build();
     }
 
     public boolean getDisableDefaultOperations() {

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TaggableTrait.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TaggableTrait.java
@@ -11,7 +11,6 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.TraitService;
-import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -59,10 +58,14 @@ public final class TaggableTrait extends AbstractTrait implements ToSmithyBuilde
 
     @Override
     protected Node createNode() {
-        return new ObjectNode(MapUtils.of(), getSourceLocation())
+        ObjectNode.Builder builder = ObjectNode.builder()
+                .sourceLocation(getSourceLocation())
                 .withOptionalMember("property", getProperty().map(Node::from))
-                .withOptionalMember("apiConfig", getApiConfig().map(TaggableApiConfig::toNode))
-                .withMember("disableSystemTags", getDisableSystemTags());
+                .withOptionalMember("apiConfig", getApiConfig().map(TaggableApiConfig::toNode));
+        if (disableSystemTags) {
+            builder.withMember("disableSystemTags", true);
+        }
+        return builder.build();
     }
 
     public static Builder builder() {


### PR DESCRIPTION
This makes IDL serialization a lot cleaner. For example, setting a simple `@arn` trait with only a template:

```
 @arn(
    template: "foo:{fooId}"
)
```

and passing reserializing it through the `SmithyIdlModelSerializer` would then output:

```
 @arn(
    template: "foo:{fooId}"
    absolute: false
    noAccount: false
    noRegion: false
    reusable: false
)
```

This only changes some of the AWS traits for now, but could potentially expand to more traits.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
