### PR TITLE
Use tab sets to avoid synchronization of input/ouput tabs in Sphinx

### DIFF
--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/integrations/SphinxIntegration.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/integrations/SphinxIntegration.java
@@ -98,7 +98,6 @@ public final class SphinxIntegration implements DocIntegration {
     private static final List<String> MARKDOWN_REQUIREMENTS = parseRequirements("requirements-markdown.txt");
 
     private static final List<String> BASE_EXTENSIONS = List.of(
-            "sphinx_inline_tabs",
             "sphinx_copybutton",
             "sphinx_design");
     private static final List<String> MARKDOWN_EXTENSIONS = List.of(

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/writers/SphinxMarkdownWriter.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/writers/SphinxMarkdownWriter.java
@@ -21,8 +21,6 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 @SmithyUnstableApi
 public final class SphinxMarkdownWriter extends MarkdownWriter {
 
-    private boolean isNewTabGroup = true;
-
     /**
      * Constructs a SphinxMarkdownWriter.
      *
@@ -65,27 +63,19 @@ public final class SphinxMarkdownWriter extends MarkdownWriter {
 
     @Override
     public DocWriter openTabGroup() {
-        isNewTabGroup = true;
+        write("::::{tab-set}");
         return this;
     }
 
     @Override
     public DocWriter closeTabGroup() {
-        isNewTabGroup = true;
+        write("::::");
         return this;
     }
 
     @Override
     public DocWriter openTab(String title) {
-        write(":::{tab} $L", title);
-        if (isNewTabGroup) {
-            // The inline tab plugin will automatically gather tabs into groups so long
-            // as no other elements separate them, so to make sure we never accidentally
-            // merge what should be two groups, we add this directive config to opening
-            // tabs to ensure a new group gets created.
-            write(":new-set:\n");
-            isNewTabGroup = false;
-        }
+        write(":::{tab-item} $L", title);
         return this;
     }
 

--- a/smithy-docgen/src/main/resources/software/amazon/smithy/docgen/integrations/sphinx/requirements-base.txt
+++ b/smithy-docgen/src/main/resources/software/amazon/smithy/docgen/integrations/sphinx/requirements-base.txt
@@ -1,6 +1,5 @@
 # These are base requirements needed for any sphinx project output.
 Sphinx==8.1.3
-sphinx_inline_tabs==2023.4.21
 sphinx-copybutton==0.5.2
 Pygments==2.18.0
 sphinx-design==0.6.1


### PR DESCRIPTION
#### Background
The current implementation in Smithy-docgen synchronizes all "Input" and "Output" tabs across operation examples, which creates a poor user experience when dealing with multiple examples in Sphinx.

It is not yet [possible](https://github.com/pradyunsg/sphinx-inline-tabs/issues/18) to avoid tab synchronization without changing the tab labels which in this case are fixed to "Input" and "Output" for all examples.

We can instead use [tab sets](https://sphinx-design.readthedocs.io/en/latest/tabs.html) supported in sphinx-design.

#### Testing
- I did an end-to-end doc generation run for a quick-start example and verified the tabs are no longer synchronized. 
- I also did an end-to-end doc generation run without the inline_tab dependency to verify it is no longer needed.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
