### PR TITLE
Remove the constraint to reject the smithy package for traits codegen

### DIFF
--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/TraitCodegenSettings.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/TraitCodegenSettings.java
@@ -29,7 +29,6 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  */
 @SmithyUnstableApi
 public final class TraitCodegenSettings {
-    private static final String SMITHY_MODEL_NAMESPACE = "software.amazon.smithy";
     private static final String SMITHY_API_NAMESPACE = "smithy";
 
     private final String packageName;
@@ -55,9 +54,6 @@ public final class TraitCodegenSettings {
             List<String> excludeTags
     ) {
         this.packageName = Objects.requireNonNull(packageName);
-        if (packageName.startsWith(SMITHY_MODEL_NAMESPACE)) {
-            throw new IllegalArgumentException("The `software.amazon.smithy` package namespace is reserved.");
-        }
         this.smithyNamespace = Objects.requireNonNull(smithyNamespace);
         if (smithyNamespace.startsWith(SMITHY_API_NAMESPACE)) {
             throw new IllegalArgumentException("The `smithy` namespace is reserved.");


### PR DESCRIPTION
#### Background

Remove the constraint to reject the smithy package for traits codegen.

#### Testing

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
