### PR TITLE
Relax TaggableResource instance validation

### DIFF
--- a/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TaggableResourceValidator.java
+++ b/smithy-aws-traits/src/main/java/software/amazon/smithy/aws/traits/tagging/TaggableResourceValidator.java
@@ -88,7 +88,7 @@ public final class TaggableResourceValidator extends AbstractValidator {
         }
 
         if (!isServiceWideTaggable && !isInstanceOpTaggable) {
-            events.add(error(resource,
+            events.add(danger(resource,
                     String.format("Resource does not have tagging CRUD operations and is not"
                             + " compatible with service-wide tagging operations"
                             + " for service `%s`.",

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/tagging/invalid-tag-enabled-service-list-broken.errors
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/tagging/invalid-tag-enabled-service-list-broken.errors
@@ -1,3 +1,3 @@
 [DANGER] example.weather#Weather: Shape `example.weather#ListTagsForResource` does not satisfy 'ListTagsForResource' operation requirements. | ServiceTagging
-[ERROR] example.weather#City: Resource does not have tagging CRUD operations and is not compatible with service-wide tagging operations for service `example.weather#Weather`. | TaggableResource
+[DANGER] example.weather#City: Resource does not have tagging CRUD operations and is not compatible with service-wide tagging operations for service `example.weather#Weather`. | TaggableResource
 [WARNING] example.weather#Weather: Service marked `aws.api#tagEnabled` trait does not have consistent tagging operations implemented: {TagResource, UntagResource, and ListTagsForResource}. | TagEnabledService

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/tagging/invalid-tag-on-create.errors
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/tagging/invalid-tag-on-create.errors
@@ -2,4 +2,4 @@
 [WARNING] example.weather#Weather: Service marked `aws.api#TagEnabled` is missing an operation named 'TagResource.' | ServiceTagging
 [WARNING] example.weather#Weather: Service marked `aws.api#TagEnabled` is missing an operation named 'UntagResource.' | ServiceTagging
 [WARNING] example.weather#Weather: Service marked `aws.api#tagEnabled` trait does not have consistent tagging operations implemented: {TagResource, UntagResource, and ListTagsForResource}. | TagEnabledService
-[ERROR] example.weather#City: Resource does not have tagging CRUD operations and is not compatible with service-wide tagging operations for service `example.weather#Weather`. | TaggableResource
+[DANGER] example.weather#City: Resource does not have tagging CRUD operations and is not compatible with service-wide tagging operations for service `example.weather#Weather`. | TaggableResource

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/tagging/invalid-tag-service-wide-two-services.errors
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/tagging/invalid-tag-service-wide-two-services.errors
@@ -1,3 +1,3 @@
 [WARNING] example.weather#Forecast: Resource is likely missing `aws.api#taggable` trait. | TaggableResource
 [WARNING] example.weather#AnotherService: Service has resources with `aws.api#taggable` applied but does not have the `aws.api#tagEnabled` trait. | TaggableResource
-[ERROR] example.weather#City: Resource does not have tagging CRUD operations and is not compatible with service-wide tagging operations for service `example.weather#AnotherService`. | TaggableResource
+[DANGER] example.weather#City: Resource does not have tagging CRUD operations and is not compatible with service-wide tagging operations for service `example.weather#AnotherService`. | TaggableResource

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/tagging/invalid-tag-types.errors
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/errorfiles/tagging/invalid-tag-types.errors
@@ -3,4 +3,4 @@
 [WARNING] example.weather#Weather: Service marked `aws.api#TagEnabled` is missing an operation named 'UntagResource.' | ServiceTagging
 [WARNING] example.weather#Weather: Service marked `aws.api#tagEnabled` trait does not have consistent tagging operations implemented: {TagResource, UntagResource, and ListTagsForResource}. | TagEnabledService
 [ERROR] example.weather#City: Tag property must be a list shape targeting a member containing a pair of strings, or a Map shape targeting a string member. | TagResourcePropertyType
-[ERROR] example.weather#City: Resource does not have tagging CRUD operations and is not compatible with service-wide tagging operations for service `example.weather#Weather`. | TaggableResource
+[DANGER] example.weather#City: Resource does not have tagging CRUD operations and is not compatible with service-wide tagging operations for service `example.weather#Weather`. | TaggableResource


### PR DESCRIPTION
This commit lowers the severity (ERROR to DANGER) when a resource does not have instance operations for manipulating tags when service level tagging operations are not present.

This is useful for serivces that have operation inputs that vary subtly, making direct instance bindings not possible.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
