### PR TITLE
Prefer ID for hasTrait lookups

### DIFF
--- a/buildSrc/src/main/kotlin/smithy.profiling-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy.profiling-conventions.gradle.kts
@@ -11,3 +11,8 @@ tasks {
         duplicatesStrategy = DuplicatesStrategy.WARN
     }
 }
+
+// We don't need to lint benchmarks.
+tasks.findByName("spotbugsJmh")?.apply {
+    enabled = false
+}

--- a/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddRequestValidators.java
+++ b/smithy-aws-apigateway-openapi/src/main/java/software/amazon/smithy/aws/apigateway/openapi/AddRequestValidators.java
@@ -77,8 +77,8 @@ final class AddRequestValidators implements ApiGatewayMapper {
 
         // Check if the service has a request validator.
         String serviceValidator = null;
-        if (context.getService().getTrait(RequestValidatorTrait.class).isPresent()) {
-            serviceValidator = context.getService().getTrait(RequestValidatorTrait.class).get().getValue();
+        if (context.getService().hasTrait(RequestValidatorTrait.ID)) {
+            serviceValidator = context.getService().expectTrait(RequestValidatorTrait.class).getValue();
             validators.add(serviceValidator);
         }
 

--- a/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceIndex.java
+++ b/smithy-aws-cloudformation-traits/src/main/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceIndex.java
@@ -237,7 +237,7 @@ public final class CfnResourceIndex implements KnowledgeIndex {
     private List<Map<String, ShapeId>> computeResourceAdditionalIdentifiers(StructureShape readInput) {
         List<Map<String, ShapeId>> identifiers = new ArrayList<>();
         for (MemberShape member : readInput.members()) {
-            if (!member.hasTrait(CfnAdditionalIdentifierTrait.class)) {
+            if (!member.hasTrait(CfnAdditionalIdentifierTrait.ID)) {
                 continue;
             }
 

--- a/smithy-aws-cloudformation-traits/src/test/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceTraitTest.java
+++ b/smithy-aws-cloudformation-traits/src/test/java/software/amazon/smithy/aws/cloudformation/traits/CfnResourceTraitTest.java
@@ -26,20 +26,20 @@ public class CfnResourceTraitTest {
                 .unwrap();
 
         Shape fooResource = result.expectShape(ShapeId.from("smithy.example#FooResource"));
-        assertTrue(fooResource.hasTrait(CfnResourceTrait.class));
+        assertTrue(fooResource.hasTrait(CfnResourceTrait.ID));
         CfnResourceTrait fooTrait = fooResource.expectTrait(CfnResourceTrait.class);
         assertFalse(fooTrait.getName().isPresent());
         assertTrue(fooTrait.getAdditionalSchemas().isEmpty());
 
         Shape barResource = result.expectShape(ShapeId.from("smithy.example#BarResource"));
-        assertTrue(barResource.hasTrait(CfnResourceTrait.class));
+        assertTrue(barResource.hasTrait(CfnResourceTrait.ID));
         CfnResourceTrait barTrait = barResource.expectTrait(CfnResourceTrait.class);
         assertThat(barTrait.getName().get(), equalTo("CustomResource"));
         assertFalse(barTrait.getAdditionalSchemas().isEmpty());
         assertThat(barTrait.getAdditionalSchemas(), contains(ShapeId.from("smithy.example#ExtraBarRequest")));
 
         Shape tadResource = result.expectShape(ShapeId.from("smithy.example#TadResource"));
-        assertTrue(tadResource.hasTrait(CfnResourceTrait.class));
+        assertTrue(tadResource.hasTrait(CfnResourceTrait.ID));
         CfnResourceTrait tadTrait = tadResource.expectTrait(CfnResourceTrait.class);
         assertFalse(tadTrait.getName().isPresent());
         assertTrue(tadTrait.getAdditionalSchemas().isEmpty());

--- a/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/CfnConverter.java
+++ b/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/CfnConverter.java
@@ -166,7 +166,7 @@ public final class CfnConverter {
         // Create an environment for each of the resources to be converted with.
         List<ConversionEnvironment> environments = new ArrayList<>();
         for (ResourceShape resourceShape : resourceShapes) {
-            if (resourceShape.getTrait(CfnResourceTrait.class).isPresent()) {
+            if (resourceShape.hasTrait(CfnResourceTrait.ID)) {
                 ConversionEnvironment environment = createConversionEnvironment(model, serviceShape, resourceShape);
                 environments.add(environment);
             }

--- a/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/mappers/HandlerPermissionMapper.java
+++ b/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/mappers/HandlerPermissionMapper.java
@@ -56,7 +56,7 @@ final class HandlerPermissionMapper implements CfnMapper {
                 .orElse(SetUtils.of());
         createPermissions.addAll(putPermissions);
         // Put operations without the noReplace trait are used for updates.
-        if (!resource.hasTrait(NoReplaceTrait.class)) {
+        if (!resource.hasTrait(NoReplaceTrait.ID)) {
             updatePermissions.addAll(putPermissions);
         }
 

--- a/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/mappers/TaggingMapper.java
+++ b/smithy-aws-cloudformation/src/main/java/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/mappers/TaggingMapper.java
@@ -43,7 +43,7 @@ public final class TaggingMapper implements CfnMapper {
             StructureShape.Builder builder
     ) {
         String tagMemberName = getTagMemberName(config, resource);
-        if (resource.hasTrait(TaggableTrait.class)) {
+        if (resource.hasTrait(TaggableTrait.ID)) {
             AwsTagIndex tagIndex = AwsTagIndex.of(model);
             TaggableTrait trait = resource.expectTrait(TaggableTrait.class);
             CfnResourceIndex resourceIndex = CfnResourceIndex.of(model);
@@ -68,7 +68,7 @@ public final class TaggingMapper implements CfnMapper {
     @Override
     public ResourceSchema after(Context context, ResourceSchema resourceSchema) {
         ResourceShape resourceShape = context.getResource();
-        if (!resourceShape.hasTrait(TaggableTrait.class)) {
+        if (!resourceShape.hasTrait(TaggableTrait.ID)) {
             return resourceSchema;
         }
 

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeysIndex.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeysIndex.java
@@ -174,8 +174,8 @@ public final class ConditionKeysIndex implements KnowledgeIndex {
 
         // Continue recursing into resources and computing keys.
         subject.asResourceShape().ifPresent(resource -> {
-            boolean disableConditionKeyInference = resource.hasTrait(DisableConditionKeyInferenceTrait.class)
-                    || service.hasTrait(DisableConditionKeyInferenceTrait.class);
+            boolean disableConditionKeyInference = resource.hasTrait(DisableConditionKeyInferenceTrait.ID)
+                    || service.hasTrait(DisableConditionKeyInferenceTrait.ID);
 
             // Add any inferred resource identifiers to the resource and to the service-wide definitions.
             Map<String, String> childIdentifiers = !disableConditionKeyInference
@@ -218,7 +218,7 @@ public final class ConditionKeysIndex implements KnowledgeIndex {
                 // Only infer identifiers introduced by a child. Children should
                 // use their parent identifiers and not duplicate them.
                 ConditionKeyDefinition.Builder builder = ConditionKeyDefinition.builder();
-                if (shape.hasTrait(ArnReferenceTrait.class)) {
+                if (shape.hasTrait(ArnReferenceTrait.ID)) {
                     // Use an ARN type if the targeted shape has the arnReference trait.
                     builder.type(ARN_TYPE);
                 } else {

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeysValidator.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeysValidator.java
@@ -40,13 +40,13 @@ public final class ConditionKeysValidator extends AbstractValidator {
         OperationIndex operationIndex = OperationIndex.of(model);
 
         return model.shapes(ServiceShape.class)
-                .filter(service -> service.hasTrait(ServiceTrait.class))
+                .filter(service -> service.hasTrait(ServiceTrait.ID))
                 .flatMap(service -> {
                     List<ValidationEvent> results = new ArrayList<>();
                     Set<String> knownKeys = conditionIndex.getDefinedConditionKeys(service).keySet();
                     Set<String> serviceResolvedKeys = Collections.emptySet();
 
-                    if (service.hasTrait(ServiceResolvedConditionKeysTrait.class)) {
+                    if (service.hasTrait(ServiceResolvedConditionKeysTrait.ID)) {
                         ServiceResolvedConditionKeysTrait trait =
                                 service.expectTrait(ServiceResolvedConditionKeysTrait.class);
                         //assign so we can compare against condition key values for any intersection
@@ -83,7 +83,7 @@ public final class ConditionKeysValidator extends AbstractValidator {
                         }
 
                         for (MemberShape memberShape : operationIndex.getInputMembers(operation).values()) {
-                            if (memberShape.hasTrait(ConditionKeyValueTrait.class)) {
+                            if (memberShape.hasTrait(ConditionKeyValueTrait.ID)) {
                                 ConditionKeyValueTrait trait = memberShape.expectTrait(ConditionKeyValueTrait.class);
                                 String conditionKey = trait.getValue();
                                 if (!knownKeys.contains(conditionKey)) {

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/IamResourceTraitValidator.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/IamResourceTraitValidator.java
@@ -28,7 +28,7 @@ public class IamResourceTraitValidator extends AbstractValidator {
         for (ResourceShape resource : model.getResourceShapesWithTrait(IamResourceTrait.class)) {
             // If the resource has both the IamResourceTrait and Arn trait,
             // check that the resource name is consistent between the two traits
-            if (resource.hasTrait(ArnTrait.class)) {
+            if (resource.hasTrait(ArnTrait.ID)) {
                 String resourceName = resource.expectTrait(IamResourceTrait.class)
                         .getName()
                         .orElseGet(() -> StringUtils.lowerCase(resource.getId().getName()));

--- a/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/IamActionTraitTest.java
+++ b/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/IamActionTraitTest.java
@@ -31,7 +31,7 @@ public class IamActionTraitTest {
 
         Shape fooOperation = result.expectShape(ID);
 
-        assertTrue(fooOperation.hasTrait(IamActionTrait.class));
+        assertTrue(fooOperation.hasTrait(IamActionTrait.ID));
         IamActionTrait trait = fooOperation.expectTrait(IamActionTrait.class);
         assertEquals(trait.getName().get(), "foo");
         assertEquals(trait.getDocumentation().get(), "docs");

--- a/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/IamResourceTraitTest.java
+++ b/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/IamResourceTraitTest.java
@@ -27,7 +27,7 @@ public class IamResourceTraitTest {
 
         Shape superResource = result.expectShape(ID);
 
-        assertTrue(superResource.hasTrait(IamResourceTrait.class));
+        assertTrue(superResource.hasTrait(IamResourceTrait.ID));
         assertEquals(superResource.expectTrait(IamResourceTrait.class).getName().get(), "super");
         assertEquals(superResource.expectTrait(IamResourceTrait.class).getRelativeDocumentation().get(),
                 "API-Super.html");

--- a/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/RequiredActionsTraitTest.java
+++ b/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/RequiredActionsTraitTest.java
@@ -25,7 +25,7 @@ public class RequiredActionsTraitTest {
 
         Shape myOperation = result.expectShape(ShapeId.from("smithy.example#MyOperation"));
 
-        assertTrue(myOperation.hasTrait(RequiredActionsTrait.class));
+        assertTrue(myOperation.hasTrait(RequiredActionsTrait.ID));
         assertThat(myOperation.expectTrait(RequiredActionsTrait.class).getValues(),
                 containsInAnyOrder(
                         "iam:PassRole",

--- a/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/SupportedPrincipalTypesTraitTest.java
+++ b/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/SupportedPrincipalTypesTraitTest.java
@@ -25,13 +25,13 @@ public class SupportedPrincipalTypesTraitTest {
         Shape myService = result.expectShape(ShapeId.from("smithy.example#MyService"));
         Shape myOperation = result.expectShape(ShapeId.from("smithy.example#MyOperation"));
 
-        assertTrue(myService.hasTrait(SupportedPrincipalTypesTrait.class));
+        assertTrue(myService.hasTrait(SupportedPrincipalTypesTrait.ID));
         assertThat(myService.expectTrait(SupportedPrincipalTypesTrait.class).getValues(),
                 containsInAnyOrder(
                         "IAMUser",
                         "IAMRole"));
 
-        assertTrue(myOperation.hasTrait(SupportedPrincipalTypesTrait.class));
+        assertTrue(myOperation.hasTrait(SupportedPrincipalTypesTrait.ID));
         assertThat(myOperation.expectTrait(SupportedPrincipalTypesTrait.class).getValues(),
                 containsInAnyOrder(
                         "Root",

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnIndex.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ArnIndex.java
@@ -43,7 +43,7 @@ public final class ArnIndex implements KnowledgeIndex {
         // Pre-compute all of the ARN templates in a service shape.
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         List<ServiceShape> services = model.shapes(ServiceShape.class)
-                .filter(shape -> shape.hasTrait(ServiceTrait.class))
+                .filter(shape -> shape.hasTrait(ServiceTrait.ID))
                 .collect(Collectors.toList());
 
         templates = unmodifiableMap(services.stream()

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ErrorRenameValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/ErrorRenameValidator.java
@@ -79,7 +79,7 @@ public final class ErrorRenameValidator extends AbstractValidator {
         renames.keySet().forEach(shapeId -> {
             Optional<Shape> shape = model.getShape(shapeId);
 
-            if (!shape.isPresent() || !shape.get().hasTrait(ErrorTrait.class)) {
+            if (!shape.isPresent() || !shape.get().hasTrait(ErrorTrait.ID)) {
                 return;
             }
 

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/PlaneIndex.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/PlaneIndex.java
@@ -135,9 +135,9 @@ public final class PlaneIndex implements KnowledgeIndex {
     }
 
     private Plane extractPlane(Shape shape) {
-        if (shape.hasTrait(ControlPlaneTrait.class)) {
+        if (shape.hasTrait(ControlPlaneTrait.ID)) {
             return Plane.CONTROL;
-        } else if (shape.hasTrait(DataPlaneTrait.class)) {
+        } else if (shape.hasTrait(DataPlaneTrait.ID)) {
             return Plane.DATA;
         } else {
             return null;

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/CleanClientDiscoveryTraitTransformer.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/CleanClientDiscoveryTraitTransformer.java
@@ -72,7 +72,7 @@ public final class CleanClientDiscoveryTraitTransformer implements ModelTransfor
         ClientEndpointDiscoveryIndex discoveryIndex = ClientEndpointDiscoveryIndex.of(model);
         Set<ShapeId> stillBoundOperations = model.shapes(ServiceShape.class)
                 // Get all endpoint discovery services
-                .filter(service -> service.hasTrait(ClientEndpointDiscoveryTrait.class))
+                .filter(service -> service.hasTrait(ClientEndpointDiscoveryTrait.ID))
                 .map(Shape::getId)
                 // Get those services who aren't having their discovery traits removed
                 .filter(service -> !updatedServices.contains(service))
@@ -96,7 +96,7 @@ public final class CleanClientDiscoveryTraitTransformer implements ModelTransfor
     private Set<Shape> getMembersToUpdate(Model model, Set<ShapeId> updatedOperations) {
         Set<ShapeId> stillBoundMembers = model.shapes(OperationShape.class)
                 // Get all endpoint discovery operations
-                .filter(operation -> operation.hasTrait(ClientDiscoveredEndpointTrait.class))
+                .filter(operation -> operation.hasTrait(ClientDiscoveredEndpointTrait.ID))
                 // Filter out the ones which are having their endpoint discovery traits removed
                 .filter(operation -> !updatedOperations.contains(operation.getId()))
                 // Get the input shapes of those operations
@@ -109,7 +109,7 @@ public final class CleanClientDiscoveryTraitTransformer implements ModelTransfor
 
         return model.shapes(MemberShape.class)
                 // Get all members which have the endpoint discovery id trait
-                .filter(member -> member.hasTrait(ClientEndpointDiscoveryIdTrait.class))
+                .filter(member -> member.hasTrait(ClientEndpointDiscoveryIdTrait.ID))
                 // Get those which are on structures that aren't still bound to endpoint discovery operations
                 .filter(member -> !stillBoundMembers.contains(member.getId()))
                 // Remove the trait

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIndex.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIndex.java
@@ -86,7 +86,7 @@ public final class ClientEndpointDiscoveryIndex implements KnowledgeIndex {
     private List<MemberShape> getDiscoveryIds(OperationIndex opIndex, OperationShape operation) {
         List<MemberShape> discoveryIds = new ArrayList<>();
         for (MemberShape member : opIndex.expectInputShape(operation).getAllMembers().values()) {
-            if (member.hasTrait(ClientEndpointDiscoveryIdTrait.class)) {
+            if (member.hasTrait(ClientEndpointDiscoveryIdTrait.ID)) {
                 discoveryIds.add(member);
             }
         }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryValidator.java
@@ -111,7 +111,7 @@ public final class ClientEndpointDiscoveryValidator extends AbstractValidator {
             Map<ServiceShape, ClientEndpointDiscoveryTrait> endpointDiscoveryServices
     ) {
         return model.shapes(OperationShape.class)
-                .filter(operation -> operation.hasTrait(ClientDiscoveredEndpointTrait.class))
+                .filter(operation -> operation.hasTrait(ClientDiscoveredEndpointTrait.ID))
                 .map(operation -> {
                     List<ClientEndpointDiscoveryInfo> infos = endpointDiscoveryServices.keySet()
                             .stream()

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/AwsTagIndex.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/AwsTagIndex.java
@@ -301,7 +301,7 @@ public final class AwsTagIndex implements KnowledgeIndex {
             // Put is always a create operation
             resourceIsTagOnCreate.add(resource.getId());
             // and it's also an update when not annotated with `@noReplace`.
-            if (!resource.hasTrait(NoReplaceTrait.class)) {
+            if (!resource.hasTrait(NoReplaceTrait.ID)) {
                 resourceIsTagOnUpdate.add(resource.getId());
             }
         }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TagEnabledServiceValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TagEnabledServiceValidator.java
@@ -38,7 +38,7 @@ public final class TagEnabledServiceValidator extends AbstractValidator {
 
         int taggableResourceCount = 0;
         for (ResourceShape resource : topDownIndex.getContainedResources(service)) {
-            if (resource.hasTrait(TaggableTrait.class)) {
+            if (resource.hasTrait(TaggableTrait.ID)) {
                 ++taggableResourceCount;
             }
         }

--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TaggableResourceValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TaggableResourceValidator.java
@@ -35,10 +35,10 @@ public final class TaggableResourceValidator extends AbstractValidator {
         for (ServiceShape service : model.getServiceShapes()) {
             for (ResourceShape resource : topDownIndex.getContainedResources(service)) {
                 boolean resourceLikelyTaggable = false;
-                if (resource.hasTrait(TaggableTrait.class)) {
+                if (resource.hasTrait(TaggableTrait.ID)) {
                     events.addAll(validateResource(model, resource, service, tagIndex));
                     resourceLikelyTaggable = true;
-                } else if (resource.hasTrait(ArnTrait.class) && tagIndex.serviceHasTagApis(service)) {
+                } else if (resource.hasTrait(ArnTrait.ID) && tagIndex.serviceHasTagApis(service)) {
                     // If a resource does not have the taggable trait, but has an ARN, and the service has tag
                     // operations, it is most likely a mistake.
                     events.add(warning(resource, "Resource is likely missing `aws.api#taggable` trait."));
@@ -46,7 +46,7 @@ public final class TaggableResourceValidator extends AbstractValidator {
                 }
 
                 // It's possible the resource was marked as taggable but the service isn't tagEnabled.
-                if (resourceLikelyTaggable && !service.hasTrait(TagEnabledTrait.class)) {
+                if (resourceLikelyTaggable && !service.hasTrait(TagEnabledTrait.ID)) {
                     events.add(warning(service,
                             "Service has resources with `aws.api#taggable` applied but does not "
                                     + "have the `aws.api#tagEnabled` trait."));
@@ -81,7 +81,7 @@ public final class TaggableResourceValidator extends AbstractValidator {
         boolean isServiceWideTaggable = awsTagIndex.serviceHasTagApis(service.getId());
         boolean isInstanceOpTaggable = isTaggableViaInstanceOperations(model, resource);
 
-        if (isServiceWideTaggable && !isInstanceOpTaggable && !resource.hasTrait(ArnTrait.class)) {
+        if (isServiceWideTaggable && !isInstanceOpTaggable && !resource.hasTrait(ArnTrait.ID)) {
             events.add(error(resource,
                     "Resource is taggable only via service-wide tag operations."
                             + " It must use the `aws.api@arn` trait."));

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/CleanClientDiscoveryTraitTransformerTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/CleanClientDiscoveryTraitTransformerTest.java
@@ -50,11 +50,11 @@ public class CleanClientDiscoveryTraitTransformerTest {
                 .flatMap(Shape::asMemberShape)
                 .get();
 
-        assertFalse(service.hasTrait(ClientEndpointDiscoveryTrait.class));
+        assertFalse(service.hasTrait(ClientEndpointDiscoveryTrait.ID));
         // discovery is required for this operation, so it keeps the trait
-        assertTrue(getOperation.hasTrait(ClientDiscoveredEndpointTrait.class));
-        assertFalse(putOperation.hasTrait(ClientDiscoveredEndpointTrait.class));
-        assertFalse(putId.hasTrait(ClientEndpointDiscoveryIdTrait.class));
+        assertTrue(getOperation.hasTrait(ClientDiscoveredEndpointTrait.ID));
+        assertFalse(putOperation.hasTrait(ClientDiscoveredEndpointTrait.ID));
+        assertFalse(putId.hasTrait(ClientEndpointDiscoveryIdTrait.ID));
     }
 
     @Test
@@ -89,10 +89,10 @@ public class CleanClientDiscoveryTraitTransformerTest {
                 .flatMap(Shape::asMemberShape)
                 .get();
 
-        assertTrue(service.hasTrait(ClientEndpointDiscoveryTrait.class));
-        assertTrue(getOperation.hasTrait(ClientDiscoveredEndpointTrait.class));
-        assertTrue(putOperation.hasTrait(ClientDiscoveredEndpointTrait.class));
-        assertTrue(putId.hasTrait(ClientEndpointDiscoveryIdTrait.class));
+        assertTrue(service.hasTrait(ClientEndpointDiscoveryTrait.ID));
+        assertTrue(getOperation.hasTrait(ClientDiscoveredEndpointTrait.ID));
+        assertTrue(putOperation.hasTrait(ClientDiscoveredEndpointTrait.ID));
+        assertTrue(putId.hasTrait(ClientEndpointDiscoveryIdTrait.ID));
     }
 
     @Test
@@ -117,8 +117,8 @@ public class CleanClientDiscoveryTraitTransformerTest {
                 .flatMap(Shape::asOperationShape)
                 .get();
 
-        assertTrue(getOperation.hasTrait(ClientDiscoveredEndpointTrait.class));
-        assertTrue(putOperation.hasTrait(ClientDiscoveredEndpointTrait.class));
+        assertTrue(getOperation.hasTrait(ClientDiscoveredEndpointTrait.ID));
+        assertTrue(putOperation.hasTrait(ClientDiscoveredEndpointTrait.ID));
     }
 
     @Test
@@ -138,7 +138,7 @@ public class CleanClientDiscoveryTraitTransformerTest {
                 .flatMap(Shape::asMemberShape)
                 .get();
 
-        assertTrue(id.hasTrait(ClientEndpointDiscoveryIdTrait.class));
+        assertTrue(id.hasTrait(ClientEndpointDiscoveryIdTrait.ID));
 
     }
 }

--- a/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIdTraitTest.java
+++ b/smithy-aws-traits/src/test/java/software/amazon/smithy/aws/traits/clientendpointdiscovery/ClientEndpointDiscoveryIdTraitTest.java
@@ -41,7 +41,7 @@ public class ClientEndpointDiscoveryIdTraitTest {
                 .getMember("Id")
                 .get();
 
-        assertTrue(member.getTrait(ClientEndpointDiscoveryIdTrait.class).isPresent());
+        assertTrue(member.hasTrait(ClientEndpointDiscoveryIdTrait.ID));
     }
 
     @Test

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeTraitsByTag.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/ExcludeTraitsByTag.java
@@ -72,7 +72,7 @@ public final class ExcludeTraitsByTag extends BackwardCompatHelper<ExcludeTraits
 
     private boolean removeIfPredicate(Shape shape, Collection<String> tags) {
         return !Prelude.isPreludeShape(shape)
-                && shape.hasTrait(TraitDefinition.class)
+                && shape.hasTrait(TraitDefinition.ID)
                 && hasAnyTag(shape, tags);
     }
 

--- a/smithy-build/src/main/java/software/amazon/smithy/build/transforms/IncludeTraitsByTag.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/transforms/IncludeTraitsByTag.java
@@ -72,7 +72,7 @@ public final class IncludeTraitsByTag extends BackwardCompatHelper<IncludeTraits
 
     private boolean removeIfPredicate(Shape shape, Collection<String> tags) {
         return !Prelude.isPreludeShape(shape)
-                && shape.hasTrait(TraitDefinition.class)
+                && shape.hasTrait(TraitDefinition.ID)
                 && !hasAnyTag(shape, tags);
     }
 

--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/MigrateCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/MigrateCommand.java
@@ -296,7 +296,7 @@ final class MigrateCommand implements Command {
 
         @Override
         protected Void getDefault(Shape shape) {
-            if (shape.hasTrait(BoxTrait.class)) {
+            if (shape.hasTrait(BoxTrait.ID)) {
                 writer.eraseTrait(shape, shape.expectTrait(BoxTrait.class));
             } else if (hasSyntheticDefault(shape)) {
                 addDefault(shape, shape.getType());
@@ -314,7 +314,7 @@ final class MigrateCommand implements Command {
                 addDefault(shape, completeModel.expectShape(shape.getTarget()).getType());
             }
 
-            if (shape.hasTrait(BoxTrait.class)) {
+            if (shape.hasTrait(BoxTrait.ID)) {
                 writer.eraseTrait(shape, shape.expectTrait(BoxTrait.class));
             }
         }
@@ -337,7 +337,7 @@ final class MigrateCommand implements Command {
             }
             String defaultValue = "";
             // Boxed members get a null default.
-            if (shape.hasTrait(BoxTrait.class)) {
+            if (shape.hasTrait(BoxTrait.ID)) {
                 defaultValue = "null";
             } else {
                 switch (targetType) {

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java
@@ -587,7 +587,7 @@ public final class CodegenDirector<
 
         @Override
         public Void structureShape(StructureShape shape) {
-            if (shape.hasTrait(ErrorTrait.class)) {
+            if (shape.hasTrait(ErrorTrait.ID)) {
                 LOGGER.finest(() -> "Generating error " + shape.getId());
                 directedCodegen.generateError(new GenerateErrorDirective<>(context, serviceShape, shape));
             } else {

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateStructureDirective.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateStructureDirective.java
@@ -28,7 +28,7 @@ public final class GenerateStructureDirective<C extends CodegenContext<S, ?, ?>,
     /**
      * Check if this is a shape used exclusively for input.
      *
-     * <p>This is equivalent to calling {@code shape().hasTrait(InputTrait.class)}.
+     * <p>This is equivalent to calling {@code shape().hasTrait(InputTrait.ID)}.
      *
      * <p>Use the {@link CodegenDirector#createDedicatedInputsAndOutputs()} method
      * to ensure that every operation has a unique input shape marked with the
@@ -38,13 +38,13 @@ public final class GenerateStructureDirective<C extends CodegenContext<S, ?, ?>,
      * @see ModelTransformer#createDedicatedInputAndOutput
      */
     public boolean isInputShape() {
-        return shape().hasTrait(InputTrait.class);
+        return shape().hasTrait(InputTrait.ID);
     }
 
     /**
      * Check if this is a shape used exclusively for output.
      *
-     * <p>This is equivalent to calling {@code shape().hasTrait(OutputTrait.class)}.
+     * <p>This is equivalent to calling {@code shape().hasTrait(OutputTrait.ID)}.
      *
      * <p>Use the {@link CodegenDirector#createDedicatedInputsAndOutputs()} method
      * to ensure that every operation has a unique output shape marked with the
@@ -54,6 +54,6 @@ public final class GenerateStructureDirective<C extends CodegenContext<S, ?, ?>,
      * @see ModelTransformer#createDedicatedInputAndOutput
      */
     public boolean isOutputShape() {
-        return shape().hasTrait(OutputTrait.class);
+        return shape().hasTrait(OutputTrait.ID);
     }
 }

--- a/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateUnionDirective.java
+++ b/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/GenerateUnionDirective.java
@@ -29,6 +29,6 @@ public final class GenerateUnionDirective<C extends CodegenContext<S, ?, ?>, S>
      * @return Returns true if this is an event stream.
      */
     public boolean isEventStream() {
-        return shape().hasTrait(StreamingTrait.class);
+        return shape().hasTrait(StreamingTrait.ID);
     }
 }

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedTraitDefinition.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedTraitDefinition.java
@@ -18,7 +18,7 @@ public final class AddedTraitDefinition extends AbstractDiffEvaluator {
     @Override
     public List<ValidationEvent> evaluate(Differences differences) {
         return differences.addedShapes()
-                .filter(shape -> shape.hasTrait(TraitDefinition.class))
+                .filter(shape -> shape.hasTrait(TraitDefinition.ID))
                 .map(shape -> ValidationEvent.builder()
                         .id(getEventId())
                         .severity(Severity.NOTE)

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedDefault.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedDefault.java
@@ -62,7 +62,7 @@ public final class ChangedDefault extends AbstractDiffEvaluator {
                         newTrait,
                         "Adding the @default trait to a root-level shape will break previously generated "
                                 + "code. Added @default: " + Node.printJson(newTrait.toNode())));
-            } else if (!change.getNewShape().hasTrait(AddedDefaultTrait.class)) {
+            } else if (!change.getNewShape().hasTrait(AddedDefaultTrait.ID)) {
                 if (!newTrait.toNode().isNullNode()) {
                     events.add(error(change.getNewShape(),
                             newTrait,

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedShapeType.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedShapeType.java
@@ -46,7 +46,7 @@ public final class ChangedShapeType extends AbstractDiffEvaluator {
         // Smithy diff doesn't raise an issue if a set is changed to a list and the list
         // has the uniqueItems trait. Set is deprecated and this is a recommended change.
         if (oldType == ShapeType.SET && newType == ShapeType.LIST) {
-            return diff.getNewShape().hasTrait(UniqueItemsTrait.class);
+            return diff.getNewShape().hasTrait(UniqueItemsTrait.ID);
         }
 
         return false;

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedShape.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedShape.java
@@ -22,7 +22,7 @@ public final class RemovedShape extends AbstractDiffEvaluator {
     @Override
     public List<ValidationEvent> evaluate(Differences differences) {
         return differences.removedShapes()
-                .filter(shape -> !shape.hasTrait(PrivateTrait.class))
+                .filter(shape -> !shape.hasTrait(PrivateTrait.ID))
                 .filter(shape -> !isMemberOfRemovedShape(shape, differences))
                 .map(shape -> isInconsequentialType(shape)
                         ? ValidationEvent.builder()

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedTraitDefinition.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedTraitDefinition.java
@@ -18,7 +18,7 @@ public final class RemovedTraitDefinition extends AbstractDiffEvaluator {
     @Override
     public List<ValidationEvent> evaluate(Differences differences) {
         return differences.removedShapes()
-                .filter(shape -> shape.hasTrait(TraitDefinition.class))
+                .filter(shape -> shape.hasTrait(TraitDefinition.ID))
                 .map(shape -> ValidationEvent.builder()
                         .id(getEventId())
                         .severity(Severity.ERROR)

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedNullabilityTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedNullabilityTest.java
@@ -308,10 +308,10 @@ public class ChangedNullabilityTest {
         });
 
         // First, spot check that the transform worked and the models are different.
-        assertThat(old.expectShape(bazId).hasTrait(BoxTrait.class), is(false));
-        assertThat(newModel.expectShape(bazId).hasTrait(BoxTrait.class), is(true));
-        assertThat(old.expectShape(bamId).hasTrait(BoxTrait.class), is(false));
-        assertThat(newModel.expectShape(bamId).hasTrait(BoxTrait.class), is(true));
+        assertThat(old.expectShape(bazId).hasTrait(BoxTrait.ID), is(false));
+        assertThat(newModel.expectShape(bazId).hasTrait(BoxTrait.ID), is(true));
+        assertThat(old.expectShape(bamId).hasTrait(BoxTrait.ID), is(false));
+        assertThat(newModel.expectShape(bamId).hasTrait(BoxTrait.ID), is(true));
 
         List<ValidationEvent> events = ModelDiff.compare(old, newModel);
 

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/DirectedDocGen.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/DirectedDocGen.java
@@ -55,7 +55,7 @@ final class DirectedDocGen implements DirectedCodegen<DocGenerationContext, DocS
     @Override
     public void generateStructure(GenerateStructureDirective<DocGenerationContext, DocSettings> directive) {
         // Input and output structures are documented alongside the relevant operations.
-        if (directive.shape().hasTrait(InputTrait.class) || directive.shape().hasTrait(OutputTrait.class)) {
+        if (directive.shape().hasTrait(InputTrait.ID) || directive.shape().hasTrait(OutputTrait.ID)) {
             return;
         }
         new StructuredShapeGenerator(directive.context()).accept(directive.shape(), MemberListingType.MEMBERS);

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/DocSymbolProvider.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/DocSymbolProvider.java
@@ -160,10 +160,10 @@ public final class DocSymbolProvider extends ShapeVisitor.Default<Symbol> implem
         var operationIndex = OperationIndex.of(model);
         for (var operation : model.getOperationShapes()) {
             operationIndex.getInputShape(operation)
-                    .filter(i -> i.hasTrait(InputTrait.class))
+                    .filter(i -> i.hasTrait(InputTrait.ID))
                     .ifPresent(i -> operationIoMap.put(i.getId(), operation));
             operationIndex.getOutputShape(operation)
-                    .filter(i -> i.hasTrait(OutputTrait.class))
+                    .filter(i -> i.hasTrait(OutputTrait.ID))
                     .ifPresent(i -> operationIoMap.put(i.getId(), operation));
         }
         return Map.copyOf(operationIoMap);
@@ -196,8 +196,8 @@ public final class DocSymbolProvider extends ShapeVisitor.Default<Symbol> implem
     @Override
     public Symbol structureShape(StructureShape shape) {
         var builder = getSymbolBuilder(shape);
-        if (shape.hasTrait(TraitDefinition.class)) {
-            if (shape.hasTrait(AuthDefinitionTrait.class)) {
+        if (shape.hasTrait(TraitDefinition.ID)) {
+            if (shape.hasTrait(AuthDefinitionTrait.ID)) {
                 builder.definitionFile(getDefinitionFile(SERVICE_FILE));
             }
             return builder.build();

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/generators/MemberGenerator.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/generators/MemberGenerator.java
@@ -353,7 +353,7 @@ public final class MemberGenerator implements Runnable {
 
         @Override
         public Void structureShape(StructureShape shape) {
-            if (member.hasTrait(EnumValueTrait.class)) {
+            if (member.hasTrait(EnumValueTrait.ID)) {
                 var trait = member.expectTrait(EnumValueTrait.class);
                 if (trait.getIntValue().isPresent()) {
                     writer.writeInline("$`", trait.expectIntValue());

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/ErrorFaultInterceptor.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/ErrorFaultInterceptor.java
@@ -23,7 +23,7 @@ public final class ErrorFaultInterceptor implements CodeInterceptor<ShapeSubhead
 
     @Override
     public boolean isIntercepted(ShapeSubheadingSection section) {
-        return section.shape().hasTrait(ErrorTrait.class);
+        return section.shape().hasTrait(ErrorTrait.ID);
     }
 
     @Override

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/HttpPayloadInterceptor.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/HttpPayloadInterceptor.java
@@ -32,7 +32,7 @@ public final class HttpPayloadInterceptor extends ProtocolTraitInterceptor<HttpP
     void write(DocWriter writer, String previousText, ProtocolSection section, HttpPayloadTrait trait) {
         var target = section.context().model().expectShape(section.shape().asMemberShape().get().getTarget());
         writer.pushState();
-        writer.putContext("requiresLength", target.hasTrait(RequiresLengthTrait.class));
+        writer.putContext("requiresLength", target.hasTrait(RequiresLengthTrait.ID));
         writer.write("""
                 This is bound directly to the HTTP message body without wrapping.${?requiresLength} \
                 Its size must be sent as the value of the $` header.${/requiresLength}

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/IdempotencyInterceptor.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/IdempotencyInterceptor.java
@@ -43,7 +43,7 @@ public final class IdempotencyInterceptor implements CodeInterceptor<ShapeDetail
         var model = section.context().model();
         var operationIndex = OperationIndex.of(model);
 
-        if (shape.hasTrait(IdempotencyTokenTrait.class)
+        if (shape.hasTrait(IdempotencyTokenTrait.ID)
                 && operationIndex.isInputStructure(shape.asMemberShape().get().getContainer())) {
             return true;
         }
@@ -64,7 +64,7 @@ public final class IdempotencyInterceptor implements CodeInterceptor<ShapeDetail
     private Optional<MemberShape> getIdempotencyToken(Model model, OperationShape operation) {
         var input = model.expectShape(operation.getInputShape());
         for (var member : input.members()) {
-            if (member.hasTrait(IdempotencyTokenTrait.class)) {
+            if (member.hasTrait(IdempotencyTokenTrait.ID)) {
                 return Optional.of(member);
             }
         }

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/NoReplaceInterceptor.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/NoReplaceInterceptor.java
@@ -29,7 +29,7 @@ abstract class NoReplaceInterceptor<S extends CodeSection> implements CodeInterc
         var shape = getShape(section);
         var resource = getResource(getContext(section), shape);
         return resource.isPresent()
-                && resource.get().hasTrait(NoReplaceTrait.class)
+                && resource.get().hasTrait(NoReplaceTrait.ID)
                 && resource.get().getPut().map(put -> put.equals(shape.getId())).orElse(false);
     }
 

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/PaginationInterceptor.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/PaginationInterceptor.java
@@ -25,7 +25,7 @@ public final class PaginationInterceptor implements CodeInterceptor<ShapeDetails
 
     @Override
     public boolean isIntercepted(ShapeDetailsSection section) {
-        return section.shape().isOperationShape() && section.shape().hasTrait(PaginatedTrait.class);
+        return section.shape().isOperationShape() && section.shape().hasTrait(PaginatedTrait.ID);
     }
 
     @Override

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/RecommendedInterceptor.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/RecommendedInterceptor.java
@@ -25,7 +25,7 @@ public final class RecommendedInterceptor implements CodeInterceptor<ShapeSubhea
 
     @Override
     public boolean isIntercepted(ShapeSubheadingSection section) {
-        return section.shape().hasTrait(RecommendedTrait.class);
+        return section.shape().hasTrait(RecommendedTrait.ID);
     }
 
     @Override

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/RequestCompressionInterceptor.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/RequestCompressionInterceptor.java
@@ -26,7 +26,7 @@ public final class RequestCompressionInterceptor implements CodeInterceptor<Shap
 
     @Override
     public boolean isIntercepted(ShapeDetailsSection section) {
-        return section.shape().hasTrait(RequestCompressionTrait.class);
+        return section.shape().hasTrait(RequestCompressionTrait.ID);
     }
 
     @Override

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/RetryableInterceptor.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/RetryableInterceptor.java
@@ -23,7 +23,7 @@ public final class RetryableInterceptor implements CodeInterceptor.Prepender<Sha
 
     @Override
     public boolean isIntercepted(ShapeSubheadingSection section) {
-        return section.shape().hasTrait(RetryableTrait.class);
+        return section.shape().hasTrait(RetryableTrait.ID);
     }
 
     @Override

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/StreamingInterceptor.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/StreamingInterceptor.java
@@ -35,7 +35,7 @@ public class StreamingInterceptor implements CodeInterceptor.Appender<ShapeDetai
                 .orElse(section.shape());
         if (target.isBlobShape()) {
             writer.pushState();
-            writer.putContext("requiresLength", target.hasTrait(RequiresLengthTrait.class));
+            writer.putContext("requiresLength", target.hasTrait(RequiresLengthTrait.ID));
             writer.openAdmonition(NoticeType.IMPORTANT);
             writer.write("""
                     The data in this member is potentially very large and therefore must be streamed and not \

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/XmlFlattenedInterceptor.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/XmlFlattenedInterceptor.java
@@ -68,13 +68,13 @@ public class XmlFlattenedInterceptor implements CodeInterceptor<ProtocolSection,
     private Pair<String, String> getRef(DocGenerationContext context, Shape shape) {
         var target = context.model().expectShape(shape.asMemberShape().get().getTarget());
         if (target.isMapShape()) {
-            if (shape.hasTrait(XmlFlattenedTrait.class)) {
+            if (shape.hasTrait(XmlFlattenedTrait.ID)) {
                 return FLAT_MAP_REF;
             }
             return WRAPPED_MAP_REF;
         }
 
-        if (shape.hasTrait(XmlFlattenedTrait.class)) {
+        if (shape.hasTrait(XmlFlattenedTrait.ID)) {
             return FLAT_LIST_REF;
         }
         return WRAPPED_LIST_REF;

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/XmlNameInterceptor.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/interceptors/XmlNameInterceptor.java
@@ -29,7 +29,7 @@ public final class XmlNameInterceptor extends ProtocolTraitInterceptor<XmlNameTr
     @Override
     public boolean isIntercepted(ProtocolSection section) {
         // The xmlName trait uniquely doesn't inherit values from the target as a member.
-        return super.isIntercepted(section) && section.shape().hasTrait(XmlNameTrait.class);
+        return super.isIntercepted(section) && section.shape().hasTrait(XmlNameTrait.ID);
     }
 
     @Override

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/DeconflictingStrategy.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/DeconflictingStrategy.java
@@ -86,7 +86,7 @@ final class DeconflictingStrategy implements RefStrategy {
                 || shape.isServiceShape()
                 || shape.isOperationShape()
                 || shape.isMemberShape()
-                || (Prelude.isPreludeShape(shape) && shape.hasTrait(PrivateTrait.class));
+                || (Prelude.isPreludeShape(shape) && shape.hasTrait(PrivateTrait.ID));
     }
 
     private String deconflict(Shape shape, String pointer, Map<String, ShapeId> reversePointers) {

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaConfig.java
@@ -380,7 +380,7 @@ public class JsonSchemaConfig {
      * @return Returns the optionally detected format.
      */
     public Optional<String> detectJsonTimestampFormat(Shape shape) {
-        if (shape.isTimestampShape() || shape.hasTrait(TimestampFormatTrait.class)) {
+        if (shape.isTimestampShape() || shape.hasTrait(TimestampFormatTrait.ID)) {
             return Optional.of(shape.getTrait(TimestampFormatTrait.class)
                     .map(TimestampFormatTrait::getValue)
                     .orElseGet(() -> getDefaultTimestampFormat().toString()));

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/JsonSchemaShapeVisitor.java
@@ -84,7 +84,7 @@ final class JsonSchemaShapeVisitor extends ShapeVisitor.Default<Schema> {
     @Override
     public Schema listShape(ListShape shape) {
         Schema.Builder builder = createBuilder(shape, "array").items(createRef(shape.getMember()));
-        if (shape.hasTrait(UniqueItemsTrait.class)) {
+        if (shape.hasTrait(UniqueItemsTrait.ID)) {
             builder.uniqueItems(true);
         }
         return buildSchema(shape, builder);
@@ -95,7 +95,7 @@ final class JsonSchemaShapeVisitor extends ShapeVisitor.Default<Schema> {
             return member.accept(this);
         } else {
             Schema.Builder refBuilder = Schema.builder().ref(converter.toPointer(member.getTarget()));
-            if (member.hasTrait(DeprecatedTrait.class) && getJsonSchemaVersion() != JsonSchemaVersion.DRAFT07) {
+            if (member.hasTrait(DeprecatedTrait.ID) && getJsonSchemaVersion() != JsonSchemaVersion.DRAFT07) {
                 refBuilder.deprecated(true);
             }
 
@@ -104,7 +104,7 @@ final class JsonSchemaShapeVisitor extends ShapeVisitor.Default<Schema> {
             }
 
             // Wrap the ref and default in an allOf if disableDefaultValues has been not been disabled on config.
-            if (member.hasTrait(DefaultTrait.class) && !converter.getConfig().getDisableDefaultValues()) {
+            if (member.hasTrait(DefaultTrait.ID) && !converter.getConfig().getDisableDefaultValues()) {
                 Schema def = Schema.builder().defaultValue(member.expectTrait(DefaultTrait.class).toNode()).build();
                 return Schema.builder().allOf(ListUtils.of(refBuilder.build(), def)).build();
             }
@@ -353,7 +353,7 @@ final class JsonSchemaShapeVisitor extends ShapeVisitor.Default<Schema> {
             }
         });
 
-        if (shape.hasTrait(UniqueItemsTrait.class)) {
+        if (shape.hasTrait(UniqueItemsTrait.ID)) {
             builder.uniqueItems(true);
         }
 
@@ -365,11 +365,11 @@ final class JsonSchemaShapeVisitor extends ShapeVisitor.Default<Schema> {
             builder.intEnumValues(shape.asIntEnumShape().get().getEnumValues().values());
         }
 
-        if (shape.hasTrait(DefaultTrait.class) && !converter.getConfig().getDisableDefaultValues()) {
+        if (shape.hasTrait(DefaultTrait.ID) && !converter.getConfig().getDisableDefaultValues()) {
             builder.defaultValue(shape.expectTrait(DefaultTrait.class).toNode());
         }
 
-        if (shape.hasTrait(DeprecatedTrait.class) && getJsonSchemaVersion() != JsonSchemaVersion.DRAFT07) {
+        if (shape.hasTrait(DeprecatedTrait.ID) && getJsonSchemaVersion() != JsonSchemaVersion.DRAFT07) {
             builder.deprecated(true);
         }
 

--- a/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/PropertyNamingStrategy.java
+++ b/smithy-jsonschema/src/main/java/software/amazon/smithy/jsonschema/PropertyNamingStrategy.java
@@ -41,7 +41,7 @@ public interface PropertyNamingStrategy {
     static PropertyNamingStrategy createDefaultStrategy() {
         return (containingShape, member, config) -> {
             // Use the jsonName trait if configured to do so.
-            if (config.getUseJsonName() && member.hasTrait(JsonNameTrait.class)) {
+            if (config.getUseJsonName() && member.hasTrait(JsonNameTrait.ID)) {
                 return member.expectTrait(JsonNameTrait.class).getValue();
             }
 

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/CamelCaseValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/CamelCaseValidator.java
@@ -127,7 +127,7 @@ public final class CamelCaseValidator extends AbstractValidator {
         // Normal shapes are expected to be upper camel.
         model.shapes()
                 .filter(FunctionalUtils.not(Shape::isMemberShape))
-                .filter(shape -> !shape.hasTrait(TraitDefinition.class))
+                .filter(shape -> !shape.hasTrait(TraitDefinition.ID))
                 .filter(shape -> !MemberNameHandling.UPPER.getRegex().matcher(shape.getId().getName()).find())
                 .map(shape -> danger(shape,
                         format(
@@ -139,9 +139,9 @@ public final class CamelCaseValidator extends AbstractValidator {
 
         // Trait shapes are expected to be lower camel.
         model.shapes()
-                .filter(shape -> shape.hasTrait(TraitDefinition.class))
-                .filter(shape -> !shape.hasTrait(AuthDefinitionTrait.class))
-                .filter(shape -> !shape.hasTrait(ProtocolDefinitionTrait.class))
+                .filter(shape -> shape.hasTrait(TraitDefinition.ID))
+                .filter(shape -> !shape.hasTrait(AuthDefinitionTrait.ID))
+                .filter(shape -> !shape.hasTrait(ProtocolDefinitionTrait.ID))
                 .filter(shape -> !MemberNameHandling.LOWER.getRegex().matcher(shape.getId().getName()).find())
                 .map(shape -> danger(shape,
                         format(

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/InputOutputStructureReuseValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/InputOutputStructureReuseValidator.java
@@ -49,7 +49,7 @@ public final class InputOutputStructureReuseValidator extends AbstractValidator 
             StructureShape output,
             List<ValidationEvent> events
     ) {
-        if (!input.hasTrait(InputTrait.class)) {
+        if (!input.hasTrait(InputTrait.ID)) {
             events.add(warning(input,
                     String.format(
                             "This structure is the input of `%s`, but it is not marked with the "
@@ -61,7 +61,7 @@ public final class InputOutputStructureReuseValidator extends AbstractValidator 
                     operation.getId().getName()));
         }
 
-        if (!output.hasTrait(OutputTrait.class)) {
+        if (!output.hasTrait(OutputTrait.ID)) {
             events.add(warning(output,
                     String.format(
                             "This structure is the output of `%s`, but it is not marked with "

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/MissingClientOptionalTrait.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/MissingClientOptionalTrait.java
@@ -80,13 +80,13 @@ public final class MissingClientOptionalTrait extends AbstractValidator {
     public List<ValidationEvent> validate(Model model) {
         List<ValidationEvent> events = new ArrayList<>();
         for (MemberShape member : model.getMemberShapes()) {
-            if (member.hasTrait(ClientOptionalTrait.class)) {
+            if (member.hasTrait(ClientOptionalTrait.ID)) {
                 continue;
             }
-            if (member.hasTrait(DefaultTrait.class) && config.onRequiredOrDefault) {
+            if (member.hasTrait(DefaultTrait.ID) && config.onRequiredOrDefault) {
                 events.add(danger(member, "@default members must also be marked with the @clientOptional trait"));
             }
-            if (member.hasTrait(RequiredTrait.class)) {
+            if (member.hasTrait(RequiredTrait.ID)) {
                 if (config.onRequiredOrDefault) {
                     events.add(danger(member, "@required members must also be marked with the @clientOptional trait"));
                 } else if (config.onRequiredStructureOrUnion && isTargetingStructureOrUnion(model, member)) {

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/MissingPaginatedTraitValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/MissingPaginatedTraitValidator.java
@@ -168,7 +168,7 @@ public final class MissingPaginatedTraitValidator extends AbstractValidator {
     public List<ValidationEvent> validate(Model model) {
         OperationIndex operationIndex = OperationIndex.of(model);
         return model.shapes(OperationShape.class)
-                .filter(shape -> !shape.getTrait(PaginatedTrait.class).isPresent())
+                .filter(shape -> !shape.hasTrait(PaginatedTrait.ID))
                 .flatMap(shape -> validateShape(model, operationIndex, shape))
                 .collect(Collectors.toList());
     }

--- a/smithy-linters/src/main/java/software/amazon/smithy/linters/MissingSensitiveTraitValidator.java
+++ b/smithy-linters/src/main/java/software/amazon/smithy/linters/MissingSensitiveTraitValidator.java
@@ -131,9 +131,9 @@ public final class MissingSensitiveTraitValidator extends AbstractValidator {
                 Shape containingShape = model.expectShape(memberShape.getContainer());
                 Shape targetShape = model.expectShape(memberShape.getTarget());
 
-                if (!containingShape.hasTrait(SensitiveTrait.class)
+                if (!containingShape.hasTrait(SensitiveTrait.ID)
                         && !containingShape.isEnumShape()
-                        && !targetShape.hasTrait(SensitiveTrait.class)) {
+                        && !targetShape.hasTrait(SensitiveTrait.ID)) {
                     Optional<ValidationEvent> optionalValidationEvent =
                             detectSensitiveTerms(memberShape.getMemberName(), memberShape);
                     optionalValidationEvent.ifPresent(validationEvents::add);
@@ -141,7 +141,7 @@ public final class MissingSensitiveTraitValidator extends AbstractValidator {
             } else if (!shape.isOperationShape()
                     && !shape.isServiceShape()
                     && !shape.isResourceShape()
-                    && !shape.hasTrait(SensitiveTrait.class)) {
+                    && !shape.hasTrait(SensitiveTrait.ID)) {
                 Optional<ValidationEvent> optionalValidationEvent =
                         detectSensitiveTerms(shape.toShapeId().getName(), shape);
                 optionalValidationEvent.ifPresent(validationEvents::add);

--- a/smithy-model/src/jmh/java/software/amazon/smithy/model/jmh/Selectors.java
+++ b/smithy-model/src/jmh/java/software/amazon/smithy/model/jmh/Selectors.java
@@ -121,10 +121,10 @@ public class Selectors {
         return model.shapes(ServiceShape.class).flatMap(service -> {
             Set<OperationShape> operations = topDownIndex.getContainedOperations(service);
             // Stop early if there are no bindings at all in the model for any operation.
-            if (operations.stream().noneMatch(o -> o.hasTrait(HttpTrait.class))) {
+            if (operations.stream().noneMatch(o -> o.hasTrait(HttpTrait.ID))) {
                 return Stream.empty();
             }
-            return operations.stream().filter(shape -> !shape.hasTrait(HttpTrait.class));
+            return operations.stream().filter(shape -> !shape.hasTrait(HttpTrait.ID));
         })
                 .collect(Collectors.toSet());
     }

--- a/smithy-model/src/jmh/java/software/amazon/smithy/model/jmh/TraitLookups.java
+++ b/smithy-model/src/jmh/java/software/amazon/smithy/model/jmh/TraitLookups.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.model.jmh;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.ModelAssembler;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.HttpErrorTrait;
+import software.amazon.smithy.model.traits.InputTrait;
+import software.amazon.smithy.model.traits.OutputTrait;
+import software.amazon.smithy.utils.ListUtils;
+
+@Warmup(iterations = 3)
+@Measurement(iterations = 3, timeUnit = TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@Fork(1)
+public class TraitLookups {
+    @State(Scope.Thread)
+    public static class TraitLookupState {
+        public List<ShapeId> shapeIds = new ArrayList<>();
+        public Model model;
+
+        @Setup
+        public void prepare() {
+            ModelAssembler assembler = new ModelAssembler();
+
+            for (String prefix : ListUtils.of("one", "two", "three", "four")) {
+                for (int i = 0; i < 100; i++) {
+                    ShapeId id = ShapeId.fromParts("ns.foo", prefix + i);
+                    shapeIds.add(id);
+                    StructureShape.Builder builder = StructureShape.builder()
+                            .id(id);
+                    switch (prefix) {
+                        case "four":
+                            builder.addTrait(new InputTrait());
+                        case "three":
+                            builder.addTrait(new OutputTrait());
+                        case "two":
+                            builder.addTrait(new ErrorTrait("client"));
+                        case "one":
+                            builder.addTrait(new HttpErrorTrait(400));
+                    }
+                    assembler.addShape(builder.build());
+                }
+            }
+
+            model = assembler
+                    .disableValidation()
+                    .assemble()
+                    .getResult()
+                    .get();
+        }
+    }
+
+    @Benchmark
+    public void hasTraitByShapeId(TraitLookupState state) {
+        for (ShapeId shapeId : state.shapeIds) {
+            state.model.expectShape(shapeId).hasTrait(InputTrait.ID);
+            state.model.expectShape(shapeId).hasTrait(OutputTrait.ID);
+            state.model.expectShape(shapeId).hasTrait(ErrorTrait.ID);
+            state.model.expectShape(shapeId).hasTrait(HttpErrorTrait.ID);
+        }
+    }
+
+    @Benchmark
+    public void hasTraitByShapeIdOld(TraitLookupState state) {
+        for (ShapeId shapeId : state.shapeIds) {
+            state.model.expectShape(shapeId).findTrait(InputTrait.ID).isPresent();
+            state.model.expectShape(shapeId).findTrait(OutputTrait.ID).isPresent();
+            state.model.expectShape(shapeId).findTrait(ErrorTrait.ID).isPresent();
+            state.model.expectShape(shapeId).findTrait(HttpErrorTrait.ID).isPresent();
+        }
+    }
+
+    @Benchmark
+    public void hasTraitByString(TraitLookupState state) {
+        for (ShapeId shapeId : state.shapeIds) {
+            state.model.expectShape(shapeId).hasTrait(InputTrait.ID.toString());
+            state.model.expectShape(shapeId).hasTrait(OutputTrait.ID.toString());
+            state.model.expectShape(shapeId).hasTrait(ErrorTrait.ID.toString());
+            state.model.expectShape(shapeId).hasTrait(HttpErrorTrait.ID.toString());
+        }
+    }
+
+    @Benchmark
+    public void hasTraitByClass(TraitLookupState state) {
+        for (ShapeId shapeId : state.shapeIds) {
+            state.model.expectShape(shapeId).hasTrait(InputTrait.class);
+            state.model.expectShape(shapeId).hasTrait(OutputTrait.class);
+            state.model.expectShape(shapeId).hasTrait(ErrorTrait.class);
+            state.model.expectShape(shapeId).hasTrait(HttpErrorTrait.class);
+        }
+    }
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/EventStreamIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/EventStreamIndex.java
@@ -52,7 +52,7 @@ public final class EventStreamIndex implements KnowledgeIndex {
     ) {
         for (MemberShape member : shape.getAllMembers().values()) {
             Shape target = model.expectShape(member.getTarget());
-            if (target.hasTrait(StreamingTrait.class) && target.isUnionShape()) {
+            if (target.hasTrait(StreamingTrait.ID) && target.isUnionShape()) {
                 createEventStreamInfo(model, operation, shape, member).ifPresent(info -> {
                     infoMap.put(operation.getId(), info);
                 });

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/HttpBindingIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/HttpBindingIndex.java
@@ -79,12 +79,12 @@ public final class HttpBindingIndex implements KnowledgeIndex {
      *  payload, prefix headers, query string, or label.
      */
     public static boolean hasHttpRequestBindings(Shape shape) {
-        return shape.hasTrait(HttpHeaderTrait.class)
-                || shape.hasTrait(HttpPrefixHeadersTrait.class)
-                || shape.hasTrait(HttpPayloadTrait.class)
-                || shape.hasTrait(HttpQueryTrait.class)
-                || shape.hasTrait(HttpQueryParamsTrait.class)
-                || shape.hasTrait(HttpLabelTrait.class);
+        return shape.hasTrait(HttpHeaderTrait.ID)
+                || shape.hasTrait(HttpPrefixHeadersTrait.ID)
+                || shape.hasTrait(HttpPayloadTrait.ID)
+                || shape.hasTrait(HttpQueryTrait.ID)
+                || shape.hasTrait(HttpQueryParamsTrait.ID)
+                || shape.hasTrait(HttpLabelTrait.ID);
     }
 
     /**
@@ -95,10 +95,10 @@ public final class HttpBindingIndex implements KnowledgeIndex {
      *  payload, of prefix headers.
      */
     public static boolean hasHttpResponseBindings(Shape shape) {
-        return shape.hasTrait(HttpHeaderTrait.class)
-                || shape.hasTrait(HttpPrefixHeadersTrait.class)
-                || shape.hasTrait(HttpPayloadTrait.class)
-                || shape.hasTrait(HttpResponseCodeTrait.class);
+        return shape.hasTrait(HttpHeaderTrait.ID)
+                || shape.hasTrait(HttpPrefixHeadersTrait.ID)
+                || shape.hasTrait(HttpPayloadTrait.ID)
+                || shape.hasTrait(HttpResponseCodeTrait.ID);
     }
 
     private HttpTrait getHttpTrait(ToShapeId operation) {
@@ -129,9 +129,9 @@ public final class HttpBindingIndex implements KnowledgeIndex {
 
         if (shape.isOperationShape()) {
             return getHttpTrait(id).getCode();
-        } else if (shape.getTrait(HttpErrorTrait.class).isPresent()) {
+        } else if (shape.hasTrait(HttpErrorTrait.ID)) {
             return shape.getTrait(HttpErrorTrait.class).get().getCode();
-        } else if (shape.getTrait(ErrorTrait.class).isPresent()) {
+        } else if (shape.hasTrait(ErrorTrait.ID)) {
             return shape.getTrait(ErrorTrait.class).get().getDefaultHttpStatusCode();
         }
 
@@ -364,7 +364,7 @@ public final class HttpBindingIndex implements KnowledgeIndex {
                         || target.isMapShape()) {
                     // Document type and structure targets are always the document content-type.
                     return documentContentType;
-                } else if (target.getTrait(MediaTypeTrait.class).isPresent()) {
+                } else if (target.hasTrait(MediaTypeTrait.ID)) {
                     // Use the @mediaType trait if available.
                     return target.getTrait(MediaTypeTrait.class).get().getValue();
                 } else if (target.isBlobShape()) {
@@ -422,27 +422,27 @@ public final class HttpBindingIndex implements KnowledgeIndex {
         boolean foundPayload = false;
 
         for (MemberShape member : struct.getAllMembers().values()) {
-            if (member.getTrait(HttpHeaderTrait.class).isPresent()) {
-                HttpHeaderTrait trait = member.getTrait(HttpHeaderTrait.class).get();
+            if (member.hasTrait(HttpHeaderTrait.ID)) {
+                HttpHeaderTrait trait = member.expectTrait(HttpHeaderTrait.class);
                 bindings.add(new HttpBinding(member, HttpBinding.Location.HEADER, trait.getValue(), trait));
-            } else if (member.getTrait(HttpPrefixHeadersTrait.class).isPresent()) {
-                HttpPrefixHeadersTrait trait = member.getTrait(HttpPrefixHeadersTrait.class).get();
+            } else if (member.hasTrait(HttpPrefixHeadersTrait.ID)) {
+                HttpPrefixHeadersTrait trait = member.expectTrait(HttpPrefixHeadersTrait.class);
                 bindings.add(new HttpBinding(member, HttpBinding.Location.PREFIX_HEADERS, trait.getValue(), trait));
-            } else if (isRequest && member.getTrait(HttpQueryTrait.class).isPresent()) {
-                HttpQueryTrait trait = member.getTrait(HttpQueryTrait.class).get();
+            } else if (isRequest && member.hasTrait(HttpQueryTrait.ID)) {
+                HttpQueryTrait trait = member.expectTrait(HttpQueryTrait.class);
                 bindings.add(new HttpBinding(member, HttpBinding.Location.QUERY, trait.getValue(), trait));
-            } else if (isRequest && member.getTrait(HttpQueryParamsTrait.class).isPresent()) {
-                HttpQueryParamsTrait trait = member.getTrait(HttpQueryParamsTrait.class).get();
+            } else if (isRequest && member.hasTrait(HttpQueryParamsTrait.ID)) {
+                HttpQueryParamsTrait trait = member.expectTrait(HttpQueryParamsTrait.class);
                 bindings.add(new HttpBinding(member, HttpBinding.Location.QUERY_PARAMS, member.getMemberName(), trait));
-            } else if (member.getTrait(HttpPayloadTrait.class).isPresent()) {
+            } else if (member.hasTrait(HttpPayloadTrait.ID)) {
                 foundPayload = true;
-                HttpPayloadTrait trait = member.getTrait(HttpPayloadTrait.class).get();
+                HttpPayloadTrait trait = member.expectTrait(HttpPayloadTrait.class);
                 bindings.add(new HttpBinding(member, HttpBinding.Location.PAYLOAD, member.getMemberName(), trait));
-            } else if (isRequest && member.getTrait(HttpLabelTrait.class).isPresent()) {
-                HttpLabelTrait trait = member.getTrait(HttpLabelTrait.class).get();
+            } else if (isRequest && member.hasTrait(HttpLabelTrait.ID)) {
+                HttpLabelTrait trait = member.expectTrait(HttpLabelTrait.class);
                 bindings.add(new HttpBinding(member, HttpBinding.Location.LABEL, member.getMemberName(), trait));
-            } else if (!isRequest && member.getTrait(HttpResponseCodeTrait.class).isPresent()) {
-                HttpResponseCodeTrait trait = member.getTrait(HttpResponseCodeTrait.class).get();
+            } else if (!isRequest && member.hasTrait(HttpResponseCodeTrait.ID)) {
+                HttpResponseCodeTrait trait = member.expectTrait(HttpResponseCodeTrait.class);
                 bindings.add(new HttpBinding(
                         member,
                         HttpBinding.Location.RESPONSE_CODE,

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/IdentifierBindingIndex.java
@@ -150,14 +150,14 @@ public final class IdentifierBindingIndex implements KnowledgeIndex {
 
     private boolean isImplicitIdentifierBinding(MemberShape member, ResourceShape resource) {
         return resource.getIdentifiers().containsKey(member.getMemberName())
-                && member.getTrait(RequiredTrait.class).isPresent()
+                && member.hasTrait(RequiredTrait.ID)
                 && member.getTarget().equals(resource.getIdentifiers().get(member.getMemberName()));
     }
 
     private Map<String, String> computeBindings(ResourceShape resource, StructureShape shape) {
         Map<String, String> bindings = new HashMap<>();
         for (MemberShape member : shape.getAllMembers().values()) {
-            if (member.hasTrait(ResourceIdentifierTrait.class)) {
+            if (member.hasTrait(ResourceIdentifierTrait.ID)) {
                 // Mark as a binding if the member has an explicit @resourceIdentifier trait.
                 String bindingName = member.expectTrait(ResourceIdentifierTrait.class).getValue();
                 // Override any implicit bindings with explicit trait bindings.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/NullableIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/NullableIndex.java
@@ -52,7 +52,7 @@ public class NullableIndex implements KnowledgeIndex {
         CLIENT {
             @Override
             boolean isStructureMemberOptional(StructureShape container, MemberShape member, Shape target) {
-                if (member.hasTrait(ClientOptionalTrait.class) || container.hasTrait(InputTrait.class)) {
+                if (member.hasTrait(ClientOptionalTrait.ID) || container.hasTrait(InputTrait.ID)) {
                     return true;
                 }
 
@@ -86,7 +86,7 @@ public class NullableIndex implements KnowledgeIndex {
         CLIENT_ZERO_VALUE_V1 {
             @Override
             boolean isStructureMemberOptional(StructureShape container, MemberShape member, Shape target) {
-                return container.hasTrait(InputTrait.class)
+                return container.hasTrait(InputTrait.ID)
                         || CLIENT_ZERO_VALUE_V1_NO_INPUT.isStructureMemberOptional(container, member, target);
             }
         },
@@ -101,7 +101,7 @@ public class NullableIndex implements KnowledgeIndex {
         CLIENT_ZERO_VALUE_V1_NO_INPUT {
             @Override
             boolean isStructureMemberOptional(StructureShape container, MemberShape member, Shape target) {
-                if (member.hasTrait(AddedDefaultTrait.class) || member.hasTrait(ClientOptionalTrait.class)) {
+                if (member.hasTrait(AddedDefaultTrait.ID) || member.hasTrait(ClientOptionalTrait.ID)) {
                     return true;
                 }
 
@@ -128,7 +128,7 @@ public class NullableIndex implements KnowledgeIndex {
                 // 1. Does the member have the required trait? Stop further checks, it's non-optional.
                 // 2. Does the member have a default trait set to null? Stop further checks, it's optional.
                 // 3. Does the member have a default trait not set to null? Stop further checks, it's non-optional.
-                return !member.hasTrait(RequiredTrait.class) && !member.hasNonNullDefault();
+                return !member.hasTrait(RequiredTrait.ID) && !member.hasNonNullDefault();
             }
         };
 
@@ -180,7 +180,7 @@ public class NullableIndex implements KnowledgeIndex {
                 // fall-through.
             case LIST:
                 // Map values and list members are only null if they have the @sparse trait.
-                return container.hasTrait(SparseTrait.class);
+                return container.hasTrait(SparseTrait.ID);
             default:
                 return false;
         }
@@ -221,7 +221,7 @@ public class NullableIndex implements KnowledgeIndex {
             case LONG:
             case FLOAT:
             case DOUBLE:
-                return shape.hasTrait(BoxTrait.class);
+                return shape.hasTrait(BoxTrait.ID);
             default:
                 return true;
         }
@@ -246,7 +246,7 @@ public class NullableIndex implements KnowledgeIndex {
                 } // fall-through
             case LIST:
                 // Sparse lists and maps are considered nullable.
-                return container.hasTrait(SparseTrait.class);
+                return container.hasTrait(SparseTrait.ID);
             default:
                 return false;
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/OperationIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/OperationIndex.java
@@ -145,7 +145,7 @@ public final class OperationIndex implements KnowledgeIndex {
      * @return Returns true if the structure is used as input.
      */
     public boolean isInputStructure(ToShapeId structureId) {
-        if (structureId instanceof Shape && ((Shape) structureId).hasTrait(InputTrait.class)) {
+        if (structureId instanceof Shape && ((Shape) structureId).hasTrait(InputTrait.ID)) {
             return true;
         }
 
@@ -238,7 +238,7 @@ public final class OperationIndex implements KnowledgeIndex {
      * @return Returns true if the structure is used as output.
      */
     public boolean isOutputStructure(ToShapeId structureId) {
-        if (structureId instanceof Shape && ((Shape) structureId).hasTrait(OutputTrait.class)) {
+        if (structureId instanceof Shape && ((Shape) structureId).hasTrait(OutputTrait.ID)) {
             return true;
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PaginatedIndex.java
@@ -42,7 +42,7 @@ public final class PaginatedIndex implements KnowledgeIndex {
             PaginatedTrait serviceTrait = service.getTrait(PaginatedTrait.class).orElse(null);
             Map<ShapeId, PaginationInfo> mappings = new HashMap<>();
             for (OperationShape operation : topDownIndex.getContainedOperations(service)) {
-                if (operation.hasTrait(PaginatedTrait.class)) {
+                if (operation.hasTrait(PaginatedTrait.ID)) {
                     PaginatedTrait merged = operation.expectTrait(PaginatedTrait.class).merge(serviceTrait);
                     create(model, service, opIndex, operation, merged).ifPresent(info -> {
                         mappings.put(info.getOperation().getId(), info);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PropertyBindingIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/PropertyBindingIndex.java
@@ -178,8 +178,8 @@ public final class PropertyBindingIndex implements KnowledgeIndex {
         Model model = getModel();
         return model.getShapesWithTrait(NotPropertyTrait.class)
                 .stream()
-                .filter(shape -> shape.hasTrait(TraitDefinition.class))
-                .map(shape -> shape.toShapeId())
+                .filter(shape -> shape.hasTrait(TraitDefinition.ID))
+                .map(Shape::toShapeId)
                 .collect(Collectors.toSet());
     }
 
@@ -188,13 +188,13 @@ public final class PropertyBindingIndex implements KnowledgeIndex {
     }
 
     private boolean doesNotRequireProperty(MemberShape memberShape) {
-        return notPropertyMetaTraitSet.stream().anyMatch(traitId -> memberShape.hasTrait(traitId));
+        return notPropertyMetaTraitSet.stream().anyMatch(memberShape::hasTrait);
     }
 
     private StructureShape getPropertiesShape(Collection<MemberShape> members, StructureShape presumedShape) {
         Model model = getModel();
         for (MemberShape member : members) {
-            if (member.hasTrait(NestedPropertiesTrait.class)) {
+            if (member.hasTrait(NestedPropertiesTrait.ID)) {
                 Shape shape = model.expectShape(member.getTarget());
                 if (shape.isStructureShape()) {
                     return shape.asStructureShape().get();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/ServiceIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/ServiceIndex.java
@@ -275,12 +275,12 @@ public final class ServiceIndex implements KnowledgeIndex {
     private boolean hasOptionalAuth(ToShapeId operation) {
         return getModel()
                 .getShape(operation.toShapeId())
-                .filter(shape -> shape.hasTrait(OptionalAuthTrait.class))
+                .filter(shape -> shape.hasTrait(OptionalAuthTrait.ID))
                 .isPresent();
     }
 
     private static Map<ShapeId, Trait> getAuthTraitValues(Shape service, Shape subject) {
-        if (!subject.hasTrait(AuthTrait.class)) {
+        if (!subject.hasTrait(AuthTrait.ID)) {
             return null;
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelInteropTransformer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/ModelInteropTransformer.java
@@ -106,7 +106,7 @@ final class ModelInteropTransformer {
             Node defaultValue = getDefaultValueOfType(member, target.getType());
             builder.addTrait(new DefaultTrait(defaultValue));
             shapeUpgrades.add(builder.build());
-        } else if (member.hasTrait(BoxTrait.class)) {
+        } else if (member.hasTrait(BoxTrait.ID)) {
             // Add a default trait to the member set to null to indicate it was boxed in v1.
             MemberShape.Builder builder = member.toBuilder();
             builder.addTrait(new DefaultTrait(new NullNode(member.getSourceLocation())));
@@ -169,7 +169,7 @@ final class ModelInteropTransformer {
     // The addedDefault trait implies that a member did not previously have a default, and a default value
     // was added later. In this case, naive box implementation can assume the member is boxed.
     private boolean isMemberInherentlyBoxedInV1(MemberShape member) {
-        return member.hasTrait(AddedDefaultTrait.class);
+        return member.hasTrait(AddedDefaultTrait.ID);
     }
 
     // If the member has a default trait set to the zero value, then consider the member

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/Prelude.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/Prelude.java
@@ -50,7 +50,7 @@ public final class Prelude {
      */
     public static boolean isPublicPreludeShape(ToShapeId id) {
         return getPreludeModel().getShape(id.toShapeId())
-                .filter(shape -> !shape.hasTrait(PrivateTrait.class))
+                .filter(shape -> !shape.hasTrait(PrivateTrait.ID))
                 .isPresent();
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/IdRefShapeRelationships.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/neighbor/IdRefShapeRelationships.java
@@ -43,7 +43,7 @@ final class IdRefShapeRelationships {
     Map<ShapeId, Set<Relationship>> getRelationships() {
         PathFinder finder = PathFinder.create(model);
         for (Shape traitDef : model.getShapesWithTrait(TraitDefinition.class)) {
-            if (traitDef.hasTrait(IdRefTrait.class)) {
+            if (traitDef.hasTrait(IdRefTrait.ID)) {
                 // PathFinder doesn't handle the case where the trait def has the idRef
                 NodeQuery query = new NodeQuery().self();
                 addRelationships(traitDef, query);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EnumShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/EnumShape.java
@@ -285,7 +285,7 @@ public final class EnumShape extends StringShape {
                 .orElse(Collections.emptyList());
 
         builder.tags(tags);
-        if (member.hasTrait(InternalTrait.class) && !tags.contains("internal")) {
+        if (member.hasTrait(InternalTrait.ID) && !tags.contains("internal")) {
             builder.addTag("internal");
         }
         return builder.build();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MemberShape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/MemberShape.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.model.shapes;
 import java.util.Optional;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.traits.DefaultTrait;
+import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.utils.OptionalUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
@@ -81,7 +82,7 @@ public final class MemberShape extends Shape implements ToSmithyBuilder<MemberSh
      * @return Returns true if the member has the required trait.
      */
     public boolean isRequired() {
-        return findTrait("required").isPresent();
+        return hasTrait(RequiredTrait.ID);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/Shape.java
@@ -262,7 +262,7 @@ public abstract class Shape implements FromSourceLocation, Tagged, ToShapeId, Co
      * @return Returns true if the shape has the given trait.
      */
     public boolean hasTrait(ShapeId id) {
-        return findTrait(id).isPresent();
+        return traits.containsKey(id);
     }
 
     /**

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlComponentOrder.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlComponentOrder.java
@@ -118,11 +118,11 @@ public enum SmithyIdlComponentOrder {
         @Override
         public int compare(Shape s1, Shape s2) {
             // Traits go first
-            if (s1.hasTrait(TraitDefinition.class) || s2.hasTrait(TraitDefinition.class)) {
-                if (!s1.hasTrait(TraitDefinition.class)) {
+            if (s1.hasTrait(TraitDefinition.ID) || s2.hasTrait(TraitDefinition.ID)) {
+                if (!s1.hasTrait(TraitDefinition.ID)) {
                     return 1;
                 }
-                if (!s2.hasTrait(TraitDefinition.class)) {
+                if (!s2.hasTrait(TraitDefinition.ID)) {
                     return -1;
                 }
                 // The other sorting rules don't matter for traits.

--- a/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java
@@ -635,7 +635,7 @@ public final class SmithyIdlModelSerializer {
                     for (MemberShape member : members) {
                         serializeTraits(member.getAllTraits(), TraitFeature.MEMBER);
                         String assignment = "";
-                        if (member.hasTrait(DefaultTrait.class)) {
+                        if (member.hasTrait(DefaultTrait.ID)) {
                             assignment = " = " + Node.printJson(member.expectTrait(DefaultTrait.class).toNode());
                         }
                         codeWriter.write("$L: $I$L", member.getMemberName(), member.getTarget(), assignment);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/AddClientOptional.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/AddClientOptional.java
@@ -33,17 +33,17 @@ final class AddClientOptional {
             MemberShape member = (MemberShape) shape;
 
             // Don't do anything if it's already marked with clientOptional.
-            if (member.hasTrait(ClientOptionalTrait.class)) {
+            if (member.hasTrait(ClientOptionalTrait.ID)) {
                 return member;
             }
 
             Shape container = model.expectShape(member.getContainer());
             Shape target = model.expectShape(member.getTarget());
 
-            boolean hasInputTrait = container.hasTrait(InputTrait.class);
+            boolean hasInputTrait = container.hasTrait(InputTrait.ID);
             boolean targetsShapeWithNoZeroValue = target.isStructureShape() || target.isUnionShape();
             boolean isEffectivelyClientOptional = hasInputTrait
-                    || !(member.hasTrait(RequiredTrait.class) || member.hasTrait(DefaultTrait.class))
+                    || !(member.hasTrait(RequiredTrait.ID) || member.hasTrait(DefaultTrait.ID))
                     || (targetsShapeWithNoZeroValue && applyWhenNoDefaultValue);
 
             if (isEffectivelyClientOptional) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/CreateDedicatedInputAndOutput.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/CreateDedicatedInputAndOutput.java
@@ -99,7 +99,7 @@ final class CreateDedicatedInputAndOutput {
             StructureShape input,
             NeighborProvider reverse
     ) {
-        if (input.hasTrait(InputTrait.class)) {
+        if (input.hasTrait(InputTrait.ID)) {
             return renameShapeIfNeeded(model, input, operation, inputSuffix);
         } else if (isDedicatedHeuristic(operation, input, reverse)) {
             LOGGER.fine(() -> "Attaching the @input trait to " + input.getId());
@@ -116,7 +116,7 @@ final class CreateDedicatedInputAndOutput {
             StructureShape output,
             NeighborProvider reverse
     ) {
-        if (output.hasTrait(OutputTrait.class)) {
+        if (output.hasTrait(OutputTrait.ID)) {
             return renameShapeIfNeeded(model, output, operation, outputSuffix);
         } else if (isDedicatedHeuristic(operation, output, reverse)) {
             LOGGER.fine(() -> "Attaching the @output trait to " + output.getId());

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/DowngradeToV1.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/DowngradeToV1.java
@@ -126,7 +126,7 @@ final class DowngradeToV1 {
 
         for (StructureShape structure : model.getStructureShapes()) {
             for (MemberShape member : structure.getAllMembers().values()) {
-                if (member.hasTrait(ClientOptionalTrait.class)) {
+                if (member.hasTrait(ClientOptionalTrait.ID)) {
                     updates.add(member.toBuilder().removeTrait(ClientOptionalTrait.ID).build());
                 }
             }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/FlattenAndRemoveMixins.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/FlattenAndRemoveMixins.java
@@ -20,7 +20,7 @@ final class FlattenAndRemoveMixins {
         List<ShapeId> toRemove = new ArrayList<>();
 
         for (Shape shape : model.toSet()) {
-            if (shape.hasTrait(MixinTrait.class)) {
+            if (shape.hasTrait(MixinTrait.ID)) {
                 toRemove.add(shape.getId());
             } else if (!shape.getMixins().isEmpty()) {
                 updatedShapes.add(Shape.shapeToBuilder(shape).flattenMixins().build());

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptional.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptional.java
@@ -19,9 +19,9 @@ final class MakeIdempotencyTokenClientOptional {
     public static Model transform(Model model) {
         return ModelTransformer.create().mapShapes(model, shape -> {
             if (shape.isMemberShape()
-                    && shape.hasTrait(RequiredTrait.class)
-                    && shape.hasTrait(IdempotencyTokenTrait.class)
-                    && !shape.hasTrait(ClientOptionalTrait.class)) {
+                    && shape.hasTrait(RequiredTrait.ID)
+                    && shape.hasTrait(IdempotencyTokenTrait.ID)
+                    && !shape.hasTrait(ClientOptionalTrait.ID)) {
                 return Shape.shapeToBuilder(shape).addTrait(new ClientOptionalTrait()).build();
             }
             return shape;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/RemoveInvalidDefaults.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/RemoveInvalidDefaults.java
@@ -62,7 +62,7 @@ final class RemoveInvalidDefaults {
             MemberShape member = shape.asMemberShape().get();
             boolean targetHasDefault = model.getShape(member.getTarget())
                     // Treat target shapes that will have their default removed as if it doesn't have a default.
-                    .filter(target -> !otherShapes.contains(target) && target.hasTrait(DefaultTrait.class))
+                    .filter(target -> !otherShapes.contains(target) && target.hasTrait(DefaultTrait.ID))
                     .isPresent();
             if (targetHasDefault) {
                 return member.toBuilder().addTrait(new DefaultTrait(Node.nullNode())).build();

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ReplaceShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ReplaceShapes.java
@@ -165,7 +165,7 @@ final class ReplaceShapes {
 
         // Add shapes that are mixins or use mixins.
         for (Shape shape : model.toSet()) {
-            if (!shape.isMemberShape() && (shape.hasTrait(MixinTrait.class) || !shape.getMixins().isEmpty())) {
+            if (!shape.isMemberShape() && (shape.hasTrait(MixinTrait.ID) || !shape.getMixins().isEmpty())) {
                 sorter.enqueue(shape);
             }
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/ScrubTraitDefinitions.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/ScrubTraitDefinitions.java
@@ -41,7 +41,7 @@ final class ScrubTraitDefinitions {
         // Find all trait definition shapes, excluding those to be kept, and private shapes in the prelude.
         Set<Shape> toMark = Stream.concat(
                 model.shapes().filter(shape -> isTraitDefinitionToRemove(shape, keepFilter)),
-                model.shapes().filter(shape -> Prelude.isPreludeShape(shape) && shape.hasTrait(PrivateTrait.class)))
+                model.shapes().filter(shape -> Prelude.isPreludeShape(shape) && shape.hasTrait(PrivateTrait.ID)))
                 .collect(Collectors.toSet());
 
         MarkAndSweep markAndSweep = new MarkAndSweep(
@@ -58,10 +58,10 @@ final class ScrubTraitDefinitions {
     }
 
     private static boolean notPublicPreludeShape(Shape shape) {
-        return !(Prelude.isPublicPreludeShape(shape.getId()) && !shape.hasTrait(TraitDefinition.class));
+        return !(Prelude.isPublicPreludeShape(shape.getId()) && !shape.hasTrait(TraitDefinition.ID));
     }
 
     private static boolean isTraitDefinitionToRemove(Shape shape, Predicate<Shape> keepFilter) {
-        return shape.hasTrait(TraitDefinition.class) && keepFilter.test(shape);
+        return shape.hasTrait(TraitDefinition.ID) && keepFilter.test(shape);
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/RemoveMixins.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/RemoveMixins.java
@@ -32,7 +32,7 @@ public final class RemoveMixins implements ModelTransformerPlugin {
         Map<Shape, Set<Shape>> mixinShapesToRemove = new HashMap<>();
 
         for (Shape removedShape : shapes) {
-            if (removedShape.hasTrait(MixinTrait.class) && !removedShape.isMemberShape()) {
+            if (removedShape.hasTrait(MixinTrait.ID) && !removedShape.isMemberShape()) {
                 // Remove the mixin from any shape that uses it.
                 Stream.concat(model.shapes(StructureShape.class), model.shapes(UnionShape.class)).forEach(shape -> {
                     if (shape.getMixins().contains(removedShape.getId())) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/RemoveTraits.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/plugins/RemoveTraits.java
@@ -28,7 +28,7 @@ public final class RemoveTraits implements ModelTransformerPlugin {
         // Find all shapes with the "@trait" trait to ensure references to it are removed
         // from other shapes.
         Set<ShapeId> removedTraits = shapes.stream()
-                .filter(shape -> shape.hasTrait(TraitDefinition.class))
+                .filter(shape -> shape.hasTrait(TraitDefinition.ID))
                 .map(Shape::getId)
                 .collect(Collectors.toSet());
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/RangeTraitPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/RangeTraitPlugin.java
@@ -23,7 +23,7 @@ class RangeTraitPlugin implements NodeValidatorPlugin {
 
     @Override
     public final void apply(Shape shape, Node value, Context context, Emitter emitter) {
-        if (shape.hasTrait(RangeTrait.class)) {
+        if (shape.hasTrait(RangeTrait.ID)) {
             if (value.isNumberNode()) {
                 check(shape, context, shape.expectTrait(RangeTrait.class), value.expectNumberNode(), emitter);
             } else if (value.isStringNode()) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampFormatPlugin.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/node/TimestampFormatPlugin.java
@@ -30,15 +30,15 @@ final class TimestampFormatPlugin implements NodeValidatorPlugin {
         if (shape instanceof TimestampShape) {
             // Don't validate the timestamp target if a referring member had the timestampFormat trait.
             boolean fromMemberWithTrait = context.getReferringMember()
-                    .filter(member -> member.hasTrait(TimestampFormatTrait.class))
+                    .filter(member -> member.hasTrait(TimestampFormatTrait.ID))
                     .isPresent();
             if (!fromMemberWithTrait) {
                 validate(shape, shape.getTrait(TimestampFormatTrait.class).orElse(null), value, emitter);
             }
-        } else if (shape instanceof MemberShape && shape.getTrait(TimestampFormatTrait.class).isPresent()) {
+        } else if (shape instanceof MemberShape && shape.hasTrait(TimestampFormatTrait.ID)) {
             // Only perform timestamp format validation on a member when it references
             // a timestamp shape and the member has an explicit timestampFormat trait.
-            validate(shape, shape.getTrait(TimestampFormatTrait.class).get(), value, emitter);
+            validate(shape, shape.expectTrait(TimestampFormatTrait.class), value, emitter);
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/suppressions/ModelBasedEventDecorator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/suppressions/ModelBasedEventDecorator.java
@@ -150,7 +150,7 @@ public final class ModelBasedEventDecorator {
             ShapeId target = event.getShapeId().get();
             Shape shape = model.getShape(target).orElse(null);
             if (shape != null) {
-                if (shape.hasTrait(SuppressTrait.class)) {
+                if (shape.hasTrait(SuppressTrait.ID)) {
                     Suppression suppression = Suppression.fromSuppressTrait(shape);
                     if (suppression.test(event)) {
                         return changeSeverity(event, Severity.SUPPRESSED, suppression.getReason().orElse(null));

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/AuthTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/AuthTraitValidator.java
@@ -52,8 +52,8 @@ public final class AuthTraitValidator extends AbstractValidator {
             Shape shape,
             List<ValidationEvent> events
     ) {
-        if (shape.getTrait(AuthTrait.class).isPresent()) {
-            AuthTrait authTrait = shape.getTrait(AuthTrait.class).get();
+        if (shape.hasTrait(AuthTrait.ID)) {
+            AuthTrait authTrait = shape.expectTrait(AuthTrait.class);
             Set<ShapeId> appliedAuthTraitValue = new TreeSet<>(authTrait.getValueSet());
             appliedAuthTraitValue.removeAll(serviceAuth);
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/DefaultValueInUpdateValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/DefaultValueInUpdateValidator.java
@@ -39,7 +39,7 @@ public final class DefaultValueInUpdateValidator extends AbstractValidator {
             StructureShape input = model.expectShape(operation.getInputShape(), StructureShape.class);
 
             for (MemberShape member : input.getAllMembers().values()) {
-                if (member.hasTrait(DefaultTrait.class)) {
+                if (member.hasTrait(DefaultTrait.ID)) {
                     defaultedMembers.add(member.getMemberName());
                 }
             }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/DeprecatedTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/DeprecatedTraitValidator.java
@@ -34,7 +34,7 @@ public final class DeprecatedTraitValidator extends AbstractValidator {
         List<ValidationEvent> events = new ArrayList<>();
 
         for (Shape trait : model.getShapesWithTrait(TraitDefinition.class)) {
-            if (trait.hasTrait(DeprecatedTrait.class)) {
+            if (trait.hasTrait(DeprecatedTrait.ID)) {
                 // Don't emit for deprecation warnings that are handled by some other validation.
                 if (HANDLED_ELSEWHERE.contains(trait.toShapeId())) {
                     continue;

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/EventPayloadTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/EventPayloadTraitValidator.java
@@ -61,6 +61,6 @@ public final class EventPayloadTraitValidator extends AbstractValidator {
     }
 
     private boolean isMarked(Shape s) {
-        return s.getTrait(EventHeaderTrait.class).isPresent() || s.getTrait(EventPayloadTrait.class).isPresent();
+        return s.hasTrait(EventHeaderTrait.ID) || s.hasTrait(EventPayloadTrait.ID);
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HostLabelTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HostLabelTraitValidator.java
@@ -103,7 +103,7 @@ public final class HostLabelTraitValidator extends AbstractValidator {
                 .collect(Collectors.toSet());
 
         for (MemberShape member : input.getAllMembers().values()) {
-            if (member.hasTrait(HostLabelTrait.class)) {
+            if (member.hasTrait(HostLabelTrait.ID)) {
                 HostLabelTrait trait = member.expectTrait(HostLabelTrait.class);
                 labels.remove(member.getMemberName());
                 if (!hostPrefix.getLabel(member.getMemberName()).isPresent()) {

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpBindingTraitIgnoredValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpBindingTraitIgnoredValidator.java
@@ -73,7 +73,7 @@ public class HttpBindingTraitIgnoredValidator extends AbstractValidator {
         for (MemberShape memberShape : model.getMemberShapes()) {
             Shape container = model.expectShape(memberShape.getContainer());
             // Skip non-structures (invalid) and mixins (handled at mixed site).
-            if (!container.isStructureShape() || container.hasTrait(MixinTrait.class)) {
+            if (!container.isStructureShape() || container.hasTrait(MixinTrait.ID)) {
                 continue;
             }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpBindingsMissingValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpBindingsMissingValidator.java
@@ -71,7 +71,7 @@ public final class HttpBindingsMissingValidator extends AbstractValidator {
     }
 
     private boolean hasBindings(OperationShape op) {
-        return op.getTrait(HttpTrait.class).isPresent();
+        return op.hasTrait(HttpTrait.ID);
     }
 
     private List<ValidationEvent> validateOperations(
@@ -81,7 +81,7 @@ public final class HttpBindingsMissingValidator extends AbstractValidator {
             String reason
     ) {
         return operations.stream()
-                .filter(operation -> !operation.getTrait(HttpTrait.class).isPresent())
+                .filter(operation -> !operation.hasTrait(HttpTrait.ID))
                 .map(operation -> createEvent(severity,
                         operation,
                         operation.getSourceLocation(),

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpHeaderTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpHeaderTraitValidator.java
@@ -177,7 +177,7 @@ public final class HttpHeaderTraitValidator extends AbstractValidator {
         return structure.getAllMembers()
                 .values()
                 .stream()
-                .filter(member -> member.hasTrait(HttpHeaderTrait.class))
+                .filter(member -> member.hasTrait(HttpHeaderTrait.ID))
                 .collect(groupingBy(shape -> shape.expectTrait(HttpHeaderTrait.class).getValue().toLowerCase(Locale.US),
                         mapping(MemberShape::getMemberName, toList())))
                 .entrySet()

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpMethodSemanticsValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpMethodSemanticsValidator.java
@@ -118,7 +118,7 @@ public final class HttpMethodSemanticsValidator extends AbstractValidator {
             events.add(warning(shape, trait, semantics.warningWhenModeled, method));
         }
 
-        boolean isReadonly = shape.getTrait(ReadonlyTrait.class).isPresent();
+        boolean isReadonly = shape.hasTrait(ReadonlyTrait.ID);
         if (semantics.isReadonly != null && semantics.isReadonly != isReadonly) {
             events.add(warning(shape,
                     trait,
@@ -129,7 +129,7 @@ public final class HttpMethodSemanticsValidator extends AbstractValidator {
                     isReadonly ? UNNECESSARY_READONLY_TRAIT : MISSING_READONLY_TRAIT));
         }
 
-        boolean isIdempotent = shape.getTrait(IdempotentTrait.class).isPresent();
+        boolean isIdempotent = shape.hasTrait(IdempotentTrait.ID);
         if (semantics.isIdempotent != null && semantics.isIdempotent != isIdempotent) {
             events.add(warning(shape,
                     trait,

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpUriConflictValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/HttpUriConflictValidator.java
@@ -52,7 +52,7 @@ public final class HttpUriConflictValidator extends AbstractValidator {
     private List<ValidationEvent> validateService(Model model, ServiceShape service) {
         List<OperationShape> operations = new ArrayList<>();
         for (OperationShape operation : TopDownIndex.of(model).getContainedOperations(service)) {
-            if (operation.hasTrait(HttpTrait.class)) {
+            if (operation.hasTrait(HttpTrait.ID)) {
                 operations.add(operation);
             }
         }
@@ -79,7 +79,7 @@ public final class HttpUriConflictValidator extends AbstractValidator {
         List<Pair<ShapeId, UriPattern>> allowableConflicts = new ArrayList<>();
 
         for (OperationShape other : operations) {
-            if (other != operation && other.hasTrait(HttpTrait.class)) {
+            if (other != operation && other.hasTrait(HttpTrait.ID)) {
                 HttpTrait otherHttpTrait = other.expectTrait(HttpTrait.class);
                 if (otherHttpTrait.getMethod().equals(method)
                         && otherHttpTrait.getUri().conflictsWith(pattern)
@@ -210,7 +210,7 @@ public final class HttpUriConflictValidator extends AbstractValidator {
     private Map<String, Pattern> getHostLabelPatterns(Model model, OperationShape operation) {
         Map<String, Pattern> result = new HashMap<>();
         for (MemberShape member : OperationIndex.of(model).expectInputShape(operation).getAllMembers().values()) {
-            if (member.hasTrait(HostLabelTrait.class) && member.hasTrait(PatternTrait.class)) {
+            if (member.hasTrait(HostLabelTrait.ID) && member.hasTrait(PatternTrait.ID)) {
                 result.put(member.getMemberName(), member.expectTrait(PatternTrait.class).getPattern());
             }
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/IdempotencyTokenIgnoredValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/IdempotencyTokenIgnoredValidator.java
@@ -43,7 +43,7 @@ public final class IdempotencyTokenIgnoredValidator extends AbstractValidator {
         for (MemberShape memberShape : model.getMemberShapesWithTrait(IdempotencyTokenTrait.class)) {
             Shape container = model.expectShape(memberShape.getContainer());
             // Skip non-structures (invalid) and mixins (handled at mixed site).
-            if (!container.isStructureShape() || container.hasTrait(MixinTrait.class)) {
+            if (!container.isStructureShape() || container.hasTrait(MixinTrait.ID)) {
                 continue;
             }
             Trait trait = memberShape.expectTrait(IdempotencyTokenTrait.class);

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/MemberShouldReferenceResourceValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/MemberShouldReferenceResourceValidator.java
@@ -125,7 +125,7 @@ public final class MemberShouldReferenceResourceValidator extends AbstractValida
     }
 
     private void ignoreReferencedResources(Shape shape, Set<ShapeId> resourcesToIgnore) {
-        if (shape.hasTrait(ReferencesTrait.class)) {
+        if (shape.hasTrait(ReferencesTrait.ID)) {
             for (ReferencesTrait.Reference reference : shape.expectTrait(ReferencesTrait.class)
                     .getReferences()) {
                 resourcesToIgnore.add(reference.getResource());

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/RequestCompressionTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/RequestCompressionTraitValidator.java
@@ -50,7 +50,7 @@ public final class RequestCompressionTraitValidator extends AbstractValidator {
         StructureShape inputShape = model.expectShape(operationShape.getInputShape(), StructureShape.class);
         for (MemberShape memberShape : inputShape.members()) {
             Shape targetShape = model.expectShape(memberShape.getTarget());
-            if (targetShape.hasTrait(StreamingTrait.class) && targetShape.hasTrait(RequiresLengthTrait.class)) {
+            if (targetShape.hasTrait(StreamingTrait.ID) && targetShape.hasTrait(RequiresLengthTrait.ID)) {
                 events.add(error(operationShape,
                         String.format(
                                 "The `requestCompression` trait can only be applied to operations which do not have "

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ResourceIdentifierBindingValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ResourceIdentifierBindingValidator.java
@@ -102,7 +102,7 @@ public final class ResourceIdentifierBindingValidator extends AbstractValidator 
         // Ensure no two members use a resourceIdentifier trait to bind to
         // the same identifier.
         for (MemberShape member : structure.members()) {
-            if (member.hasTrait(ResourceIdentifierTrait.class)) {
+            if (member.hasTrait(ResourceIdentifierTrait.ID)) {
                 explicitBindings.computeIfAbsent(member.expectTrait(ResourceIdentifierTrait.class).getValue(),
                         k -> new HashSet<>()).add(member.getMemberName());
             }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ResourceLifecycleValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ResourceLifecycleValidator.java
@@ -70,7 +70,7 @@ public final class ResourceLifecycleValidator extends AbstractValidator {
             String lifecycle,
             boolean requireReadOnly
     ) {
-        if (requireReadOnly == operation.hasTrait(ReadonlyTrait.class)) {
+        if (requireReadOnly == operation.hasTrait(ReadonlyTrait.ID)) {
             return Optional.empty();
         }
 
@@ -89,7 +89,7 @@ public final class ResourceLifecycleValidator extends AbstractValidator {
             String lifecycle,
             String additionalMessage
     ) {
-        if (operation.hasTrait(IdempotentTrait.class)) {
+        if (operation.hasTrait(IdempotentTrait.ID)) {
             return Optional.empty();
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ServiceBoundResourceOperationValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ServiceBoundResourceOperationValidator.java
@@ -81,7 +81,7 @@ public final class ServiceBoundResourceOperationValidator extends AbstractValida
 
     private boolean isImplicitIdentifierBinding(MemberShape member, ResourceShape resource) {
         return resource.getIdentifiers().containsKey(member.getMemberName())
-                && member.getTrait(RequiredTrait.class).isPresent()
+                && member.hasTrait(RequiredTrait.ID)
                 && member.getTarget().equals(resource.getIdentifiers().get(member.getMemberName()));
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ShapeRecursionValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/ShapeRecursionValidator.java
@@ -79,7 +79,7 @@ public final class ShapeRecursionValidator extends AbstractValidator {
     private void validateStructurePaths(PathFinder finder, Model model, List<ValidationEvent> events) {
         finder.relationshipFilter(rel -> {
             if (rel.getShape().isStructureShape()) {
-                return rel.getNeighborShape().get().hasTrait(RequiredTrait.class);
+                return rel.getNeighborShape().get().hasTrait(RequiredTrait.ID);
             } else {
                 return rel.getShape().isMemberShape();
             }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/StreamingTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/StreamingTraitValidator.java
@@ -61,8 +61,8 @@ public final class StreamingTraitValidator extends AbstractValidator {
     private void validateBlobTargetsAreNonOptional(Model model, List<ValidationEvent> events) {
         for (MemberShape member : model.toSet(MemberShape.class)) {
             Shape target = model.expectShape(member.getTarget());
-            if (target.isBlobShape() && target.hasTrait(StreamingTrait.class)
-                    && !(member.hasTrait(RequiredTrait.class) || member.hasTrait(DefaultTrait.class))) {
+            if (target.isBlobShape() && target.hasTrait(StreamingTrait.ID)
+                    && !(member.hasTrait(RequiredTrait.ID) || member.hasTrait(DefaultTrait.ID))) {
                 events.add(error(member,
                         "Members that target blobs marked with the `streaming` trait MUST also be "
                                 + "marked with the `required` or `default` trait."));
@@ -85,10 +85,10 @@ public final class StreamingTraitValidator extends AbstractValidator {
         Walker walker = new Walker(model);
         for (ServiceShape service : servicesWithPayloadSupportingProtocols) {
             walker.iterateShapes(service).forEachRemaining(shape -> {
-                if (shape.isMemberShape() && !shape.hasTrait(HttpPayloadTrait.class)) {
+                if (shape.isMemberShape() && !shape.hasTrait(HttpPayloadTrait.ID)) {
                     MemberShape member = shape.asMemberShape().get();
                     Shape target = model.expectShape(member.getTarget());
-                    if (target.hasTrait(StreamingTrait.class)) {
+                    if (target.hasTrait(StreamingTrait.ID)) {
                         events.add(error(member,
                                 String.format(
                                         "Member `%s` referencing @streaming shape `%s` must have the @httpPayload trait, "
@@ -132,7 +132,7 @@ public final class StreamingTraitValidator extends AbstractValidator {
                     case MIXIN:
                         break;
                     case OUTPUT:
-                        if (target.hasTrait(RequiresLengthTrait.class)) {
+                        if (target.hasTrait(RequiresLengthTrait.ID)) {
                             events.add(error(rel.getNeighborShape().get(),
                                     String.format(
                                             "Structures that contain a reference to a stream marked with the "

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TargetValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TargetValidator.java
@@ -23,6 +23,7 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.traits.DeprecatedTrait;
+import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.model.traits.MixinTrait;
 import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.model.validation.AbstractValidator;
@@ -103,7 +104,7 @@ public final class TargetValidator extends AbstractValidator {
         RelationshipType relType = rel.getRelationshipType();
 
         if (relType != RelationshipType.MIXIN && relType.getDirection() == RelationshipDirection.DIRECTED) {
-            if (target.hasTrait(TraitDefinition.class)) {
+            if (target.hasTrait(TraitDefinition.ID)) {
                 events.add(error(shape,
                         format(
                                 "Found a %s reference to trait definition `%s`. Trait definitions cannot be targeted by "
@@ -115,7 +116,7 @@ public final class TargetValidator extends AbstractValidator {
             }
 
             // Ignoring members with the mixin trait, forbid shapes to reference mixins except as mixins.
-            if (!target.isMemberShape() && target.hasTrait(MixinTrait.class)) {
+            if (!target.isMemberShape() && target.hasTrait(MixinTrait.ID)) {
                 events.add(error(shape,
                         format(
                                 "Illegal %s reference to mixin `%s`; shapes marked with the mixin trait can only be "
@@ -158,7 +159,7 @@ public final class TargetValidator extends AbstractValidator {
                 // Input/output must target structures and cannot have the error trait.
                 if (target.getType() != ShapeType.STRUCTURE) {
                     events.add(badType(shape, target, relType, ShapeType.STRUCTURE));
-                } else if (target.findTrait("error").isPresent()) {
+                } else if (target.hasTrait(ErrorTrait.ID)) {
                     events.add(inputOutputWithErrorTrait(shape, target, rel.getRelationshipType()));
                 }
                 break;
@@ -166,7 +167,7 @@ public final class TargetValidator extends AbstractValidator {
                 // Errors must target a structure with the error trait.
                 if (target.getType() != ShapeType.STRUCTURE) {
                     events.add(badType(shape, target, relType, ShapeType.STRUCTURE));
-                } else if (!target.findTrait("error").isPresent()) {
+                } else if (!target.hasTrait(ErrorTrait.ID)) {
                     events.add(errorNoTrait(shape, target.getId()));
                 }
                 break;
@@ -187,7 +188,7 @@ public final class TargetValidator extends AbstractValidator {
                 }
                 break;
             case MIXIN:
-                if (!target.hasTrait(MixinTrait.class)) {
+                if (!target.hasTrait(MixinTrait.ID)) {
                     events.add(error(shape,
                             format(
                                     "Attempted to use %s as a mixin, but it is not marked with the mixin trait",
@@ -205,7 +206,7 @@ public final class TargetValidator extends AbstractValidator {
             RelationshipType relType,
             List<ValidationEvent> events
     ) {
-        if (!target.hasTrait(DeprecatedTrait.class)) {
+        if (!target.hasTrait(DeprecatedTrait.ID)) {
             return;
         }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitTargetValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/TraitTargetValidator.java
@@ -66,7 +66,7 @@ public final class TraitTargetValidator extends AbstractValidator {
     }
 
     private void validateMixinsUsedAsTraits(Shape traitShape, Set<Shape> appliedTo, List<ValidationEvent> events) {
-        if (traitShape.hasTrait(MixinTrait.class)) {
+        if (traitShape.hasTrait(MixinTrait.ID)) {
             for (Shape shape : appliedTo) {
                 events.add(error(shape,
                         String.format(

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/UnionValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/UnionValidator.java
@@ -37,7 +37,7 @@ public final class UnionValidator extends AbstractValidator {
     }
 
     private void validateUnionMemberTarget(MemberShape member, Shape target, List<ValidationEvent> events) {
-        if (target.hasTrait(DefaultTrait.class)) {
+        if (target.hasTrait(DefaultTrait.ID)) {
             events.add(note(member,
                     String.format(
                             "This union member targets `%s`, a shape with a default value of `%s`. Note that "
@@ -50,7 +50,7 @@ public final class UnionValidator extends AbstractValidator {
     }
 
     private void validateUnionMember(MemberShape member, List<ValidationEvent> events) {
-        if (member.hasTrait(BoxTrait.class)) {
+        if (member.hasTrait(BoxTrait.ID)) {
             events.add(warning(member,
                     member.expectTrait(BoxTrait.class),
                     "Invalid box trait found on a union member. The box trait on union members "

--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/XmlFlattenedTraitValidator.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/validators/XmlFlattenedTraitValidator.java
@@ -25,7 +25,7 @@ public final class XmlFlattenedTraitValidator extends AbstractValidator {
         List<ValidationEvent> events = new ArrayList<>();
         for (MemberShape member : model.getMemberShapesWithTrait(XmlFlattenedTrait.class)) {
             // Don't emit the event if they're being explicit about the xmlName on this member
-            if (member.hasTrait(XmlNameTrait.class)) {
+            if (member.hasTrait(XmlNameTrait.ID)) {
                 continue;
             }
 
@@ -39,7 +39,7 @@ public final class XmlFlattenedTraitValidator extends AbstractValidator {
     }
 
     private void validateMemberTargetingList(MemberShape member, ListShape targetList, List<ValidationEvent> events) {
-        if (targetList.getMember().hasTrait(XmlNameTrait.class)) {
+        if (targetList.getMember().hasTrait(XmlNameTrait.ID)) {
             XmlNameTrait xmlName = targetList.getMember().expectTrait(XmlNameTrait.class);
             if (!member.getMemberName().equals(xmlName.getValue())) {
                 events.add(warning(member,

--- a/smithy-model/src/test/java/software/amazon/smithy/model/ShapeMatcher.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/ShapeMatcher.java
@@ -86,7 +86,7 @@ public final class ShapeMatcher<S extends Shape> extends TypeSafeMatcher<ShapeId
     public static ShapeMatcher<MemberShape> memberIsNullable(ValidatedResult<Model> result) {
         return ShapeMatcher.builderFor(MemberShape.class, result)
                 .description("Member is marked with @required or @default trait")
-                .addAssertion(member -> !member.hasTrait(RequiredTrait.class),
+                .addAssertion(member -> !member.hasTrait(RequiredTrait.ID),
                         member -> "Member is marked with the @required trait")
                 .addAssertion(member -> {
                     DefaultTrait trait = member.getTrait(DefaultTrait.class).orElse(null);

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/IdlModelLoaderTest.java
@@ -386,7 +386,7 @@ public class IdlModelLoaderTest {
         ShapeId myInteger = ShapeId.from("smithy.example#MyInteger");
         assertThat(model.getShape(myInteger).isPresent(), is(true));
         // Ensure recovery happened on the docs trait, capturing it on the shape.
-        assertThat(model.expectShape(myInteger).hasTrait(DocumentationTrait.class), is(true));
+        assertThat(model.expectShape(myInteger).hasTrait(DocumentationTrait.ID), is(true));
 
         boolean foundSyntax = false;
         boolean foundTrait = false;
@@ -416,7 +416,7 @@ public class IdlModelLoaderTest {
 
         ShapeId myString = ShapeId.from("smithy.example#MyString");
         assertThat(model.getShape(myString).isPresent(), is(true));
-        assertThat(model.expectShape(myString).hasTrait(ExternalDocumentationTrait.class), is(false));
+        assertThat(model.expectShape(myString).hasTrait(ExternalDocumentationTrait.ID), is(false));
 
         boolean foundSyntax = result.getValidationEvents()
                 .stream()

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -118,7 +118,7 @@ public class ModelAssemblerTest {
 
         assertThat(result.getValidationEvents(), empty());
         Shape resultShape = result.unwrap().getShape(ShapeId.from("ns.foo#Bar")).get();
-        assertTrue(resultShape.findTrait("smithy.api#suppress").isPresent());
+        assertTrue(resultShape.hasTrait(SuppressTrait.ID));
         assertTrue(resultShape.getTrait(SuppressTrait.class).isPresent());
     }
 
@@ -133,7 +133,7 @@ public class ModelAssemblerTest {
 
         assertThat(result.getValidationEvents(), empty());
         Shape resultShape = result.unwrap().getShape(ShapeId.from("ns.foo#Bar")).get();
-        assertTrue(resultShape.findTrait("smithy.api#suppress").isPresent());
+        assertTrue(resultShape.hasTrait(SuppressTrait.ID));
         assertTrue(resultShape.getTrait(SuppressTrait.class).isPresent());
     }
 
@@ -149,7 +149,7 @@ public class ModelAssemblerTest {
 
         assertThat(result.getValidationEvents(), empty());
         Shape resultShape = result.unwrap().getShape(ShapeId.from("ns.foo#Bar")).get();
-        assertTrue(resultShape.findTrait("smithy.api#suppress").isPresent());
+        assertTrue(resultShape.hasTrait(SuppressTrait.ID));
         assertTrue(resultShape.getTrait(SuppressTrait.class).isPresent());
     }
 
@@ -165,7 +165,7 @@ public class ModelAssemblerTest {
 
         assertThat(result.getValidationEvents(), empty());
         Shape resultShape = result.unwrap().getShape(ShapeId.from("ns.foo#Bar")).get();
-        assertTrue(resultShape.findTrait("smithy.api#suppress").isPresent());
+        assertTrue(resultShape.hasTrait(SuppressTrait.ID));
         assertTrue(resultShape.getTrait(SuppressTrait.class).isPresent());
     }
 
@@ -713,9 +713,9 @@ public class ModelAssemblerTest {
 
         // Ensure that traits across each duplicate are all merged together.
         StructureShape shape = result.unwrap().expectShape(ShapeId.from("foo.baz#Foo"), StructureShape.class);
-        assertTrue(shape.hasTrait(DeprecatedTrait.class));
+        assertTrue(shape.hasTrait(DeprecatedTrait.ID));
         assertTrue(shape.getMember("foo").isPresent());
-        assertTrue(shape.getMember("foo").get().hasTrait(InternalTrait.class));
+        assertTrue(shape.getMember("foo").get().hasTrait(InternalTrait.ID));
     }
 
     @Test
@@ -778,7 +778,7 @@ public class ModelAssemblerTest {
                 .assemble()
                 .unwrap();
 
-        assertTrue(model.expectShape(id).findTrait(traitId).isPresent());
+        assertTrue(model.expectShape(id).hasTrait(traitId));
         assertThat(model.expectShape(id).findTrait(traitId).get(), instanceOf(DynamicTrait.class));
     }
 
@@ -890,7 +890,7 @@ public class ModelAssemblerTest {
         assertThat(f.getMemberNames(), contains("a", "b", "c", "d", "e", "f"));
         assertThat(f.getMember("a").get().expectTrait(DocumentationTrait.class).getValue(), equalTo("I've changed"));
         assertThat(f.getMember("c").get().expectTrait(DocumentationTrait.class).getValue(), equalTo("I've changed"));
-        assertTrue(f.getMember("c").get().hasTrait(InternalTrait.class));
+        assertTrue(f.getMember("c").get().hasTrait(InternalTrait.ID));
     }
 
     @Test
@@ -1072,13 +1072,13 @@ public class ModelAssemblerTest {
     public void findsBoxTraitOnPreludeShapes() {
         Model model = Model.assembler().assemble().unwrap();
 
-        assertThat(model.expectShape(ShapeId.from("smithy.api#Boolean")).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(ShapeId.from("smithy.api#Byte")).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(ShapeId.from("smithy.api#Short")).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(ShapeId.from("smithy.api#Integer")).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(ShapeId.from("smithy.api#Long")).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(ShapeId.from("smithy.api#Float")).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(ShapeId.from("smithy.api#Double")).hasTrait(BoxTrait.class), is(true));
+        assertThat(model.expectShape(ShapeId.from("smithy.api#Boolean")).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(ShapeId.from("smithy.api#Byte")).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(ShapeId.from("smithy.api#Short")).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(ShapeId.from("smithy.api#Integer")).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(ShapeId.from("smithy.api#Long")).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(ShapeId.from("smithy.api#Float")).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(ShapeId.from("smithy.api#Double")).hasTrait(BoxTrait.ID), is(true));
     }
 
     @Test
@@ -1149,13 +1149,13 @@ public class ModelAssemblerTest {
         ShapeId fooMember = ShapeId.from("smithy.example#Struct$foo");
         ShapeId barMember = ShapeId.from("smithy.example#Struct$bar");
         ShapeId boxedMember = ShapeId.from("smithy.example#Struct$boxed");
-        assertThat(model.expectShape(boxDouble).hasTrait(DefaultTrait.class), is(false));
-        assertThat(model.expectShape(primitiveDouble).hasTrait(DefaultTrait.class), is(true));
-        assertThat(model.expectShape(fooMember).hasTrait(DefaultTrait.class), is(true));
-        assertThat(model.expectShape(barMember).hasTrait(DefaultTrait.class), is(false));
-        assertThat(model.expectShape(boxedMember).hasTrait(DefaultTrait.class), is(true));
+        assertThat(model.expectShape(boxDouble).hasTrait(DefaultTrait.ID), is(false));
+        assertThat(model.expectShape(primitiveDouble).hasTrait(DefaultTrait.ID), is(true));
+        assertThat(model.expectShape(fooMember).hasTrait(DefaultTrait.ID), is(true));
+        assertThat(model.expectShape(barMember).hasTrait(DefaultTrait.ID), is(false));
+        assertThat(model.expectShape(boxedMember).hasTrait(DefaultTrait.ID), is(true));
         assertThat(model.expectShape(boxedMember).expectTrait(DefaultTrait.class).toNode(), equalTo(Node.nullNode()));
-        assertThat(model.expectShape(boxedMember).hasTrait(BoxTrait.class), is(true));
+        assertThat(model.expectShape(boxedMember).hasTrait(BoxTrait.ID), is(true));
     }
 
     @Test
@@ -1235,18 +1235,18 @@ public class ModelAssemblerTest {
                 .unwrap();
 
         // MixedInteger and MixinInteger have synthetic box traits.
-        assertThat(model1.expectShape(ShapeId.from("smithy.example#MixinInteger")).hasTrait(BoxTrait.class), is(true));
-        assertThat(model1.expectShape(ShapeId.from("smithy.example#MixedInteger")).hasTrait(BoxTrait.class), is(true));
+        assertThat(model1.expectShape(ShapeId.from("smithy.example#MixinInteger")).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model1.expectShape(ShapeId.from("smithy.example#MixedInteger")).hasTrait(BoxTrait.ID), is(true));
 
         // MixinStruct$bar and MixedStruct$bar have synthetic box traits.
         StructureShape mixinStruct = model1.expectShape(ShapeId.from("smithy.example#MixinStruct"),
                 StructureShape.class);
         StructureShape mixedStruct = model1.expectShape(ShapeId.from("smithy.example#MixedStruct"),
                 StructureShape.class);
-        assertThat(mixinStruct.getAllMembers().get("bar").hasTrait(BoxTrait.class), is(true));
-        assertThat(mixinStruct.getAllMembers().get("bar").hasTrait(DefaultTrait.class), is(true));
-        assertThat(mixedStruct.getAllMembers().get("bar").hasTrait(BoxTrait.class), is(true));
-        assertThat(mixedStruct.getAllMembers().get("bar").hasTrait(DefaultTrait.class), is(true));
+        assertThat(mixinStruct.getAllMembers().get("bar").hasTrait(BoxTrait.ID), is(true));
+        assertThat(mixinStruct.getAllMembers().get("bar").hasTrait(DefaultTrait.ID), is(true));
+        assertThat(mixedStruct.getAllMembers().get("bar").hasTrait(BoxTrait.ID), is(true));
+        assertThat(mixedStruct.getAllMembers().get("bar").hasTrait(DefaultTrait.ID), is(true));
 
         // Now ensure round-tripping results in the same model.
         Node serialized = ModelSerializer.builder().build().serialize(model1);

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelInteropTransformerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelInteropTransformerTest.java
@@ -96,8 +96,8 @@ public class ModelInteropTransformerTest {
         assertThat(ShapeId.from("smithy.example#Foo$boxedMember"), targetsShape(result, "PrimitiveInteger"));
 
         Shape shape = result.getResult().get().expectShape(ShapeId.from("smithy.example#Foo$boxedMember"));
-        assertThat(shape.hasTrait(BoxTrait.class), is(true));
-        assertThat(shape.hasTrait(DefaultTrait.class), is(true));
+        assertThat(shape.hasTrait(BoxTrait.ID), is(true));
+        assertThat(shape.hasTrait(DefaultTrait.ID), is(true));
         assertThat(shape.expectTrait(DefaultTrait.class).toNode().isNullNode(), is(true));
 
         assertThat(ShapeId.from("smithy.example#Foo$previouslyBoxedTarget"), not(addedDefaultTrait(result)));
@@ -180,7 +180,7 @@ public class ModelInteropTransformerTest {
     private static Matcher<ShapeId> addedDefaultTrait(ValidatedResult<Model> result) {
         return ShapeMatcher.builderFor(MemberShape.class, result)
                 .description("member to have a default trait")
-                .addAssertion(member -> member.hasTrait(DefaultTrait.class),
+                .addAssertion(member -> member.hasTrait(DefaultTrait.ID),
                         member -> "no @default trait")
                 .build();
     }
@@ -320,9 +320,9 @@ public class ModelInteropTransformerTest {
         ShapeId primitiveInteger = ShapeId.from("smithy.example#PrimitiveInteger");
         ShapeId fooBam = ShapeId.from("smithy.example#Foo$bam");
 
-        assertThat(model.expectShape(myInteger).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(foo).hasTrait(BoxTrait.class), is(false));
-        assertThat(model.expectShape(fooBaz).hasTrait(BoxTrait.class), is(true));
+        assertThat(model.expectShape(myInteger).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(foo).hasTrait(BoxTrait.ID), is(false));
+        assertThat(model.expectShape(fooBaz).hasTrait(BoxTrait.ID), is(true));
 
         Node serialized = ModelSerializer.builder().build().serialize(model);
         String raw = Node.prettyPrintJson(serialized);
@@ -331,22 +331,22 @@ public class ModelInteropTransformerTest {
                 .assemble()
                 .unwrap();
 
-        assertThat(model2.expectShape(myInteger).hasTrait(BoxTrait.class), is(true));
-        assertThat(model2.expectShape(myInteger).hasTrait(DefaultTrait.class), is(false));
-        assertThat(model2.expectShape(foo).hasTrait(BoxTrait.class), is(false));
-        assertThat(model2.expectShape(fooBaz).hasTrait(DefaultTrait.class), is(true));
+        assertThat(model2.expectShape(myInteger).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model2.expectShape(myInteger).hasTrait(DefaultTrait.ID), is(false));
+        assertThat(model2.expectShape(foo).hasTrait(BoxTrait.ID), is(false));
+        assertThat(model2.expectShape(fooBaz).hasTrait(DefaultTrait.ID), is(true));
         assertThat(model2.expectShape(fooBaz).expectTrait(DefaultTrait.class).toNode(), equalTo(Node.nullNode()));
 
         // This member gets a synthetic box trait because the default value is set to null.
-        assertThat(model2.expectShape(fooBaz).hasTrait(BoxTrait.class), is(true));
+        assertThat(model2.expectShape(fooBaz).hasTrait(BoxTrait.ID), is(true));
 
         // Primitive integer gets a synthetic default trait and no box trait.
-        assertThat(model2.expectShape(primitiveInteger).hasTrait(DefaultTrait.class), is(true));
-        assertThat(model2.expectShape(primitiveInteger).hasTrait(BoxTrait.class), is(false));
+        assertThat(model2.expectShape(primitiveInteger).hasTrait(DefaultTrait.ID), is(true));
+        assertThat(model2.expectShape(primitiveInteger).hasTrait(BoxTrait.ID), is(false));
 
         // The member referring to PrimitiveInteger gets a synthetic default trait and no box trait.
-        assertThat(model2.expectShape(fooBam).hasTrait(DefaultTrait.class), is(true));
-        assertThat(model2.expectShape(fooBam).hasTrait(BoxTrait.class), is(false));
+        assertThat(model2.expectShape(fooBam).hasTrait(DefaultTrait.ID), is(true));
+        assertThat(model2.expectShape(fooBam).hasTrait(BoxTrait.ID), is(false));
     }
 
     @Test
@@ -424,46 +424,46 @@ public class ModelInteropTransformerTest {
         ShapeId fooPrimitiveIntEnum = ShapeId.from("smithy.example#Foo$PrimitiveIntEnum");
 
         // Do not box strings for v1 compatibility.
-        assertThat(model.expectShape(defaultString).hasTrait(BoxTrait.class), is(false));
-        assertThat(model.expectShape(fooDefaultString).hasTrait(BoxTrait.class), is(false));
-        assertThat(model.expectShape(fooDefaultString).hasTrait(DefaultTrait.class), is(true));
-        assertThat(model.expectShape(defaultString).hasTrait(DefaultTrait.class), is(true));
+        assertThat(model.expectShape(defaultString).hasTrait(BoxTrait.ID), is(false));
+        assertThat(model.expectShape(fooDefaultString).hasTrait(BoxTrait.ID), is(false));
+        assertThat(model.expectShape(fooDefaultString).hasTrait(DefaultTrait.ID), is(true));
+        assertThat(model.expectShape(defaultString).hasTrait(DefaultTrait.ID), is(true));
 
         // Add box to BoxedInteger because it has no default trait.
-        assertThat(model.expectShape(boxedInteger).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(fooBoxedInteger).hasTrait(BoxTrait.class), is(false)); // no need to box member too
-        assertThat(model.expectShape(boxedInteger).hasTrait(DefaultTrait.class), is(false));
-        assertThat(model.expectShape(fooBoxedInteger).hasTrait(DefaultTrait.class), is(false));
+        assertThat(model.expectShape(boxedInteger).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(fooBoxedInteger).hasTrait(BoxTrait.ID), is(false)); // no need to box member too
+        assertThat(model.expectShape(boxedInteger).hasTrait(DefaultTrait.ID), is(false));
+        assertThat(model.expectShape(fooBoxedInteger).hasTrait(DefaultTrait.ID), is(false));
 
         // Add box to BoxedIntegerWithDefault because it has a default that isn't the v1 zero value.
-        assertThat(model.expectShape(boxedIntegerWithDefault).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(fooBoxedIntegerWithDefault).hasTrait(BoxTrait.class), is(false)); // no need to box the member too
-        assertThat(model.expectShape(boxedIntegerWithDefault).hasTrait(DefaultTrait.class), is(true));
-        assertThat(model.expectShape(fooBoxedIntegerWithDefault).hasTrait(DefaultTrait.class), is(true));
+        assertThat(model.expectShape(boxedIntegerWithDefault).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(fooBoxedIntegerWithDefault).hasTrait(BoxTrait.ID), is(false)); // no need to box the member too
+        assertThat(model.expectShape(boxedIntegerWithDefault).hasTrait(DefaultTrait.ID), is(true));
+        assertThat(model.expectShape(fooBoxedIntegerWithDefault).hasTrait(DefaultTrait.ID), is(true));
 
         // No box trait on PrimitiveInteger because it has a zero value default.
-        assertThat(model.expectShape(primitiveInteger).hasTrait(BoxTrait.class), is(false));
-        assertThat(model.expectShape(fooPrimitiveInteger).hasTrait(BoxTrait.class), is(false));
-        assertThat(model.expectShape(primitiveInteger).hasTrait(DefaultTrait.class), is(true));
-        assertThat(model.expectShape(fooPrimitiveInteger).hasTrait(DefaultTrait.class), is(true));
+        assertThat(model.expectShape(primitiveInteger).hasTrait(BoxTrait.ID), is(false));
+        assertThat(model.expectShape(fooPrimitiveInteger).hasTrait(BoxTrait.ID), is(false));
+        assertThat(model.expectShape(primitiveInteger).hasTrait(DefaultTrait.ID), is(true));
+        assertThat(model.expectShape(fooPrimitiveInteger).hasTrait(DefaultTrait.ID), is(true));
 
         // Add box to BoxedIntEnum because it has no default trait.
-        assertThat(model.expectShape(boxedIntEnum).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(fooBoxedIntEnum).hasTrait(BoxTrait.class), is(false)); // no need to box the member too
-        assertThat(model.expectShape(boxedIntEnum).hasTrait(DefaultTrait.class), is(false));
-        assertThat(model.expectShape(fooBoxedIntEnum).hasTrait(DefaultTrait.class), is(false));
+        assertThat(model.expectShape(boxedIntEnum).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(fooBoxedIntEnum).hasTrait(BoxTrait.ID), is(false)); // no need to box the member too
+        assertThat(model.expectShape(boxedIntEnum).hasTrait(DefaultTrait.ID), is(false));
+        assertThat(model.expectShape(fooBoxedIntEnum).hasTrait(DefaultTrait.ID), is(false));
 
         // Add box to BoxedIntEnumWithDefault because it has a default that isn't the v1 zero value.
-        assertThat(model.expectShape(boxedIntEnumWithDefault).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(fooBoxedIntEnumWithDefault).hasTrait(BoxTrait.class), is(false)); // no need to box the member too
-        assertThat(model.expectShape(boxedIntEnumWithDefault).hasTrait(DefaultTrait.class), is(true));
-        assertThat(model.expectShape(fooBoxedIntEnumWithDefault).hasTrait(DefaultTrait.class), is(true));
+        assertThat(model.expectShape(boxedIntEnumWithDefault).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(fooBoxedIntEnumWithDefault).hasTrait(BoxTrait.ID), is(false)); // no need to box the member too
+        assertThat(model.expectShape(boxedIntEnumWithDefault).hasTrait(DefaultTrait.ID), is(true));
+        assertThat(model.expectShape(fooBoxedIntEnumWithDefault).hasTrait(DefaultTrait.ID), is(true));
 
         // No box trait on PrimitiveIntEnum because it has a zero value default.
-        assertThat(model.expectShape(primitiveIntEnum).hasTrait(BoxTrait.class), is(false));
-        assertThat(model.expectShape(fooPrimitiveIntEnum).hasTrait(BoxTrait.class), is(false));
-        assertThat(model.expectShape(primitiveIntEnum).hasTrait(DefaultTrait.class), is(true));
-        assertThat(model.expectShape(fooPrimitiveIntEnum).hasTrait(DefaultTrait.class), is(true));
+        assertThat(model.expectShape(primitiveIntEnum).hasTrait(BoxTrait.ID), is(false));
+        assertThat(model.expectShape(fooPrimitiveIntEnum).hasTrait(BoxTrait.ID), is(false));
+        assertThat(model.expectShape(primitiveIntEnum).hasTrait(DefaultTrait.ID), is(true));
+        assertThat(model.expectShape(fooPrimitiveIntEnum).hasTrait(DefaultTrait.ID), is(true));
     }
 
     @Test
@@ -478,7 +478,7 @@ public class ModelInteropTransformerTest {
         ShapeId shapeId1 = ShapeId.from("smithy.example#MyLong1");
         Shape shape1 = model1.expectShape(shapeId1);
 
-        assertThat(shape1.hasTrait(RangeTrait.class), is(true));
+        assertThat(shape1.hasTrait(RangeTrait.ID), is(true));
         // Make sure the range trait wasn't modified.
         assertThat(shape1.expectTrait(RangeTrait.class).getMin().get().toString(), equalTo("1"));
         assertThat(result.getValidationEvents()

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/PreludeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/PreludeTest.java
@@ -46,7 +46,7 @@ public class PreludeTest {
         ModelTransformer transformer = ModelTransformer.create();
         Model result = transformer.scrubTraitDefinitions(model);
         Set<ShapeId> unreferencedPrivateShapes = result.shapes()
-                .filter(shape -> shape.hasTrait(PrivateTrait.class))
+                .filter(shape -> shape.hasTrait(PrivateTrait.ID))
                 .map(Shape::getId)
                 .collect(Collectors.toSet());
 
@@ -76,13 +76,13 @@ public class PreludeTest {
     public void preludeShapesAreAlwaysBoxed() {
         Model model = Model.assembler().assemble().unwrap();
 
-        assertThat(model.expectShape(ShapeId.from("smithy.api#Boolean")).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(ShapeId.from("smithy.api#Byte")).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(ShapeId.from("smithy.api#Short")).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(ShapeId.from("smithy.api#Integer")).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(ShapeId.from("smithy.api#Long")).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(ShapeId.from("smithy.api#Float")).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(ShapeId.from("smithy.api#Double")).hasTrait(BoxTrait.class), is(true));
-        assertThat(model.expectShape(ShapeId.from("smithy.api#PrimitiveBoolean")).hasTrait(BoxTrait.class), is(false));
+        assertThat(model.expectShape(ShapeId.from("smithy.api#Boolean")).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(ShapeId.from("smithy.api#Byte")).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(ShapeId.from("smithy.api#Short")).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(ShapeId.from("smithy.api#Integer")).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(ShapeId.from("smithy.api#Long")).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(ShapeId.from("smithy.api#Float")).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(ShapeId.from("smithy.api#Double")).hasTrait(BoxTrait.ID), is(true));
+        assertThat(model.expectShape(ShapeId.from("smithy.api#PrimitiveBoolean")).hasTrait(BoxTrait.ID), is(false));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/ShapeTest.java
@@ -131,7 +131,7 @@ public class ShapeTest {
         assertFalse(shape.hasTrait("notThere"));
 
         assertTrue(shape.getTrait(DocumentationTrait.class).isPresent());
-        assertTrue(shape.hasTrait(DocumentationTrait.class));
+        assertTrue(shape.hasTrait(DocumentationTrait.ID));
         assertTrue(shape.findTrait("documentation").isPresent());
         assertTrue(shape.findTrait("smithy.api#documentation").isPresent());
         assertTrue(shape.findTrait("documentation").get() instanceof DocumentationTrait);

--- a/smithy-model/src/test/java/software/amazon/smithy/model/shapes/StructureShapeTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/shapes/StructureShapeTest.java
@@ -133,9 +133,9 @@ public class StructureShapeTest {
                 .addTrait(new DocumentationTrait("hi"))
                 .build();
 
-        assertTrue(concrete.hasTrait(SensitiveTrait.class));
-        assertTrue(concrete.hasTrait(DeprecatedTrait.class));
-        assertTrue(concrete.hasTrait(DocumentationTrait.class));
+        assertTrue(concrete.hasTrait(SensitiveTrait.ID));
+        assertTrue(concrete.hasTrait(DeprecatedTrait.ID));
+        assertTrue(concrete.hasTrait(DocumentationTrait.ID));
     }
 
     @Test
@@ -194,7 +194,7 @@ public class StructureShapeTest {
         StructureShape updated = concrete.toBuilder().addMember(updatedA).build();
 
         assertThat(updated.getMemberNames(), contains("a"));
-        assertTrue(updated.getMember("a").get().hasTrait(SensitiveTrait.class));
+        assertTrue(updated.getMember("a").get().hasTrait(SensitiveTrait.ID));
         assertThat(updated.getMember("a").get().getMixins(), contains(mixin1.getMember("a").get().getId()));
     }
 
@@ -218,10 +218,10 @@ public class StructureShapeTest {
                 .addMixin(mixin1)
                 .build();
 
-        assertTrue(concrete.getMember("a").get().hasTrait(SensitiveTrait.class));
+        assertTrue(concrete.getMember("a").get().hasTrait(SensitiveTrait.ID));
         assertThat(concrete.getMember("a").get().getMixins(), contains(mixin1.getMember("a").get().getId()));
 
-        assertTrue(concrete.getMember("b").get().hasTrait(SensitiveTrait.class));
+        assertTrue(concrete.getMember("b").get().hasTrait(SensitiveTrait.ID));
         assertThat(concrete.getMember("b").get().getMixins(), contains(mixin1.getMember("b").get().getId()));
     }
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/AddClientOptionalTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/AddClientOptionalTest.java
@@ -28,8 +28,8 @@ public class AddClientOptionalTest {
         Model model2 = ModelTransformer.create().addClientOptional(model, false);
         StructureShape struct2 = model2.expectShape(structure.getId(), StructureShape.class);
 
-        assertTrue(struct2.getMember("foo").get().hasTrait(ClientOptionalTrait.class));
-        assertTrue(struct2.getMember("bar").get().hasTrait(ClientOptionalTrait.class));
+        assertTrue(struct2.getMember("foo").get().hasTrait(ClientOptionalTrait.ID));
+        assertTrue(struct2.getMember("bar").get().hasTrait(ClientOptionalTrait.ID));
     }
 
     @Test
@@ -43,8 +43,8 @@ public class AddClientOptionalTest {
         Model model2 = ModelTransformer.create().addClientOptional(model, false);
         StructureShape struct2 = model2.expectShape(structure.getId(), StructureShape.class);
 
-        assertTrue(struct2.getMember("foo").get().hasTrait(ClientOptionalTrait.class));
-        assertFalse(struct2.getMember("bar").get().hasTrait(ClientOptionalTrait.class));
+        assertTrue(struct2.getMember("foo").get().hasTrait(ClientOptionalTrait.ID));
+        assertFalse(struct2.getMember("bar").get().hasTrait(ClientOptionalTrait.ID));
     }
 
     @Test
@@ -60,8 +60,8 @@ public class AddClientOptionalTest {
         Model model2 = ModelTransformer.create().addClientOptional(model, true);
         StructureShape struct2 = model2.expectShape(structure.getId(), StructureShape.class);
 
-        assertTrue(struct2.getMember("foo").get().hasTrait(ClientOptionalTrait.class));
-        assertFalse(struct2.getMember("bar").get().hasTrait(ClientOptionalTrait.class));
-        assertTrue(struct2.getMember("baz").get().hasTrait(ClientOptionalTrait.class));
+        assertTrue(struct2.getMember("foo").get().hasTrait(ClientOptionalTrait.ID));
+        assertFalse(struct2.getMember("bar").get().hasTrait(ClientOptionalTrait.ID));
+        assertTrue(struct2.getMember("baz").get().hasTrait(ClientOptionalTrait.ID));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/DowngradeToV1Test.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/DowngradeToV1Test.java
@@ -114,9 +114,9 @@ public class DowngradeToV1Test {
         assertThat(downgraded.expectShape(resource.getId(), ResourceShape.class).getProperties(),
                 Matchers.anEmptyMap());
 
-        assertThat(downgraded.expectShape(input.getMember("foo").get().getId()).hasTrait(PropertyTrait.class),
+        assertThat(downgraded.expectShape(input.getMember("foo").get().getId()).hasTrait(PropertyTrait.ID),
                 Matchers.is(false));
-        assertThat(downgraded.expectShape(input.getMember("baz").get().getId()).hasTrait(NotPropertyTrait.class),
+        assertThat(downgraded.expectShape(input.getMember("baz").get().getId()).hasTrait(NotPropertyTrait.ID),
                 Matchers.is(false));
     }
 
@@ -185,38 +185,38 @@ public class DowngradeToV1Test {
 
         // A Root level shape with a 1.0 non-zero value drops the default value and is boxed
         ShapeId integerShape = ShapeId.from("smithy.example#MyInteger");
-        assertThat(downgraded.expectShape(integerShape).hasTrait(DefaultTrait.class), Matchers.is(false));
-        assertThat(downgraded.expectShape(integerShape).hasTrait(AddedDefaultTrait.class), Matchers.is(false));
-        assertThat(downgraded.expectShape(integerShape).hasTrait(BoxTrait.class), Matchers.is(true));
+        assertThat(downgraded.expectShape(integerShape).hasTrait(DefaultTrait.ID), Matchers.is(false));
+        assertThat(downgraded.expectShape(integerShape).hasTrait(AddedDefaultTrait.ID), Matchers.is(false));
+        assertThat(downgraded.expectShape(integerShape).hasTrait(BoxTrait.ID), Matchers.is(true));
 
         // A Root level shape with a 1.0 zero value keeps the default value
         ShapeId zeroIntegerShape = ShapeId.from("smithy.example#ZeroInteger");
-        assertThat(downgraded.expectShape(zeroIntegerShape).hasTrait(DefaultTrait.class), Matchers.is(true));
+        assertThat(downgraded.expectShape(zeroIntegerShape).hasTrait(DefaultTrait.ID), Matchers.is(true));
         assertThat(downgraded.expectShape(zeroIntegerShape)
                 .expectTrait(DefaultTrait.class)
                 .toNode()
                 .expectNumberNode()
                 .getValue(),
                 Matchers.is(0L));
-        assertThat(downgraded.expectShape(zeroIntegerShape).hasTrait(AddedDefaultTrait.class), Matchers.is(false));
-        assertThat(downgraded.expectShape(zeroIntegerShape).hasTrait(BoxTrait.class), Matchers.is(false));
+        assertThat(downgraded.expectShape(zeroIntegerShape).hasTrait(AddedDefaultTrait.ID), Matchers.is(false));
+        assertThat(downgraded.expectShape(zeroIntegerShape).hasTrait(BoxTrait.ID), Matchers.is(false));
 
         // A Root level shape with no default value is boxed
         ShapeId boxedIntegerShape = ShapeId.from("smithy.example#BoxedInteger");
-        assertThat(downgraded.expectShape(boxedIntegerShape).hasTrait(DefaultTrait.class), Matchers.is(false));
-        assertThat(downgraded.expectShape(boxedIntegerShape).hasTrait(AddedDefaultTrait.class), Matchers.is(false));
-        assertThat(downgraded.expectShape(boxedIntegerShape).hasTrait(BoxTrait.class), Matchers.is(true));
+        assertThat(downgraded.expectShape(boxedIntegerShape).hasTrait(DefaultTrait.ID), Matchers.is(false));
+        assertThat(downgraded.expectShape(boxedIntegerShape).hasTrait(AddedDefaultTrait.ID), Matchers.is(false));
+        assertThat(downgraded.expectShape(boxedIntegerShape).hasTrait(BoxTrait.ID), Matchers.is(true));
 
         // StructureShape still exists
         StructureShape dStruct = downgraded.expectShape(ShapeId.from("smithy.example#Struct"), StructureShape.class);
 
         // A Member that targets a shape with a 1.0 non-zero value drops the default value and is not boxed
-        assertThat(dStruct.getAllMembers().get("foo").hasTrait(DefaultTrait.class), Matchers.is(false));
-        assertThat(dStruct.getAllMembers().get("foo").hasTrait(AddedDefaultTrait.class), Matchers.is(false));
-        assertThat(dStruct.getAllMembers().get("foo").hasTrait(BoxTrait.class), Matchers.is(false));
+        assertThat(dStruct.getAllMembers().get("foo").hasTrait(DefaultTrait.ID), Matchers.is(false));
+        assertThat(dStruct.getAllMembers().get("foo").hasTrait(AddedDefaultTrait.ID), Matchers.is(false));
+        assertThat(dStruct.getAllMembers().get("foo").hasTrait(BoxTrait.ID), Matchers.is(false));
 
         // A Member that targets a shape with a matching default 1.0 zero value keeps the default value
-        assertThat(dStruct.getAllMembers().get("zeroTargetZeroMember").hasTrait(DefaultTrait.class), Matchers.is(true));
+        assertThat(dStruct.getAllMembers().get("zeroTargetZeroMember").hasTrait(DefaultTrait.ID), Matchers.is(true));
         assertThat(dStruct.getAllMembers()
                 .get("zeroTargetZeroMember")
                 .expectTrait(DefaultTrait.class)
@@ -224,12 +224,12 @@ public class DowngradeToV1Test {
                 .expectNumberNode()
                 .getValue(),
                 Matchers.is(0L));
-        assertThat(dStruct.getAllMembers().get("zeroTargetZeroMember").hasTrait(AddedDefaultTrait.class),
+        assertThat(dStruct.getAllMembers().get("zeroTargetZeroMember").hasTrait(AddedDefaultTrait.ID),
                 Matchers.is(false));
-        assertThat(dStruct.getAllMembers().get("zeroTargetZeroMember").hasTrait(BoxTrait.class), Matchers.is(false));
+        assertThat(dStruct.getAllMembers().get("zeroTargetZeroMember").hasTrait(BoxTrait.ID), Matchers.is(false));
 
         // A Member that has a default value of null keeps the default value of null and is boxed
-        assertThat(dStruct.getAllMembers().get("zeroTargetBoxedMember").hasTrait(DefaultTrait.class),
+        assertThat(dStruct.getAllMembers().get("zeroTargetBoxedMember").hasTrait(DefaultTrait.ID),
                 Matchers.is(true));
         assertThat(
                 dStruct.getAllMembers()
@@ -238,27 +238,27 @@ public class DowngradeToV1Test {
                         .toNode()
                         .isNullNode(),
                 Matchers.is(true));
-        assertThat(dStruct.getAllMembers().get("zeroTargetBoxedMember").hasTrait(AddedDefaultTrait.class),
+        assertThat(dStruct.getAllMembers().get("zeroTargetBoxedMember").hasTrait(AddedDefaultTrait.ID),
                 Matchers.is(false));
-        assertThat(dStruct.getAllMembers().get("zeroTargetBoxedMember").hasTrait(BoxTrait.class), Matchers.is(true));
+        assertThat(dStruct.getAllMembers().get("zeroTargetBoxedMember").hasTrait(BoxTrait.ID), Matchers.is(true));
 
         // A Member that has a target shape with no default value drops the default value
-        assertThat(dStruct.getAllMembers().get("boxedTargetZeroMember").hasTrait(DefaultTrait.class),
+        assertThat(dStruct.getAllMembers().get("boxedTargetZeroMember").hasTrait(DefaultTrait.ID),
                 Matchers.is(false));
-        assertThat(dStruct.getAllMembers().get("boxedTargetZeroMember").hasTrait(AddedDefaultTrait.class),
+        assertThat(dStruct.getAllMembers().get("boxedTargetZeroMember").hasTrait(AddedDefaultTrait.ID),
                 Matchers.is(false));
-        assertThat(dStruct.getAllMembers().get("boxedTargetZeroMember").hasTrait(BoxTrait.class), Matchers.is(false));
+        assertThat(dStruct.getAllMembers().get("boxedTargetZeroMember").hasTrait(BoxTrait.ID), Matchers.is(false));
 
         // A Member that has a target shape with no default value drops the default value
-        assertThat(dStruct.getAllMembers().get("boxedTargetNonzeroMember").hasTrait(DefaultTrait.class),
+        assertThat(dStruct.getAllMembers().get("boxedTargetNonzeroMember").hasTrait(DefaultTrait.ID),
                 Matchers.is(false));
-        assertThat(dStruct.getAllMembers().get("boxedTargetNonzeroMember").hasTrait(AddedDefaultTrait.class),
+        assertThat(dStruct.getAllMembers().get("boxedTargetNonzeroMember").hasTrait(AddedDefaultTrait.ID),
                 Matchers.is(false));
-        assertThat(dStruct.getAllMembers().get("boxedTargetNonzeroMember").hasTrait(BoxTrait.class),
+        assertThat(dStruct.getAllMembers().get("boxedTargetNonzeroMember").hasTrait(BoxTrait.ID),
                 Matchers.is(false));
 
         // A Member that has a default value of null keeps the default value of null and is boxed
-        assertThat(dStruct.getAllMembers().get("boxedTargetBoxedMember").hasTrait(DefaultTrait.class),
+        assertThat(dStruct.getAllMembers().get("boxedTargetBoxedMember").hasTrait(DefaultTrait.ID),
                 Matchers.is(true));
         assertThat(
                 dStruct.getAllMembers()
@@ -267,33 +267,33 @@ public class DowngradeToV1Test {
                         .toNode()
                         .isNullNode(),
                 Matchers.is(true));
-        assertThat(dStruct.getAllMembers().get("boxedTargetBoxedMember").hasTrait(AddedDefaultTrait.class),
+        assertThat(dStruct.getAllMembers().get("boxedTargetBoxedMember").hasTrait(AddedDefaultTrait.ID),
                 Matchers.is(false));
-        assertThat(dStruct.getAllMembers().get("boxedTargetBoxedMember").hasTrait(BoxTrait.class), Matchers.is(true));
+        assertThat(dStruct.getAllMembers().get("boxedTargetBoxedMember").hasTrait(BoxTrait.ID), Matchers.is(true));
 
         // A Member that has no default value has no default trait and the member is not boxed
-        assertThat(dStruct.getAllMembers().get("boxedTargetImplicitBoxedMember").hasTrait(DefaultTrait.class),
+        assertThat(dStruct.getAllMembers().get("boxedTargetImplicitBoxedMember").hasTrait(DefaultTrait.ID),
                 Matchers.is(false));
-        assertThat(dStruct.getAllMembers().get("boxedTargetImplicitBoxedMember").hasTrait(AddedDefaultTrait.class),
+        assertThat(dStruct.getAllMembers().get("boxedTargetImplicitBoxedMember").hasTrait(AddedDefaultTrait.ID),
                 Matchers.is(false));
-        assertThat(dStruct.getAllMembers().get("boxedTargetImplicitBoxedMember").hasTrait(BoxTrait.class),
+        assertThat(dStruct.getAllMembers().get("boxedTargetImplicitBoxedMember").hasTrait(BoxTrait.ID),
                 Matchers.is(false));
 
         // A Member that has a default value of null keeps the default value of null and is boxed
-        assertThat(dStruct.getAllMembers().get("baz").hasTrait(DefaultTrait.class), Matchers.is(true));
+        assertThat(dStruct.getAllMembers().get("baz").hasTrait(DefaultTrait.ID), Matchers.is(true));
         assertThat(dStruct.getAllMembers().get("baz").expectTrait(DefaultTrait.class).toNode().isNullNode(),
                 Matchers.is(true));
-        assertThat(dStruct.getAllMembers().get("baz").hasTrait(AddedDefaultTrait.class), Matchers.is(false));
-        assertThat(dStruct.getAllMembers().get("baz").hasTrait(BoxTrait.class), Matchers.is(true));
+        assertThat(dStruct.getAllMembers().get("baz").hasTrait(AddedDefaultTrait.ID), Matchers.is(false));
+        assertThat(dStruct.getAllMembers().get("baz").hasTrait(BoxTrait.ID), Matchers.is(true));
 
         // A Member with the addedDefault trait drops both the default and addedDefault trait
-        assertThat(dStruct.getAllMembers().get("bar").hasTrait(DefaultTrait.class), Matchers.is(false));
-        assertThat(dStruct.getAllMembers().get("bar").hasTrait(AddedDefaultTrait.class), Matchers.is(false));
+        assertThat(dStruct.getAllMembers().get("bar").hasTrait(DefaultTrait.ID), Matchers.is(false));
+        assertThat(dStruct.getAllMembers().get("bar").hasTrait(AddedDefaultTrait.ID), Matchers.is(false));
 
         // A Member keeps the required trait and drops the clientOptional trait
-        assertThat(dStruct.getAllMembers().get("bam").hasTrait(DefaultTrait.class), Matchers.is(false));
-        assertThat(dStruct.getAllMembers().get("bam").hasTrait(AddedDefaultTrait.class), Matchers.is(false));
-        assertThat(dStruct.getAllMembers().get("bam").hasTrait(RequiredTrait.class), Matchers.is(true));
-        assertThat(dStruct.getAllMembers().get("bam").hasTrait(ClientOptionalTrait.class), Matchers.is(false));
+        assertThat(dStruct.getAllMembers().get("bam").hasTrait(DefaultTrait.ID), Matchers.is(false));
+        assertThat(dStruct.getAllMembers().get("bam").hasTrait(AddedDefaultTrait.ID), Matchers.is(false));
+        assertThat(dStruct.getAllMembers().get("bam").hasTrait(RequiredTrait.ID), Matchers.is(true));
+        assertThat(dStruct.getAllMembers().get("bam").hasTrait(ClientOptionalTrait.ID), Matchers.is(false));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/FilterShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/FilterShapesTest.java
@@ -37,7 +37,7 @@ public class FilterShapesTest {
         StringShape b = StringShape.builder().id(bId).build();
         Model model = Model.builder().addShapes(a, b).build();
         Model result = ModelTransformer.create()
-                .filterShapes(model, shape -> !shape.getTrait(SensitiveTrait.class).isPresent());
+                .filterShapes(model, shape -> !shape.hasTrait(SensitiveTrait.class));
 
         assertThat(result.shapes().count(), Matchers.is(1L));
         assertThat(result.getShape(bId), Matchers.not(Optional.empty()));

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/FlattenPaginationInfoTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/FlattenPaginationInfoTest.java
@@ -28,7 +28,7 @@ public class FlattenPaginationInfoTest {
         Model result = ModelTransformer.create().flattenPaginationInfoIntoOperations(before, service);
 
         Shape resultService = result.expectShape(serviceId);
-        assertFalse(resultService.hasTrait(PaginatedTrait.class));
+        assertFalse(resultService.hasTrait(PaginatedTrait.ID));
 
         Shape resultOperation = result.expectShape(operationId);
         PaginatedTrait resultTrait = resultOperation.expectTrait(PaginatedTrait.class);

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptionalTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/MakeIdempotencyTokenClientOptionalTest.java
@@ -28,8 +28,8 @@ public class MakeIdempotencyTokenClientOptionalTest {
         Shape input = result.expectShape(operationInput);
         Shape member = result.expectShape(input.getMember("token").get().getId());
 
-        assertTrue(member.hasTrait(ClientOptionalTrait.class));
-        assertTrue(member.hasTrait(RequiredTrait.class));
-        assertTrue(member.hasTrait(IdempotencyTokenTrait.class));
+        assertTrue(member.hasTrait(ClientOptionalTrait.ID));
+        assertTrue(member.hasTrait(RequiredTrait.ID));
+        assertTrue(member.hasTrait(IdempotencyTokenTrait.ID));
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
@@ -319,14 +319,14 @@ public class ReplaceShapesTest {
                 .get()
                 .getMember("a")
                 .get()
-                .hasTrait(RequiredTrait.class));
+                .hasTrait(RequiredTrait.ID));
         assertTrue(result.getShape(containerId)
                 .get()
                 .asStructureShape()
                 .get()
                 .getMember("b")
                 .get()
-                .hasTrait(RequiredTrait.class));
+                .hasTrait(RequiredTrait.ID));
     }
 
     @Test

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/ResolvedTopicIndex.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/ResolvedTopicIndex.java
@@ -52,11 +52,11 @@ public final class ResolvedTopicIndex implements KnowledgeIndex {
         OperationIndex operationIndex = OperationIndex.of(model);
 
         model.shapes(OperationShape.class).forEach(operation -> {
-            if (operation.hasTrait(PublishTrait.class)) {
-                PublishTrait trait = operation.getTrait(PublishTrait.class).get();
+            if (operation.hasTrait(PublishTrait.ID)) {
+                PublishTrait trait = operation.expectTrait(PublishTrait.class);
                 createPublishBindings(operationIndex, operation, trait);
-            } else if (operation.hasTrait(SubscribeTrait.class)) {
-                SubscribeTrait trait = operation.getTrait(SubscribeTrait.class).get();
+            } else if (operation.hasTrait(SubscribeTrait.ID)) {
+                SubscribeTrait trait = operation.expectTrait(SubscribeTrait.class);
                 StructureShape input = operationIndex.expectInputShape(operation);
                 createSubscribeBinding(input, eventStreamIndex, operation, trait);
             }

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/TopicBinding.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/TopicBinding.java
@@ -78,9 +78,9 @@ public final class TopicBinding<T extends Trait> {
      * @return Returns the optionally found MQTT binding trait.
      */
     public static Optional<? extends Trait> getOperationMqttTrait(Shape operation) {
-        if (operation.hasTrait(PublishTrait.class)) {
+        if (operation.hasTrait(PublishTrait.ID)) {
             return operation.getTrait(PublishTrait.class);
-        } else if (operation.hasTrait(SubscribeTrait.class)) {
+        } else if (operation.hasTrait(SubscribeTrait.ID)) {
             return operation.getTrait(SubscribeTrait.class);
         } else {
             return Optional.empty();

--- a/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttTopicLabelValidator.java
+++ b/smithy-mqtt-traits/src/main/java/software/amazon/smithy/mqtt/traits/validators/MqttTopicLabelValidator.java
@@ -51,11 +51,11 @@ public class MqttTopicLabelValidator extends AbstractValidator {
     }
 
     private static TopicCollection createTopics(OperationShape shape) {
-        if (shape.hasTrait(SubscribeTrait.class)) {
+        if (shape.hasTrait(SubscribeTrait.ID)) {
             SubscribeTrait trait = shape.expectTrait(SubscribeTrait.class);
             List<Topic> bindings = Collections.singletonList(trait.getTopic());
             return new TopicCollection(shape, trait, bindings);
-        } else if (shape.hasTrait(PublishTrait.class)) {
+        } else if (shape.hasTrait(PublishTrait.ID)) {
             PublishTrait trait = shape.expectTrait(PublishTrait.class);
             List<Topic> bindings = Collections.singletonList(trait.getTopic());
             return new TopicCollection(shape, trait, bindings);
@@ -70,7 +70,7 @@ public class MqttTopicLabelValidator extends AbstractValidator {
         List<ValidationEvent> events = new ArrayList<>();
 
         for (MemberShape member : input.getAllMembers().values()) {
-            if (member.hasTrait(TopicLabelTrait.class)) {
+            if (member.hasTrait(TopicLabelTrait.ID)) {
                 if (labels.contains(member.getMemberName())) {
                     labels.remove(member.getMemberName());
                 } else {

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiConverter.java
@@ -451,7 +451,7 @@ public final class OpenApiConverter {
                 PathItem.Builder pathItem = paths.computeIfAbsent(result.getUri(), (uri) -> PathItem.builder());
 
                 // Mark the operation deprecated if the trait's present.
-                if (shape.hasTrait(DeprecatedTrait.class)) {
+                if (shape.hasTrait(DeprecatedTrait.ID)) {
                     result.getOperation().deprecated(true);
                 }
 

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapper.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/OpenApiJsonSchemaMapper.java
@@ -47,7 +47,7 @@ public final class OpenApiJsonSchemaMapper implements JsonSchemaMapper {
                 .map(ExternalDocumentation::toNode)
                 .ifPresent(docs -> builder.putExtension("externalDocs", docs));
 
-        if (shape.hasTrait(DeprecatedTrait.class)) {
+        if (shape.hasTrait(DeprecatedTrait.ID)) {
             builder.putExtension("deprecated", Node.from(true));
         }
 
@@ -77,7 +77,7 @@ public final class OpenApiJsonSchemaMapper implements JsonSchemaMapper {
                 config.detectJsonTimestampFormat(shape)
                         .filter(format -> format.equals(TimestampFormatTrait.EPOCH_SECONDS))
                         .ifPresent(format -> builder.format("double"));
-            } else if (shape.hasTrait(SensitiveTrait.class)) {
+            } else if (shape.hasTrait(SensitiveTrait.ID)) {
                 builder.format("password");
             }
         }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -138,7 +138,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
         bindingIndex.determineRequestContentType(operationShape, documentMediaType)
                 .ifPresent(c -> headers.addAll(ProtocolUtils.CONTENT_HEADERS));
 
-        if (operationShape.hasTrait(HttpChecksumRequiredTrait.class)) {
+        if (operationShape.hasTrait(HttpChecksumRequiredTrait.ID)) {
             headers.add("Content-Md5");
         }
         return headers;
@@ -653,7 +653,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
             StructureShape shape,
             Map<String, ResponseObject> responses
     ) {
-        Shape operationOrError = shape.hasTrait(ErrorTrait.class) ? shape : operation;
+        Shape operationOrError = shape.hasTrait(ErrorTrait.ID) ? shape : operation;
         String statusCode = context.getOpenApiProtocol().getOperationResponseStatusCode(context, operationOrError);
         ResponseObject response = createResponse(
                 context,
@@ -690,7 +690,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
     ) {
         List<HttpBinding> bindings = HttpBindingIndex.of(context.getModel())
                 .getResponseBindings(operationOrError, HttpBinding.Location.HEADER);
-        MessageType type = !operationOrError.hasTrait(ErrorTrait.class) ? MessageType.RESPONSE : MessageType.ERROR;
+        MessageType type = !operationOrError.hasTrait(ErrorTrait.ID) ? MessageType.RESPONSE : MessageType.ERROR;
         return createHeaderParameters(context, bindings, type, operationOrError, operation);
     }
 
@@ -749,7 +749,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
         // or arrays. These schemas are synthesized as references so that
         // any schemas with string types will pass validation.
         Schema schema = context.inlineOrReferenceSchema(binding.getMember());
-        MessageType type = !operationOrError.hasTrait(ErrorTrait.class) ? MessageType.RESPONSE : MessageType.ERROR;
+        MessageType type = !operationOrError.hasTrait(ErrorTrait.ID) ? MessageType.RESPONSE : MessageType.ERROR;
         MediaTypeObject mediaTypeObject = getMediaTypeObject(context, schema, operationOrError, shape -> {
             String shapeName = context.getService().getContextualName(shape.getId());
             return shape instanceof OperationShape

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1Protocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1Protocol.java
@@ -60,7 +60,7 @@ public final class AwsRestJson1Protocol extends AbstractRestProtocol<RestJson1Tr
         Set<String> headers = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         headers.addAll(super.getProtocolRequestHeaders(context, operationShape));
         headers.addAll(AWS_REQUEST_HEADERS);
-        if (operationShape.hasTrait(ClientDiscoveredEndpointTrait.class)) {
+        if (operationShape.hasTrait(ClientDiscoveredEndpointTrait.ID)) {
             headers.add("X-Amz-Api-Version");
         }
         return headers;

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/HeaderSchemaVisitor.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/HeaderSchemaVisitor.java
@@ -59,7 +59,7 @@ final class HeaderSchemaVisitor<T extends Trait> extends ShapeVisitor.Default<Sc
     // created if the format was not explicitly set.
     @Override
     public Schema timestampShape(TimestampShape shape) {
-        if (member.hasTrait(TimestampFormatTrait.class)) {
+        if (member.hasTrait(TimestampFormatTrait.ID)) {
             return schema;
         }
 
@@ -72,7 +72,7 @@ final class HeaderSchemaVisitor<T extends Trait> extends ShapeVisitor.Default<Sc
     @Override
     public Schema stringShape(StringShape shape) {
         // String shapes with the mediaType trait must be base64 encoded.
-        return shape.hasTrait(MediaTypeTrait.class)
+        return shape.hasTrait(MediaTypeTrait.ID)
                 ? schema.toBuilder().ref(null).type("string").format("byte").build()
                 : schema;
     }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/QuerySchemaVisitor.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/QuerySchemaVisitor.java
@@ -59,7 +59,7 @@ final class QuerySchemaVisitor<T extends Trait> extends ShapeVisitor.Default<Sch
     @Override
     public Schema timestampShape(TimestampShape shape) {
         // Use the referenced shape as-is since it defines an explicit format.
-        if (member.hasTrait(TimestampFormatTrait.class)) {
+        if (member.hasTrait(TimestampFormatTrait.ID)) {
             return schema;
         }
 

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/analysis/OperationContextParamsChecker.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/analysis/OperationContextParamsChecker.java
@@ -267,7 +267,7 @@ public final class OperationContextParamsChecker {
             // Create a random string that does not exceed or go under the length trait.
             int chars = 2;
 
-            if (shape.hasTrait(LengthTrait.class)) {
+            if (shape.hasTrait(LengthTrait.ID)) {
                 LengthTrait trait = shape.expectTrait(LengthTrait.class);
                 if (trait.getMin().isPresent()) {
                     chars = Math.max(chars, trait.getMin().get().intValue());
@@ -284,7 +284,7 @@ public final class OperationContextParamsChecker {
             // Create a random string that does not exceed or go under the range trait.
             double i = 8;
 
-            if (shape.hasTrait(RangeTrait.class)) {
+            if (shape.hasTrait(RangeTrait.ID)) {
                 RangeTrait trait = shape.expectTrait(RangeTrait.class);
                 if (trait.getMin().isPresent()) {
                     i = Math.max(i, trait.getMin().get().doubleValue());

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/validators/RuleSetParameterValidator.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/validators/RuleSetParameterValidator.java
@@ -66,7 +66,7 @@ public final class RuleSetParameterValidator extends AbstractValidator {
                     errorsParamsPair.getRight()));
 
             // Check that tests declare required parameters, only defined parameters, etc.
-            if (serviceShape.hasTrait(EndpointTestsTrait.class)) {
+            if (serviceShape.hasTrait(EndpointTestsTrait.ID)) {
                 errors.addAll(validateTestsParameters(model,
                         topDownIndex,
                         serviceShape,
@@ -86,7 +86,7 @@ public final class RuleSetParameterValidator extends AbstractValidator {
         List<ValidationEvent> errors = new ArrayList<>();
         Map<String, Parameter> endpointParams = new HashMap<>();
 
-        if (serviceShape.hasTrait(ClientContextParamsTrait.class)) {
+        if (serviceShape.hasTrait(ClientContextParamsTrait.ID)) {
             ClientContextParamsTrait trait = serviceShape.expectTrait(ClientContextParamsTrait.class);
             for (Map.Entry<String, ClientContextParamDefinition> entry : trait.getParameters().entrySet()) {
                 endpointParams.put(entry.getKey(),
@@ -144,7 +144,7 @@ public final class RuleSetParameterValidator extends AbstractValidator {
 
             StructureShape input = model.expectShape(operationShape.getInputShape(), StructureShape.class);
             for (MemberShape memberShape : input.members()) {
-                if (memberShape.hasTrait(ContextParamTrait.class)) {
+                if (memberShape.hasTrait(ContextParamTrait.ID)) {
                     ContextParamTrait trait = memberShape.expectTrait(ContextParamTrait.class);
                     String name = trait.getName();
                     Shape targetType = model.expectShape(memberShape.getTarget());
@@ -329,7 +329,7 @@ public final class RuleSetParameterValidator extends AbstractValidator {
                         for (String name : inputShape.getMemberNames()) {
                             MemberShape memberShape = inputShape.getMember(name).get();
                             if (input.getOperationParams().containsMember(name)
-                                    && memberShape.hasTrait(ContextParamTrait.class)) {
+                                    && memberShape.hasTrait(ContextParamTrait.ID)) {
                                 String paramName = memberShape.expectTrait(ContextParamTrait.class).getName();
                                 testParams.add(buildParameter(paramName,
                                         input.getOperationParams().expectMember(name)));

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/validators/RuleSetTestCaseValidator.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/validators/RuleSetTestCaseValidator.java
@@ -24,7 +24,7 @@ public class RuleSetTestCaseValidator extends AbstractValidator {
     public List<ValidationEvent> validate(Model model) {
         List<ValidationEvent> events = new ArrayList<>();
         for (ServiceShape serviceShape : model.getServiceShapesWithTrait(EndpointRuleSetTrait.class)) {
-            if (serviceShape.hasTrait(EndpointTestsTrait.class)) {
+            if (serviceShape.hasTrait(EndpointTestsTrait.ID)) {
                 EndpointRuleSet ruleSet = serviceShape.expectTrait(EndpointRuleSetTrait.class).getEndpointRuleSet();
                 EndpointTestsTrait testsTrait = serviceShape.expectTrait(EndpointTestsTrait.class);
 

--- a/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/traits/CleanEndpointTestOperationInputTest.java
+++ b/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/traits/CleanEndpointTestOperationInputTest.java
@@ -40,9 +40,9 @@ public class CleanEndpointTestOperationInputTest {
         assertTrue(transformed.getShape(SERVICE_ID).isPresent());
 
         ServiceShape mainService = model.expectShape(SERVICE_ID, ServiceShape.class);
-        assertTrue(mainService.hasTrait(EndpointTestsTrait.class));
+        assertTrue(mainService.hasTrait(EndpointTestsTrait.ID));
         ServiceShape transformedService = transformed.expectShape(SERVICE_ID, ServiceShape.class);
-        assertTrue(transformedService.hasTrait(EndpointTestsTrait.class));
+        assertTrue(transformedService.hasTrait(EndpointTestsTrait.ID));
 
         Node.assertEquals(transformedService.expectTrait(EndpointTestsTrait.class).toNode(),
                 mainService.expectTrait(EndpointTestsTrait.class).toNode());
@@ -56,7 +56,7 @@ public class CleanEndpointTestOperationInputTest {
         assertTrue(transformed.getShape(SERVICE_ID).isPresent());
 
         ServiceShape transformedService = transformed.expectShape(SERVICE_ID, ServiceShape.class);
-        assertTrue(transformedService.hasTrait(EndpointTestsTrait.class));
+        assertTrue(transformedService.hasTrait(EndpointTestsTrait.ID));
 
         EndpointTestsTrait trait = transformedService.expectTrait(EndpointTestsTrait.class);
         assertEquals(1, trait.getTestCases().size());
@@ -82,7 +82,7 @@ public class CleanEndpointTestOperationInputTest {
         assertTrue(transformed.getShape(SERVICE_ID).isPresent());
 
         ServiceShape transformedService = transformed.expectShape(SERVICE_ID, ServiceShape.class);
-        assertTrue(transformedService.hasTrait(EndpointTestsTrait.class));
+        assertTrue(transformedService.hasTrait(EndpointTestsTrait.ID));
 
         EndpointTestsTrait trait = transformedService.expectTrait(EndpointTestsTrait.class);
         assertEquals(0, trait.getTestCases().size());

--- a/smithy-smoke-test-traits/src/main/java/software/amazon/smithy/smoketests/traits/UniqueSmokeTestCaseIdValidator.java
+++ b/smithy-smoke-test-traits/src/main/java/software/amazon/smithy/smoketests/traits/UniqueSmokeTestCaseIdValidator.java
@@ -55,7 +55,7 @@ public class UniqueSmokeTestCaseIdValidator extends AbstractValidator {
     private void addValidationEventsForShapes(Set<OperationShape> shapes, List<ValidationEvent> events) {
         Map<String, List<Shape>> testCaseIdsToOperations = new HashMap<>();
         for (Shape shape : shapes) {
-            if (!shape.isOperationShape() || !shape.hasTrait(SmokeTestsTrait.class)) {
+            if (!shape.isOperationShape() || !shape.hasTrait(SmokeTestsTrait.ID)) {
                 continue;
             }
 

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/TraitCodegenSymbolProvider.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/TraitCodegenSymbolProvider.java
@@ -130,7 +130,7 @@ final class TraitCodegenSymbolProvider extends ShapeVisitor.DataShapeVisitor<Sym
 
     @Override
     public Symbol listShape(ListShape shape) {
-        if (shape.hasTrait(UniqueItemsTrait.class)) {
+        if (shape.hasTrait(UniqueItemsTrait.ID)) {
             return TraitCodegenUtils.fromClass(Set.class)
                     .toBuilder()
                     .addReference(toSymbol(shape.getMember()))

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/TraitCodegenUtils.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/TraitCodegenUtils.java
@@ -112,7 +112,7 @@ public final class TraitCodegenUtils {
      */
     public static boolean isJavaStringList(Shape shape, SymbolProvider symbolProvider) {
         return shape.isListShape()
-                && !shape.hasTrait(UniqueItemsTrait.class)
+                && !shape.hasTrait(UniqueItemsTrait.ID)
                 && TraitCodegenUtils.isJavaString(symbolProvider.toSymbol(
                         shape.asListShape().get().getMember()));
     }

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/BuilderGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/BuilderGenerator.java
@@ -102,7 +102,7 @@ final class BuilderGenerator implements Runnable {
     }
 
     private void writeBuilderInterface() {
-        if (baseShape.hasTrait(TraitDefinition.class)) {
+        if (baseShape.hasTrait(TraitDefinition.ID)) {
             if (TraitCodegenUtils.isJavaStringList(baseShape, symbolProvider)) {
                 writer.write("extends $T.Builder<$T, Builder> {", StringListTrait.class, symbol);
             } else {
@@ -131,7 +131,7 @@ final class BuilderGenerator implements Runnable {
                 () -> {
                     writer.writeInlineWithNoFormatting("return builder()");
                     writer.indent();
-                    if (baseShape.hasTrait(TraitDefinition.class)) {
+                    if (baseShape.hasTrait(TraitDefinition.ID)) {
                         writer.writeInlineWithNoFormatting(".sourceLocation(getSourceLocation())");
                     }
                     if (baseShape.members().isEmpty()) {
@@ -503,7 +503,7 @@ final class BuilderGenerator implements Runnable {
 
         @Override
         public Void timestampShape(TimestampShape timestampShape) {
-            if (member.hasTrait(TimestampFormatTrait.class)) {
+            if (member.hasTrait(TimestampFormatTrait.ID)) {
                 switch (member.expectTrait(TimestampFormatTrait.class).getFormat()) {
                     case EPOCH_SECONDS:
                         writer.writeInline(

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/ConstructorGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/ConstructorGenerator.java
@@ -67,7 +67,7 @@ final class ConstructorGenerator extends TraitVisitor<Void> implements Runnable 
 
     @Override
     public Void listShape(ListShape shape) {
-        if (!shape.hasTrait(UniqueItemsTrait.class)
+        if (!shape.hasTrait(UniqueItemsTrait.ID)
                 && TraitCodegenUtils.isJavaString(symbolProvider.toSymbol(shape.getMember()))) {
             writer.openBlock("public $1T($1B values, $2T sourceLocation) {",
                     "}",
@@ -170,7 +170,7 @@ final class ConstructorGenerator extends TraitVisitor<Void> implements Runnable 
     private void writeConstructorWithBuilder() {
         writer.openBlock("private $T(Builder builder) {", "}", symbol, () -> {
             // If the shape is a trait include the source location. Nested shapes don't have a separate source location.
-            if (shape.hasTrait(TraitDefinition.class)) {
+            if (shape.hasTrait(TraitDefinition.ID)) {
                 writer.writeWithNoFormatting("super(ID, builder.getSourceLocation());");
             }
             shape.accept(new InitializerVisitor());

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeGenerator.java
@@ -197,7 +197,7 @@ final class FromNodeGenerator extends TraitVisitor<Void> implements Runnable {
         // If the trait has the timestamp format trait then we only need a single
         // way to deserialize the input node. Without the timestamp format trait
         // timestamp should be able to handle both epoch seconds and date time formats.
-        if (shape.hasTrait(TimestampFormatTrait.class)) {
+        if (shape.hasTrait(TimestampFormatTrait.ID)) {
             writer.write("return new $T($C, node.getSourceLocation());",
                     symbol,
                     (Runnable) () -> shape.accept(new FromNodeMapperVisitor(writer, model, "node")));

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeMapperVisitor.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeMapperVisitor.java
@@ -134,7 +134,7 @@ final class FromNodeMapperVisitor extends ShapeVisitor.DataShapeVisitor<Void> {
 
     @Override
     public Void stringShape(StringShape shape) {
-        if (shape.hasTrait(IdRefTrait.class)) {
+        if (shape.hasTrait(IdRefTrait.ID)) {
             writer.write("$T.fromNode($L)", ShapeId.class, varName);
         } else {
             writer.write("$L.expectStringNode().getValue()", varName);
@@ -150,7 +150,7 @@ final class FromNodeMapperVisitor extends ShapeVisitor.DataShapeVisitor<Void> {
 
     @Override
     public Void timestampShape(TimestampShape shape) {
-        if (shape.hasTrait(TimestampFormatTrait.class)) {
+        if (shape.hasTrait(TimestampFormatTrait.ID)) {
             switch (shape.expectTrait(TimestampFormatTrait.class).getFormat()) {
                 case EPOCH_SECONDS:
                     writer.writeInline("$2T.ofEpochSecond($1L.expectNumberNode().getValue().longValue())",
@@ -184,7 +184,7 @@ final class FromNodeMapperVisitor extends ShapeVisitor.DataShapeVisitor<Void> {
 
     @Override
     public Void memberShape(MemberShape shape) {
-        if (shape.hasTrait(IdRefTrait.class)) {
+        if (shape.hasTrait(IdRefTrait.ID)) {
             writer.write("$T.fromNode($L)", ShapeId.class, varName);
         } else {
             model.expectShape(shape.getTarget()).accept(this);

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/ShapeGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/ShapeGenerator.java
@@ -26,7 +26,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 public final class ShapeGenerator implements Consumer<GenerateTraitDirective> {
     @Override
     public void accept(GenerateTraitDirective directive) {
-        if (directive.shape().hasTrait(TraitDefinition.class)) {
+        if (directive.shape().hasTrait(TraitDefinition.ID)) {
             new TraitGenerator().accept(directive);
         } else {
             directive.shape().accept(new NestedShapeGenerator(directive));

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/ToNodeGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/ToNodeGenerator.java
@@ -59,7 +59,7 @@ final class ToNodeGenerator implements Runnable {
     @Override
     public void run() {
         writer.override();
-        writer.openBlock(shape.hasTrait(TraitDefinition.class) ? "protected $T createNode() {" : "public $T toNode() {",
+        writer.openBlock(shape.hasTrait(TraitDefinition.ID) ? "protected $T createNode() {" : "public $T toNode() {",
                 "}",
                 Node.class,
                 () -> shape.accept(new CreateNodeBodyGenerator()));
@@ -125,7 +125,7 @@ final class ToNodeGenerator implements Runnable {
 
         @Override
         public Void enumShape(EnumShape shape) {
-            if (shape.hasTrait(TraitDefinition.class)) {
+            if (shape.hasTrait(TraitDefinition.ID)) {
                 writer.write("return $T.from(value);", Node.class);
             } else {
                 toStringCreator();
@@ -136,7 +136,7 @@ final class ToNodeGenerator implements Runnable {
         @Override
         public Void structureShape(StructureShape shape) {
             writer.write("return $T.objectNodeBuilder()", Node.class).indent();
-            if (shape.hasTrait(TraitDefinition.class)) {
+            if (shape.hasTrait(TraitDefinition.ID)) {
                 // If the shape is a trait we need to add the source location of trait to the
                 // generated node.
                 writer.writeInline(".sourceLocation(getSourceLocation())");
@@ -166,7 +166,7 @@ final class ToNodeGenerator implements Runnable {
 
         @Override
         public Void timestampShape(TimestampShape shape) {
-            if (shape.hasTrait(TimestampFormatTrait.class)) {
+            if (shape.hasTrait(TimestampFormatTrait.ID)) {
                 switch (shape.expectTrait(TimestampFormatTrait.class).getFormat()) {
                     case EPOCH_SECONDS:
                         writer.write("return new $T(value.getEpochSecond(), getSourceLocation());",
@@ -210,7 +210,7 @@ final class ToNodeGenerator implements Runnable {
 
         @Override
         public Void stringShape(StringShape shape) {
-            if (shape.hasTrait(IdRefTrait.class)) {
+            if (shape.hasTrait(IdRefTrait.ID)) {
                 toStringMapper();
             } else {
                 fromNodeMapper();
@@ -256,7 +256,7 @@ final class ToNodeGenerator implements Runnable {
 
         @Override
         public Void memberShape(MemberShape shape) {
-            if (shape.hasTrait(IdRefTrait.class)) {
+            if (shape.hasTrait(IdRefTrait.ID)) {
                 toStringMapper();
             } else {
                 model.expectShape(shape.getTarget()).accept(this);
@@ -296,7 +296,7 @@ final class ToNodeGenerator implements Runnable {
 
         @Override
         public Void timestampShape(TimestampShape shape) {
-            if (shape.hasTrait(TimestampFormatTrait.class)) {
+            if (shape.hasTrait(TimestampFormatTrait.ID)) {
                 switch (shape.expectTrait(TimestampFormatTrait.class).getFormat()) {
                     case EPOCH_SECONDS:
                         writer.write("$T.from($L.getEpochSecond())", Node.class, varName);

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/annotations/DeprecatedAnnotationInterceptor.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/annotations/DeprecatedAnnotationInterceptor.java
@@ -25,11 +25,11 @@ final class DeprecatedAnnotationInterceptor implements CodeInterceptor.Prepender
     @Override
     public boolean isIntercepted(CodeSection section) {
         if (section instanceof ClassSection) {
-            return ((ClassSection) section).shape().hasTrait(DeprecatedTrait.class);
+            return ((ClassSection) section).shape().hasTrait(DeprecatedTrait.ID);
         } else if (section instanceof GetterSection) {
-            return ((GetterSection) section).shape().hasTrait(DeprecatedTrait.class);
+            return ((GetterSection) section).shape().hasTrait(DeprecatedTrait.ID);
         } else if (section instanceof EnumVariantSection) {
-            return ((EnumVariantSection) section).memberShape().hasTrait(DeprecatedTrait.class);
+            return ((EnumVariantSection) section).memberShape().hasTrait(DeprecatedTrait.ID);
         }
         return false;
     }

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/annotations/UnstableAnnotationInterceptor.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/annotations/UnstableAnnotationInterceptor.java
@@ -26,11 +26,11 @@ final class UnstableAnnotationInterceptor implements CodeInterceptor.Prepender<C
     @Override
     public boolean isIntercepted(CodeSection section) {
         if (section instanceof ClassSection) {
-            return ((ClassSection) section).shape().hasTrait(UnstableTrait.class);
+            return ((ClassSection) section).shape().hasTrait(UnstableTrait.ID);
         } else if (section instanceof GetterSection) {
-            return ((GetterSection) section).shape().hasTrait(UnstableTrait.class);
+            return ((GetterSection) section).shape().hasTrait(UnstableTrait.ID);
         } else if (section instanceof EnumVariantSection) {
-            return ((EnumVariantSection) section).memberShape().hasTrait(UnstableTrait.class);
+            return ((EnumVariantSection) section).memberShape().hasTrait(UnstableTrait.ID);
         }
         return false;
     }

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/core/CoreIntegration.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/core/CoreIntegration.java
@@ -57,7 +57,7 @@ public final class CoreIntegration implements TraitCodegenIntegration {
         return new SymbolProvider() {
             @Override
             public Symbol toSymbol(Shape shape) {
-                if (shape.hasTrait(TraitDefinition.class)) {
+                if (shape.hasTrait(TraitDefinition.ID)) {
                     return getTraitSymbol(settings, shape, symbolProvider.toSymbol(shape));
                 }
                 return symbolProvider.toSymbol(shape);

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/idref/IdRefDecoratorIntegration.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/idref/IdRefDecoratorIntegration.java
@@ -62,7 +62,7 @@ public class IdRefDecoratorIntegration implements TraitCodegenIntegration {
     }
 
     private Symbol provideSymbol(Shape shape, SymbolProvider symbolProvider, Model model) {
-        if (shape.hasTrait(IdRefTrait.class)) {
+        if (shape.hasTrait(IdRefTrait.ID)) {
             return SHAPE_ID_SYMBOL;
         } else if (shape.isMemberShape()) {
             Shape target = model.expectShape(shape.asMemberShape().orElseThrow(RuntimeException::new).getTarget());

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/javadoc/DeprecatedInterceptor.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/javadoc/DeprecatedInterceptor.java
@@ -36,6 +36,6 @@ final class DeprecatedInterceptor implements CodeInterceptor.Appender<JavaDocSec
 
     @Override
     public boolean isIntercepted(JavaDocSection section) {
-        return section.shape().hasTrait(DeprecatedTrait.class);
+        return section.shape().hasTrait(DeprecatedTrait.ID);
     }
 }

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/javadoc/DocumentationTraitInterceptor.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/javadoc/DocumentationTraitInterceptor.java
@@ -34,6 +34,6 @@ final class DocumentationTraitInterceptor implements CodeInterceptor<JavaDocSect
 
     @Override
     public boolean isIntercepted(JavaDocSection section) {
-        return section.shape().hasTrait(DocumentationTrait.class);
+        return section.shape().hasTrait(DocumentationTrait.ID);
     }
 }

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/javadoc/ExternalDocumentationInterceptor.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/javadoc/ExternalDocumentationInterceptor.java
@@ -34,6 +34,6 @@ final class ExternalDocumentationInterceptor implements CodeInterceptor.Appender
 
     @Override
     public boolean isIntercepted(JavaDocSection section) {
-        return section.shape().hasTrait(ExternalDocumentationTrait.class);
+        return section.shape().hasTrait(ExternalDocumentationTrait.ID);
     }
 }

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/javadoc/SinceInterceptor.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/integrations/javadoc/SinceInterceptor.java
@@ -30,6 +30,6 @@ final class SinceInterceptor implements CodeInterceptor.Appender<JavaDocSection,
 
     @Override
     public boolean isIntercepted(JavaDocSection section) {
-        return section.shape().hasTrait(SinceTrait.class);
+        return section.shape().hasTrait(SinceTrait.ID);
     }
 }

--- a/smithy-waiters/src/main/java/software/amazon/smithy/waiters/ModelRuntimeTypeGenerator.java
+++ b/smithy-waiters/src/main/java/software/amazon/smithy/waiters/ModelRuntimeTypeGenerator.java
@@ -217,7 +217,7 @@ final class ModelRuntimeTypeGenerator implements ShapeVisitor<Object> {
         // Create a random string that does not exceed or go under the length trait.
         int chars = 2;
 
-        if (shape.hasTrait(LengthTrait.class)) {
+        if (shape.hasTrait(LengthTrait.ID)) {
             LengthTrait trait = shape.expectTrait(LengthTrait.class);
             if (trait.getMin().isPresent()) {
                 chars = Math.max(chars, trait.getMin().get().intValue());
@@ -234,7 +234,7 @@ final class ModelRuntimeTypeGenerator implements ShapeVisitor<Object> {
         // Create a random string that does not exceed or go under the range trait.
         double i = 8;
 
-        if (shape.hasTrait(RangeTrait.class)) {
+        if (shape.hasTrait(RangeTrait.ID)) {
             RangeTrait trait = shape.expectTrait(RangeTrait.class);
             if (trait.getMin().isPresent()) {
                 i = Math.max(i, trait.getMin().get().doubleValue());

--- a/smithy-waiters/src/main/java/software/amazon/smithy/waiters/WaitableTraitValidator.java
+++ b/smithy-waiters/src/main/java/software/amazon/smithy/waiters/WaitableTraitValidator.java
@@ -19,7 +19,7 @@ public final class WaitableTraitValidator extends AbstractValidator {
     @Override
     public List<ValidationEvent> validate(Model model) {
         return model.shapes(OperationShape.class)
-                .filter(operation -> operation.hasTrait(WaitableTrait.class))
+                .filter(operation -> operation.hasTrait(WaitableTrait.ID))
                 .flatMap(operation -> validateOperation(model, operation).stream())
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
This commit updates all calls to `hasTrait` from using Class based lookups to use ID based lookups. Traits are stored on a `Shape` in a `ShapeId`-keyed map. Using this will be faster than testing values via `isInstance`.

The lookup for `hasTrait(ShapeId)` is also updated to do a simple `containsKey` check on the map. This eliminates using `findTrait` which creates an intermediate `Optional` only to throw it away.


```
TraitLookups.hasTraitByClass       avgt    3  37.269 ± 2.546  us/op
TraitLookups.hasTraitByString      avgt    3  21.824 ± 1.066  us/op
TraitLookups.hasTraitByShapeIdOld  avgt    3  15.233 ± 5.002  us/op
TraitLookups.hasTraitByShapeId     avgt    3  11.611 ± 2.044  us/op
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
