### PR TITLE
Update trait dependencies to api instead of implementation

### DIFF
--- a/smithy-aws-protocol-tests/build.gradle.kts
+++ b/smithy-aws-protocol-tests/build.gradle.kts
@@ -14,9 +14,9 @@ extra["moduleName"] = "software.amazon.smithy.aws.protocoltests"
 
 dependencies {
     implementation(project(path = ":smithy-cli", configuration = "shadow"))
-    implementation(project(":smithy-protocol-test-traits"))
-    implementation(project(":smithy-protocol-traits"))
-    implementation(project(":smithy-aws-traits"))
+    api(project(":smithy-aws-traits"))
+    api(project(":smithy-protocol-test-traits"))
+    api(project(":smithy-protocol-traits"))
     api(project(":smithy-validation-model"))
 }
 

--- a/smithy-protocol-tests/build.gradle.kts
+++ b/smithy-protocol-tests/build.gradle.kts
@@ -14,8 +14,8 @@ extra["moduleName"] = "software.amazon.smithy.protocoltests"
 
 dependencies {
     implementation(project(path = ":smithy-cli", configuration = "shadow"))
-    implementation(project(":smithy-protocol-test-traits"))
-    implementation(project(":smithy-protocol-traits"))
+    api(project(":smithy-protocol-test-traits"))
+    api(project(":smithy-protocol-traits"))
     api(project(":smithy-validation-model"))
 }
 


### PR DESCRIPTION
#### Background
- Changes trait dependencies from implementation to api dependencies
- Today, if you try to build either protocol test suites, you need to add explicit dependencies on these trait packages otherwise you will have unresolved trait errors


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
