### PR TITLE
Add breakingChanges to the removal of sigv4 and sigv4a traits

### DIFF
--- a/.changes/next-release/feature-4352fb542ea76e90f06860fb12e80bc88b02616f.json
+++ b/.changes/next-release/feature-4352fb542ea76e90f06860fb12e80bc88b02616f.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "description": "Add breakingChanges to the removal of sigv4 and sigv4a traits",
+  "pull_requests": []
+}

--- a/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.auth.smithy
+++ b/smithy-aws-traits/src/main/resources/META-INF/smithy/aws.auth.smithy
@@ -23,7 +23,17 @@ structure cognitoUserPools {
     traits: [unsignedPayload]
 )
 @externalDocumentation(Reference: "https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html")
-@trait(selector: "service")
+@trait(
+    selector: "service"
+    breakingChanges: [
+        {
+            change: "remove",
+            message: """
+                Removing the existing authentication scheme is not backward compatible \
+                and can break existing clients' authentication."""
+        }
+    ]
+)
 structure sigv4 {
     /// The signature version 4 service signing name to use in the credential
     /// scope when signing requests. This value SHOULD match the `arnNamespace`
@@ -46,7 +56,17 @@ structure sigv4 {
     Reference: "https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html"
     Examples: "https://github.com/aws-samples/sigv4a-signing-examples"
 )
-@trait(selector: "service[trait|aws.auth#sigv4]")
+@trait(
+    selector: "service[trait|aws.auth#sigv4]"
+    breakingChanges: [
+        {
+            change: "remove",
+            message: """
+                Removing the existing authentication scheme is not backward compatible \
+                and can break existing clients' authentication."""
+        }
+    ]
+)
 structure sigv4a {
     /// The signature version 4a service signing name to use in the credential
     /// scope when signing requests. This value SHOULD match the `arnNamespace`

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/diffs/remove-sigv4.a.smithy
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/diffs/remove-sigv4.a.smithy
@@ -1,0 +1,22 @@
+$version: "2.0"
+
+metadata suppressions = [
+    {
+        id: "ModifiedTrait.Update.smithy.api#auth"
+        namespace: "ns.foo"
+    }
+]
+
+namespace ns.foo
+
+use aws.auth#sigv4
+
+@auth([sigv4])
+@sigv4(name: "service")
+service Service {
+    operations: [
+        Operation
+    ]
+}
+
+operation Operation {}

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/diffs/remove-sigv4.b.smithy
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/diffs/remove-sigv4.b.smithy
@@ -1,0 +1,20 @@
+$version: "2.0"
+
+metadata suppressions = [
+    {
+        id: "ModifiedTrait.Update.smithy.api#auth"
+        namespace: "ns.foo"
+    }
+]
+
+namespace ns.foo
+
+@auth([])
+service Service {
+    operations: [
+        Operation
+    ]
+}
+
+
+operation Operation {}

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/diffs/remove-sigv4.events
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/diffs/remove-sigv4.events
@@ -1,0 +1,7 @@
+[ERROR] ns.foo#Service: Removed trait `aws.auth#sigv4`. Previous trait value: 
+```
+{
+    "name": "service"
+}
+```
+; Removing the existing authentication scheme is not backward compatible and can break existing clients' authentication. | TraitBreakingChange.Remove

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/diffs/remove-sigv4a.a.smithy
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/diffs/remove-sigv4a.a.smithy
@@ -1,0 +1,24 @@
+$version: "2.0"
+
+metadata suppressions = [
+    {
+        id: "ModifiedTrait.Update.smithy.api#auth"
+        namespace: "ns.foo"
+    }
+]
+
+namespace ns.foo
+
+use aws.auth#sigv4
+use aws.auth#sigv4a
+
+@auth([sigv4, sigv4a])
+@sigv4(name: "service")
+@sigv4a(name: "service")
+service Service {
+    operations: [
+        Operation
+    ]
+}
+
+operation Operation {}

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/diffs/remove-sigv4a.b.smithy
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/diffs/remove-sigv4a.b.smithy
@@ -1,0 +1,23 @@
+$version: "2.0"
+
+metadata suppressions = [
+    {
+        id: "ModifiedTrait.Update.smithy.api#auth"
+        namespace: "ns.foo"
+    }
+]
+
+namespace ns.foo
+
+use aws.auth#sigv4
+
+@auth([sigv4])
+@sigv4(name: "service")
+service Service {
+    operations: [
+        Operation
+    ]
+}
+
+
+operation Operation {}

--- a/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/diffs/remove-sigv4a.events
+++ b/smithy-aws-traits/src/test/resources/software/amazon/smithy/aws/traits/diffs/remove-sigv4a.events
@@ -1,0 +1,7 @@
+[ERROR] ns.foo#Service: Removed trait `aws.auth#sigv4a`. Previous trait value: 
+```
+{
+    "name": "service"
+}
+```
+; Removing the existing authentication scheme is not backward compatible and can break existing clients' authentication. | TraitBreakingChange.Remove


### PR DESCRIPTION
#### Background
* The removal of sigv4 and sigv4a auth events will throw danger events since these are breaking changes
* The addition of these danger events informs the model developer to understand the significant customer impact on the auth scheme removals

#### Testing
* Local build passed with new unit test cases

#### Links
* Links to additional context, if necessary: N/A
* Issue #, if applicable: N/A

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
