### PR TITLE
Fix FileManifest::writeUsing

### DIFF
--- a/smithy-build/src/main/java/software/amazon/smithy/build/FileManifest.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/FileManifest.java
@@ -215,8 +215,7 @@ public interface FileManifest {
      */
     @SuppressWarnings("unused")
     default Path writeJson(Path path, Node node) {
-        writeUsing(path, (writer) -> Node.prettyPrintJsonToWriter(node, writer));
-        return path;
+        return writeUsing(path, (writer) -> Node.prettyPrintJsonToWriter(node, writer));
     }
 
     /**
@@ -236,16 +235,19 @@ public interface FileManifest {
      *
      * @param path Relative path to write to.
      * @param consumer Node data to write to JSON.
+     * @return Returns the resolved path.
      */
-    default void writeUsing(Path path, Consumer<Writer> consumer) {
-        path = addFile(path);
+    default Path writeUsing(Path path, Consumer<Writer> consumer) {
+        Path resolved = addFile(path);
 
-        try (Writer writer = Files.newBufferedWriter(path)) {
+        try (Writer writer = Files.newBufferedWriter(resolved)) {
             consumer.accept(writer);
             writer.write('\n');
         } catch (IOException e) {
-            throw new SmithyBuildException("Unable to create a write to file `" + path + "`: " + e.getMessage(), e);
+            throw new SmithyBuildException("Unable to create a write to file `" + resolved + "`: " + e.getMessage(), e);
         }
+
+        return resolved;
     }
 
     /**

--- a/smithy-build/src/main/java/software/amazon/smithy/build/MockManifest.java
+++ b/smithy-build/src/main/java/software/amazon/smithy/build/MockManifest.java
@@ -132,10 +132,10 @@ public final class MockManifest implements FileManifest {
     }
 
     @Override
-    public void writeUsing(Path path, Consumer<Writer> consumer) {
+    public Path writeUsing(Path path, Consumer<Writer> consumer) {
         Writer writer = new StringWriter();
         consumer.accept(writer);
-        writeFile(path, writer.toString());
+        return writeFile(path, writer.toString());
     }
 
     /**

--- a/smithy-build/src/test/java/software/amazon/smithy/build/FileManifestTest.java
+++ b/smithy-build/src/test/java/software/amazon/smithy/build/FileManifestTest.java
@@ -73,11 +73,11 @@ public class FileManifestTest {
     @Test
     public void writesJsonFiles() throws IOException {
         FileManifest a = FileManifest.create(outputDirectory);
-        a.writeJson("foo/file.json", Node.objectNode());
+        Path resolved = a.writeJson("foo/file.json", Node.objectNode());
 
-        assertThat(Files.isDirectory(outputDirectory.resolve("foo")), is(true));
-        assertThat(Files.isRegularFile(outputDirectory.resolve("foo/file.json")), is(true));
-        assertThat(new String(Files.readAllBytes(outputDirectory.resolve("foo/file.json"))), equalTo("{}\n"));
+        assertThat(resolved, equalTo(outputDirectory.resolve("foo/file.json")));
+        assertThat(Files.isRegularFile(resolved), is(true));
+        assertThat(new String(Files.readAllBytes(resolved)), equalTo("{}\n"));
     }
 
     @Test
@@ -106,5 +106,21 @@ public class FileManifestTest {
         a.writeFile("test.txt", getClass(), "simple-config.json");
 
         assertThat(Files.isRegularFile(outputDirectory.resolve("test.txt")), is(true));
+    }
+
+    @Test
+    public void writesWithWriter() throws IOException {
+        FileManifest a = FileManifest.create(outputDirectory);
+        Path resolved = a.writeUsing(Paths.get("foo/bar.txt"), (w) -> {
+            try {
+                w.write("foo");
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        assertThat(resolved, equalTo(outputDirectory.resolve("foo/bar.txt")));
+        assertThat(Files.isRegularFile(resolved), is(true));
+        assertThat(new String(Files.readAllBytes(resolved)).trim(), equalTo("foo"));
     }
 }


### PR DESCRIPTION
https://github.com/smithy-lang/smithy/pull/2599 introduced FileManifest::writeUsing, which does not return the resolved Path being written to, so its usage in FileManifest::writeJson resulted in the relative Path being returned from that method, instead of the resolved Path like before.

I updated writeUsing to return the resolved Path, and updated some tests.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
