### PR TITLE
Clarify behavior of structurallyExclusive

### DIFF
--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -81,6 +81,7 @@ structure trait {
     selector: String
 
     /// Whether or not only a single member in a shape can have this trait.
+    /// This only has an effect on members of structure shapes.
     structurallyExclusive: StructurallyExclusive
 
     /// The traits that this trait conflicts with.


### PR DESCRIPTION
#### Background

I noticed this field doesn't have an effect on unions or maps. Should it?

If not, I think it should be clarified (like in this change), and maybe there should be at least a NOTE emitted for non-struct cases where such a conflict is present.

For example:

```smithy
$version: "2"
namespace test

@trait(structurallyExclusive: "member")
structure myTrait {}

map Foo { @myTrait key: String, @myTrait value: String }
```

passes model validation.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
