### PR TITLE
Remove @unstable from endpoint modifier (declarative endpoints) traits 

### DIFF
--- a/smithy-aws-endpoints/src/main/resources/META-INF/smithy/aws.endpoints.smithy
+++ b/smithy-aws-endpoints/src/main/resources/META-INF/smithy/aws.endpoints.smithy
@@ -20,7 +20,6 @@ structure endpointsModifier { }
     breakingChanges: [{change: "remove"}]
 )
 @endpointsModifier
-@unstable
 structure standardRegionalEndpoints {
     /// A map of partition to partition special cases -
     /// endpoints for a partition that do not follow the standard patterns.
@@ -92,7 +91,6 @@ structure RegionSpecialCase {
     breakingChanges: [{change: "any"}]
 )
 @endpointsModifier
-@unstable
 structure standardPartitionalEndpoints {
     /// The pattern type to use for the partition endpoint.
     @required
@@ -146,7 +144,6 @@ structure PartitionEndpointSpecialCase {
     breakingChanges: [{change: "any"}]
 )
 @endpointsModifier
-@unstable
 structure dualStackOnlyEndpoints { }
 
 /// Marks that a services has hand written endpoint rules.

--- a/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/language/functions/errorfiles/invalid/invalid-endpoint-patterns.errors
+++ b/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/language/functions/errorfiles/invalid/invalid-endpoint-patterns.errors
@@ -1,10 +1,8 @@
-[WARNING] example#Service1: This shape applies a trait that is unstable: aws.endpoints#standardRegionalEndpoints | UnstableTrait.aws.endpoints#standardRegionalEndpoints
 [DANGER] example#Service1: Endpoint `https://myservice.{invalid}.{dnsSuffix}` contains unsupported patterns: {invalid} | AwsSpecialCaseEndpoint.UnsupportedEndpointPattern
 [DANGER] example#Service1: Endpoint `{invalid}-fips.{region}.{badSuffix}` contains unsupported patterns: {invalid}, {badSuffix} | AwsSpecialCaseEndpoint.UnsupportedEndpointPattern
 [DANGER] example#Service1: Endpoint `{invalid}-fips.{region}.{badSuffix}` should start with scheme `http://` or `https://` | AwsSpecialCaseEndpoint.InvalidEndpointPatternScheme
 [ERROR] example#Service1: Endpoint `{invalid}-fips.{region}.{badSuffix}` should be a valid URL. | AwsSpecialCaseEndpoint.InvalidEndpointPatternUrl
 [ERROR] example#Service1: Endpoint `https://{region}.   invalidurl   {dnsSuffix}` should be a valid URL. | AwsSpecialCaseEndpoint.InvalidEndpointPatternUrl
-[WARNING] example#Service2: This shape applies a trait that is unstable: aws.endpoints#standardPartitionalEndpoints | UnstableTrait.aws.endpoints#standardPartitionalEndpoints
 [DANGER] example#Service2: Endpoint `myservice.{invalid}.{dnsSuffix}` should start with scheme `http://` or `https://` | AwsSpecialCaseEndpoint.InvalidEndpointPatternScheme
 [DANGER] example#Service2: Endpoint `myservice.{invalid}.{dnsSuffix}` contains unsupported patterns: {invalid} | AwsSpecialCaseEndpoint.UnsupportedEndpointPattern
 [ERROR] example#Service2: Endpoint `myservice.{invalid}.{dnsSuffix}` should be a valid URL. | AwsSpecialCaseEndpoint.InvalidEndpointPatternUrl

--- a/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/traits/errorfiles/dualstack-only-endpoints-trait.errors
+++ b/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/traits/errorfiles/dualstack-only-endpoints-trait.errors
@@ -1,1 +1,0 @@
-[WARNING] smithy.example#MyService: This shape applies a trait that is unstable: aws.endpoints#dualStackOnlyEndpoints | UnstableTrait.aws.endpoints#dualStackOnlyEndpoints

--- a/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/traits/errorfiles/standard-partitional-endpoints-trait.errors
+++ b/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/traits/errorfiles/standard-partitional-endpoints-trait.errors
@@ -1,1 +1,1 @@
-[WARNING] smithy.example#MyService: This shape applies a trait that is unstable: aws.endpoints#standardPartitionalEndpoints | UnstableTrait.aws.endpoints#standardPartitionalEndpoints
+

--- a/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/traits/errorfiles/standard-regional-endpoints-trait.errors
+++ b/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/traits/errorfiles/standard-regional-endpoints-trait.errors
@@ -1,1 +1,0 @@
-[WARNING] smithy.example#MyService: This shape applies a trait that is unstable: aws.endpoints#standardRegionalEndpoints | UnstableTrait.aws.endpoints#standardRegionalEndpoints


### PR DESCRIPTION
#### Background
Remove the @unstable trait from the endpoint modifier (declarative endpoints) traits for: @standardRegionalEndpoints, @standardPartitonalEndpoints and @dualStackOnlyEndpoints.

These traits are in use and can now be considered stable.

Note: I did not remove the @unstable trait from the @rulesBasedEndpoints trait as this trait may still change.

#### Testing
Existing unit tests.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
