### PR TITLE
Fix restJson1 malformed length test

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/validation/malformed-length.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/validation/malformed-length.smithy
@@ -567,9 +567,6 @@ apply MalformedLengthQueryString @httpMalformedRequestTests([
             queryParams: [
                 "string"
             ],
-            headers: {
-                "content-type": "application/json"
-            },
         },
         response: {
             code: 400,


### PR DESCRIPTION
[RestJsonWithoutBodyEmptyInputExpectsEmptyContentType](https://github.com/smithy-lang/smithy/blob/e44fd7f91c916c8adfa55ddbef2a1bfe59573989/smithy-aws-protocol-tests/model/restJson1/malformedRequests/malformed-content-type.smithy#L131) says that when there's no request body input binding, content-type should be omitted. The test this commit fixes,
RestJsonMalformedLengthQueryStringNoValue, is on an operation with no request body input binding, but was specifying content-type, conflicting with the former test.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
