### PR TITLE
Updating build script to remove some previous workarounds.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,45 +53,43 @@ afterEvaluate {
     }
 }
 
-    apply(plugin = "org.jreleaser")
+configure<JReleaserExtension> {
+    dryrun = false
 
-    configure<JReleaserExtension> {
-        dryrun = false
-
-        release {
-            generic {
-                enabled = false
-            }
+    release {
+        generic {
+            skipTag = true
         }
+    }
 
-        // Used to announce a release to configured announcers.
-        // https://jreleaser.org/guide/latest/reference/announce/index.html
-        announce {
-            active = Active.NEVER
-        }
+    // Used to announce a release to configured announcers.
+    // https://jreleaser.org/guide/latest/reference/announce/index.html
+    announce {
+        active = Active.NEVER
+    }
 
-        // Signing configuration.
-        // https://jreleaser.org/guide/latest/reference/signing.html
-        signing {
-            active = Active.ALWAYS
-            armored = true
-        }
+    // Signing configuration.
+    // https://jreleaser.org/guide/latest/reference/signing.html
+    signing {
+        active = Active.ALWAYS
+        armored = true
+    }
 
-        // Configuration for deploying to Maven Central.
-        // https://jreleaser.org/guide/latest/examples/maven/maven-central.html#_gradle
-        deploy {
-            maven {
-                nexus2 {
-                    create("maven-central") {
-                        active = Active.ALWAYS
-                        url = "https://aws.oss.sonatype.org/service/local"
-                        snapshotUrl = "https://aws.oss.sonatype.org/content/repositories/snapshots"
-                        closeRepository = true
-                        releaseRepository = true
-                        stagingRepository(stagingDir().get().asFile.path)
-                    }
+    // Configuration for deploying to Maven Central.
+    // https://jreleaser.org/guide/latest/examples/maven/maven-central.html#_gradle
+    deploy {
+        maven {
+            nexus2 {
+                create("maven-central") {
+                    active = Active.ALWAYS
+                    url = "https://aws.oss.sonatype.org/service/local"
+                    snapshotUrl = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+                    closeRepository = true
+                    releaseRepository = true
+                    stagingRepository(stagingDir().get().asFile.path)
                 }
             }
         }
     }
+}
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ import org.jreleaser.model.Active
 
 plugins {
     java
-    alias(libs.plugins.jreleaser) apply false
+    alias(libs.plugins.jreleaser)
 }
 
 // Load the Smithy version from VERSION.
@@ -53,23 +53,14 @@ afterEvaluate {
     }
 }
 
-// We're using JReleaser in the smithy-cli subproject, so we want to have a flag to control
-// which JReleaser configuration to use to prevent conflicts
-if (project.hasProperty("release.main")) {
     apply(plugin = "org.jreleaser")
-
-    // Workaround for https://github.com/jreleaser/jreleaser/issues/1492
-    tasks.register("clean")
 
     configure<JReleaserExtension> {
         dryrun = false
 
-        // Used for creating and pushing the version tag, but this configuration ensures that
-        // an actual GitHub release isn't created (since the CLI release does that)
         release {
-            github {
-                skipRelease = true
-                tagName = "{{projectVersion}}"
+            generic {
+                enabled = false
             }
         }
 
@@ -103,4 +94,4 @@ if (project.hasProperty("release.main")) {
             }
         }
     }
-}
+


### PR DESCRIPTION
#### Background
* What do these changes do? 
This pull request updates the build script for Smithy repository to remove a few previous workarounds set in place due to issues in Jreleaser. It also removes redundant tagging of our repository when releasing a new version. These changes were co-ordinated and discussed with @haydenbaker during 1.56.0 release process.

* Why are they important?
To ensure that future releases occur without the issues.

#### Testing
* How did you test these changes?
These changes were pending to be pushed and were required to successfully release version 1.56.0 of Smithy.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
