### PR TITLE
add AWS_RECOMMENDED as partitional endpoint pattern

### DIFF
--- a/docs/source-2.0/aws/aws-endpoints-region.rst
+++ b/docs/source-2.0/aws/aws-endpoints-region.rst
@@ -269,9 +269,7 @@ Trait value
       - Description
     * - endpointPatternType
       - ``string``
-      - **Required** The pattern type to use for the partition endpoint.  This value can be set to ``service_dnsSuffix`` to
-        use the ``https://{service}.{dnsSuffix}`` pattern or ``service_region_dnsSuffix`` to use
-        ``https://{service}.{region}.{dnsSuffix}``.
+      - **Required** The pattern type to use for the partition endpoint.  This value should be set to ``aws_recommended`` in almost all cases.
     * - partitionEndpointSpecialCases
       - ``map`` of partition to `PartitionEndpointSpecialCase object`_
       - A map of partition to partition endpoint special cases - partitions that do not follow the
@@ -282,13 +280,9 @@ Conflicts with
     :ref:`aws.endpoints#standardRegionalEndpoints-trait`
 
 Partitional services (also known as "global" services) resolve a single endpoint per partition.
-That single endpoint is located in the partition's ``defaultGlobalRegion``. Partitional
-services should follow one of two standard patterns:
+That single endpoint is located in the partition's ``defaultGlobalRegion``.
 
-- ``service_dnsSuffix``: ``https://{service}.{dnsSuffix}``
-- ``service_region_dnsSuffix``: ``https://{service}.{region}.{dnsSuffix}``
-
-The following example defines a partitional service that uses ``{service}.{dnsSuffix}``:
+The following example defines a partitional service that uses AWS recommended patterns for each partition:
 
 .. code-block:: smithy
 
@@ -298,19 +292,19 @@ The following example defines a partitional service that uses ``{service}.{dnsSu
 
     use aws.endpoints#standardPartitionalEndpoints
 
-    @standardPartitionalEndpoints(endpointPatternType: "service_dnsSuffix")
+    @standardPartitionalEndpoints(endpointPatternType: "aws_recommended")
     service MyService {
         version: "2020-04-02"
     }
 
-Services should follow the standard patterns; however, occasionally there are special cases.
+Services should follow the standard patterns set by the DNS naming guidelines; however, occasionally there are special cases.
 The following example defines a partitional service that uses a special case pattern in
 the ``aws`` partition and uses a non-standard global region in the ``aws-cn`` partition:
 
 .. code-block:: smithy
 
     @standardPartitionalEndpoints(
-        endpointPatternType: "service_dnsSuffix",
+        endpointPatternType: "aws_recommended",
         partitionEndpointSpecialCases: {
             aws: [{endpoint: "https://myservice.global.amazonaws.com"}],
             aws-cn: [{region: "cn-north-1"}]

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/EndpointPatternType.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/EndpointPatternType.java
@@ -12,10 +12,15 @@ import software.amazon.smithy.model.node.StringNode;
  */
 public enum EndpointPatternType {
     /** An endpoint with pattern `{service}.{dnsSuffix}`.*/
+    @Deprecated
     SERVICE_DNSSUFFIX("service_dnsSuffix"),
 
     /** An endpoint with pattern `{service}.{region}.{dnsSuffix}`. */
-    SERVICE_REGION_DNSSUFFIX("service_region_dnsSuffix");
+    @Deprecated
+    SERVICE_REGION_DNSSUFFIX("service_region_dnsSuffix"),
+
+    /** Uses the up-to-date standards for each AWS partition */
+    AWS_RECOMMENDED("aws_recommended");
 
     private final String name;
 

--- a/smithy-aws-endpoints/src/main/resources/META-INF/smithy/aws.endpoints.smithy
+++ b/smithy-aws-endpoints/src/main/resources/META-INF/smithy/aws.endpoints.smithy
@@ -106,8 +106,11 @@ structure standardPartitionalEndpoints {
 
 @private
 enum PartitionEndpointPattern {
+    @deprecated(since: "2025-04-01", message: "Not recommended to use. Use AWS_RECOMMENDED instead")
     SERVICE_DNSSUFFIX = "service_dnsSuffix"
+    @deprecated(since: "2025-04-01", message: "Not recommended to use. Use AWS_RECOMMENDED instead")
     SERVICE_REGION_DNSSUFFIX = "service_region_dnsSuffix"
+    AWS_RECOMMENDED = "aws_recommended"
 }
 
 @private

--- a/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/traits/StandardPartitionalEndpointsTraitTest.java
+++ b/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/traits/StandardPartitionalEndpointsTraitTest.java
@@ -46,6 +46,19 @@ class StandardPartitionalEndpointsTraitTest {
         assertEquals(case2.getDualStack(), true);
         assertEquals(case2.getRegion(), "us-west-2");
         assertNull(case2.getFips());
+
+        trait = getTraitFromService(model, "ns.foo#Service3");
+
+        assertEquals(trait.getEndpointPatternType(), EndpointPatternType.AWS_RECOMMENDED);
+        assertEquals(trait.getPartitionEndpointSpecialCases().size(), 1);
+
+        cases = trait.getPartitionEndpointSpecialCases().get("aws");
+
+        case1 = cases.get(0);
+        assertEquals(case1.getEndpoint(), "https://myservice.{dnsSuffix}");
+        assertEquals(case1.getRegion(), "us-west-2");
+        assertNull(case1.getDualStack());
+        assertNull(case1.getFips());
     }
 
     private StandardPartitionalEndpointsTrait getTraitFromService(Model model, String service) {

--- a/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/traits/standardPartitionalEndpoints.smithy
+++ b/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/traits/standardPartitionalEndpoints.smithy
@@ -29,3 +29,18 @@ service Service1 {
 service Service2 {
     version: "2021-06-29"
 }
+
+@standardPartitionalEndpoints(
+    endpointPatternType: "aws_recommended",
+    partitionEndpointSpecialCases: {
+        "aws": [
+            {
+                endpoint: "https://myservice.{dnsSuffix}",
+                region: "us-west-2"
+            },
+        ]
+    }
+)
+service Service3 {
+    version: "2025-01-01"
+}


### PR DESCRIPTION
#### Background
* The two existing patterns do not match what the AWS DNS team recommends to be used for partitional service endpoints
* This PR adds a new third type which will the be recommended flag going forward, and will match the prescribed patterns 1:1 for all partitions

#### Testing
* Added a sanity test

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
