### PR TITLE
Expose Dynamic Part, just like Literal Part

### DIFF
--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/expressions/Template.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/expressions/Template.java
@@ -21,6 +21,7 @@ import software.amazon.smithy.rulesengine.language.error.InnerParseError;
 import software.amazon.smithy.rulesengine.language.evaluation.Scope;
 import software.amazon.smithy.rulesengine.language.evaluation.TypeCheck;
 import software.amazon.smithy.rulesengine.language.evaluation.type.Type;
+import software.amazon.smithy.rulesengine.language.syntax.ToExpression;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
@@ -261,7 +262,10 @@ public final class Template implements FromSourceLocation, ToNode {
         }
     }
 
-    private static final class Dynamic implements Part {
+    /**
+     * A dynamic template part.
+     */
+    public static final class Dynamic implements Part, ToExpression {
         private final String raw;
         private final Expression expression;
 
@@ -274,7 +278,8 @@ public final class Template implements FromSourceLocation, ToNode {
             return new Dynamic(value, parseShortform(value, context));
         }
 
-        private Expression getExpression() {
+        @Override
+        public Expression toExpression() {
             return expression;
         }
 


### PR DESCRIPTION
Currently only Literal Parts of Template are exposed. Exposing Dynamic Parts allows for inspecting the parts of a template for more flexibility when processing (allows for not using the streaming based visitor API that doesn't work for my usecase).


#### Background
* What do these changes do? 
* Why are they important?

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
