### PR TITLE
Optional arnNamespace for condition key traits

### DIFF
--- a/docs/source-2.0/aws/aws-iam.rst
+++ b/docs/source-2.0/aws/aws-iam.rst
@@ -491,9 +491,14 @@ Condition keys derived automatically can be applied to a resource or operation
 explicitly. Condition keys applied this way MUST be either :ref:`inferred <deriving-condition-keys>`
 or explicitly defined via the :ref:`aws.iam#defineConditionKeys-trait` trait.
 
+Values in the list MUST be valid IAM identifiers or names of condition keys,
+meaning they must adhere to the following regular expression:
+``"^(([A-Za-z0-9][A-Za-z0-9-\\.]{0,62}:)?[^:\\s]+)$"``. If only a condition key
+name is specified, the service is inferred to be the ``arnNamespace``.
+
 The following example's ``MyResource`` resource has the
-``myservice:MyResourceFoo`` and  ``myservice:Bar`` condition keys. The
-``MyOperation`` operation has the ``aws:region`` condition key.
+``myservice:MyResourceFoo``, ``myservice:Bar``, and ``myservice:Baz`` condition
+keys. The ``MyOperation`` operation has the ``aws:region`` condition key.
 
 .. code-block:: smithy
 
@@ -506,13 +511,16 @@ The following example's ``MyResource`` resource has the
     use aws.iam#conditionKeys
 
     @service(sdkId: "My Value", arnNamespace: "myservice")
-    @defineConditionKeys("myservice:Bar": { type: "String" })
+    @defineConditionKeys(
+        "myservice:Bar": { type: "String" }
+        "myservice:Baz": { type: "String" }
+    )
     service MyService {
         version: "2017-02-11"
         resources: [MyResource]
     }
 
-    @conditionKeys(["myservice:Bar"])
+    @conditionKeys(["myservice:Bar", "Baz"])
     resource MyResource {
         identifiers: {foo: String}
         operations: [MyOperation]
@@ -547,6 +555,11 @@ MUST also be defined via the :ref:`aws.iam#defineConditionKeys-trait` trait.
 :ref:`Inferred resource condition keys <deriving-condition-keys>` MUST NOT be
 included with the ``serviceResolvedConditionKeys`` trait.
 
+Values in the list MUST be valid IAM identifiers or names of condition keys,
+meaning they must adhere to the following regular expression:
+``"^(([A-Za-z0-9][A-Za-z0-9-\\.]{0,62}:)?[^:\\s]+)$"``. If only a condition key
+name is specified, the service is inferred to be the ``arnNamespace``.
+
 The following example defines two service-specific condition keys:
 
 * ``myservice:ActionContextKey1`` is expected to be resolved by the service.
@@ -565,8 +578,9 @@ The following example defines two service-specific condition keys:
     @defineConditionKeys(
         "myservice:ActionContextKey1": { type: "String" },
         "myservice:ActionContextKey2": { type: "String" }
+        "myservice:AnotherContextKey": { type: "String" }
     )
-    @serviceResolvedConditionKeys(["myservice:ActionContextKey1"])
+    @serviceResolvedConditionKeys(["myservice:ActionContextKey1", "AnotherContextKey"])
     @service(sdkId: "My Value", arnNamespace: "myservice")
     service MyService {
         version: "2018-05-10"
@@ -591,6 +605,11 @@ Members not annotated with the ``conditionKeyValue`` trait, default to the
 condition keys defined with the ``conditionKeyValue`` trait MUST also be
 defined via the :ref:`aws.iam#defineConditionKeys-trait` trait.
 
+The value MUST be a valid IAM identifier or name of a condition key,
+meaning it must adhere to the following regular expression:
+``"^(([A-Za-z0-9][A-Za-z0-9-\\.]{0,62}:)?[^:\\s]+)$"``. If only a condition key
+name is specified, the service is inferred to be the ``arnNamespace``.
+
 In the input shape for ``OperationA``, the trait ``conditionKeyValue``
 explicitly binds ``ActionContextKey1`` to the field ``key``.
 
@@ -607,6 +626,7 @@ explicitly binds ``ActionContextKey1`` to the field ``key``.
 
     @defineConditionKeys(
         "myservice:ActionContextKey1": { type: "String" }
+        "myservice:AnotherContextKey": { type: "String" }
     )
     @service(sdkId: "My Value", arnNamespace: "myservice")
     service MyService {
@@ -618,6 +638,9 @@ explicitly binds ``ActionContextKey1`` to the field ``key``.
     operation OperationA {
         input := {
             @conditionKeyValue("myservice:ActionContextKey1")
+            key: String
+
+            @conditionKeyValue("AnotherContextKey")
             key: String
         }
         output := {

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeyValueTrait.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeyValueTrait.java
@@ -6,6 +6,7 @@ package software.amazon.smithy.aws.iam.traits;
 
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.StringTrait;
 
@@ -18,6 +19,16 @@ public final class ConditionKeyValueTrait extends StringTrait {
 
     public ConditionKeyValueTrait(String conditionKey, FromSourceLocation sourceLocation) {
         super(ID, conditionKey, sourceLocation);
+    }
+
+    /**
+     * Gets the fully resolved condition key based on the service's ARN namespace.
+     *
+     * @param service The service to resolve no-prefix condition key name to.
+     * @return the resolved condition key.
+     */
+    public String resolveConditionKey(ServiceShape service) {
+        return ConditionKeysIndex.resolveFullConditionKey(service, getValue());
     }
 
     public static final class Provider extends StringTrait.Provider<ConditionKeyValueTrait> {

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeysTrait.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeysTrait.java
@@ -4,11 +4,14 @@
  */
 package software.amazon.smithy.aws.iam.traits;
 
+import java.util.ArrayList;
 import java.util.List;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.StringListTrait;
+import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -16,6 +19,7 @@ import software.amazon.smithy.utils.ToSmithyBuilder;
  */
 public final class ConditionKeysTrait extends StringListTrait implements ToSmithyBuilder<ConditionKeysTrait> {
     public static final ShapeId ID = ShapeId.from("aws.iam#conditionKeys");
+    private List<String> resolvedConditionKeys;
 
     public ConditionKeysTrait(List<String> keys, FromSourceLocation sourceLocation) {
         super(ID, keys, sourceLocation);
@@ -27,6 +31,23 @@ public final class ConditionKeysTrait extends StringListTrait implements ToSmith
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    /**
+     * Gets the fully resolved condition key names based on the service's ARN namespace.
+     *
+     * @param service The service to resolve no-prefix condition key names to.
+     * @return the resolved condition key names.
+     */
+    public List<String> resolveConditionKeys(ServiceShape service) {
+        if (resolvedConditionKeys == null) {
+            List<String> keys = new ArrayList<>();
+            for (String value : getValues()) {
+                keys.add(ConditionKeysIndex.resolveFullConditionKey(service, value));
+            }
+            resolvedConditionKeys = ListUtils.copyOf(keys);
+        }
+        return resolvedConditionKeys;
     }
 
     public static final class Provider extends StringListTrait.Provider<ConditionKeysTrait> {

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeysValidator.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ConditionKeysValidator.java
@@ -6,10 +6,8 @@ package software.amazon.smithy.aws.iam.traits;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import software.amazon.smithy.aws.traits.ServiceTrait;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.OperationIndex;
@@ -20,6 +18,7 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.model.validation.ValidationUtils;
+import software.amazon.smithy.utils.SetUtils;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -39,85 +38,81 @@ public final class ConditionKeysValidator extends AbstractValidator {
         TopDownIndex topDownIndex = TopDownIndex.of(model);
         OperationIndex operationIndex = OperationIndex.of(model);
 
-        return model.shapes(ServiceShape.class)
-                .filter(service -> service.hasTrait(ServiceTrait.ID))
-                .flatMap(service -> {
-                    List<ValidationEvent> results = new ArrayList<>();
-                    Set<String> knownKeys = conditionIndex.getDefinedConditionKeys(service).keySet();
-                    Set<String> serviceResolvedKeys = Collections.emptySet();
+        List<ValidationEvent> events = new ArrayList<>();
+        for (ServiceShape service : model.getServiceShapesWithTrait(ServiceTrait.class)) {
+            Set<String> knownKeys = conditionIndex.getDefinedConditionKeys(service).keySet();
+            Set<String> serviceResolvedKeys = Collections.emptySet();
 
-                    if (service.hasTrait(ServiceResolvedConditionKeysTrait.ID)) {
-                        ServiceResolvedConditionKeysTrait trait =
-                                service.expectTrait(ServiceResolvedConditionKeysTrait.class);
-                        //assign so we can compare against condition key values for any intersection
-                        serviceResolvedKeys = new HashSet<>(trait.getValues());
-                        //copy as this is a destructive action and will affect all future access
-                        List<String> invalidNames = new ArrayList<>(trait.getValues());
-                        invalidNames.removeAll(knownKeys);
-                        if (!invalidNames.isEmpty()) {
-                            results.add(error(service,
+            if (service.hasTrait(ServiceResolvedConditionKeysTrait.ID)) {
+                ServiceResolvedConditionKeysTrait trait =
+                        service.expectTrait(ServiceResolvedConditionKeysTrait.class);
+                // Assign so we can compare against condition key values for any intersection.
+                serviceResolvedKeys = SetUtils.copyOf(trait.resolveConditionKeys(service));
+                // Create a mutable copy as this is a destructive action and will affect all future access.
+                List<String> invalidNames = new ArrayList<>(serviceResolvedKeys);
+                invalidNames.removeAll(knownKeys);
+                if (!invalidNames.isEmpty()) {
+                    events.add(error(service,
+                            trait,
+                            String.format(
+                                    "The condition keys resolved by the `%s` service refer to undefined condition "
+                                            + "key(s) [%s]. Expected one of the following defined condition keys: [%s]",
+                                    service.getId(),
+                                    ValidationUtils.tickedList(invalidNames),
+                                    ValidationUtils.tickedList(knownKeys))));
+                }
+            }
+
+            for (OperationShape operation : topDownIndex.getContainedOperations(service)) {
+                for (String name : conditionIndex.getConditionKeyNames(service, operation)) {
+                    if (!knownKeys.contains(name) && !name.startsWith("aws:")) {
+                        events.add(error(operation,
+                                String.format(
+                                        "This operation scoped within the `%s` service refers to an undefined "
+                                                + "condition key `%s`. Expected one of the following defined condition "
+                                                + "keys: [%s]",
+                                        service.getId(),
+                                        name,
+                                        ValidationUtils.tickedList(knownKeys))));
+                    }
+                }
+
+                for (MemberShape memberShape : operationIndex.getInputMembers(operation)
+                        .values()) {
+                    if (memberShape.hasTrait(ConditionKeyValueTrait.ID)) {
+                        ConditionKeyValueTrait trait = memberShape.expectTrait(ConditionKeyValueTrait.class);
+                        String conditionKey =
+                                ConditionKeysIndex.resolveFullConditionKey(service, trait.getValue());
+                        if (!knownKeys.contains(conditionKey)) {
+                            events.add(error(memberShape,
                                     trait,
                                     String.format(
-                                            "This condition keys resolved by the `%s` service "
-                                                    + "refer to undefined "
-                                                    + "condition key(s) [%s]. Expected one of the following "
-                                                    + "defined condition keys: [%s]",
+                                            "This operation `%s` scoped within the `%s` service with member `%s` "
+                                                    + "refers to an undefined condition key `%s`. Expected one of the "
+                                                    + "following defined condition keys: [%s]",
+                                            operation.getId(),
                                             service.getId(),
-                                            ValidationUtils.tickedList(invalidNames),
+                                            memberShape.getId(),
+                                            conditionKey,
+                                            ValidationUtils.tickedList(knownKeys))));
+                        }
+
+                        if (serviceResolvedKeys.contains(conditionKey)) {
+                            events.add(error(memberShape,
+                                    trait,
+                                    String.format(
+                                            "This operation `%s` scoped within the `%s` service with member `%s` refers"
+                                                    + " to a condition key `%s` that is also resolved by service.",
+                                            operation.getId(),
+                                            service.getId(),
+                                            memberShape.getId(),
+                                            conditionKey,
                                             ValidationUtils.tickedList(knownKeys))));
                         }
                     }
-
-                    for (OperationShape operation : topDownIndex.getContainedOperations(service)) {
-                        for (String name : conditionIndex.getConditionKeyNames(service, operation)) {
-                            if (!knownKeys.contains(name) && !name.startsWith("aws:")) {
-                                results.add(error(operation,
-                                        String.format(
-                                                "This operation scoped within the `%s` service refers to an undefined "
-                                                        + "condition key `%s`. Expected one of the following defined condition "
-                                                        + "keys: [%s]",
-                                                service.getId(),
-                                                name,
-                                                ValidationUtils.tickedList(knownKeys))));
-                            }
-                        }
-
-                        for (MemberShape memberShape : operationIndex.getInputMembers(operation).values()) {
-                            if (memberShape.hasTrait(ConditionKeyValueTrait.ID)) {
-                                ConditionKeyValueTrait trait = memberShape.expectTrait(ConditionKeyValueTrait.class);
-                                String conditionKey = trait.getValue();
-                                if (!knownKeys.contains(conditionKey)) {
-                                    results.add(error(memberShape,
-                                            trait,
-                                            String.format(
-                                                    "This operation `%s` scoped within the `%s` service with member `%s` "
-                                                            + "refers to an undefined "
-                                                            + "condition key `%s`. Expected one of the following defined "
-                                                            + "condition keys: [%s]",
-                                                    operation.getId(),
-                                                    service.getId(),
-                                                    memberShape.getId(),
-                                                    conditionKey,
-                                                    ValidationUtils.tickedList(knownKeys))));
-                                }
-                                if (serviceResolvedKeys.contains(conditionKey)) {
-                                    results.add(error(memberShape,
-                                            trait,
-                                            String.format(
-                                                    "This operation `%s` scoped within the `%s` service with member `%s` refers"
-                                                            + " to a condition key `%s` that is also resolved by service.",
-                                                    operation.getId(),
-                                                    service.getId(),
-                                                    memberShape.getId(),
-                                                    conditionKey,
-                                                    ValidationUtils.tickedList(knownKeys))));
-                                }
-                            }
-                        }
-                    }
-
-                    return results.stream();
-                })
-                .collect(Collectors.toList());
+                }
+            }
+        }
+        return events;
     }
 }

--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ServiceResolvedConditionKeysTrait.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ServiceResolvedConditionKeysTrait.java
@@ -4,14 +4,18 @@
  */
 package software.amazon.smithy.aws.iam.traits;
 
+import java.util.ArrayList;
 import java.util.List;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.StringListTrait;
+import software.amazon.smithy.utils.ListUtils;
 
 public final class ServiceResolvedConditionKeysTrait extends StringListTrait {
     public static final ShapeId ID = ShapeId.from("aws.iam#serviceResolvedConditionKeys");
+    private List<String> resolvedConditionKeys;
 
     public ServiceResolvedConditionKeysTrait(List<String> conditionKeys) {
         super(ID, conditionKeys, SourceLocation.NONE);
@@ -19,6 +23,23 @@ public final class ServiceResolvedConditionKeysTrait extends StringListTrait {
 
     public ServiceResolvedConditionKeysTrait(List<String> conditionKeys, FromSourceLocation sourceLocation) {
         super(ID, conditionKeys, sourceLocation);
+    }
+
+    /**
+     * Gets the fully resolved condition key names based on the service's ARN namespace.
+     *
+     * @param service The service to resolve no-prefix condition key names to.
+     * @return the resolved condition key names.
+     */
+    public List<String> resolveConditionKeys(ServiceShape service) {
+        if (resolvedConditionKeys == null) {
+            List<String> keys = new ArrayList<>();
+            for (String value : getValues()) {
+                keys.add(ConditionKeysIndex.resolveFullConditionKey(service, value));
+            }
+            resolvedConditionKeys = ListUtils.copyOf(keys);
+        }
+        return resolvedConditionKeys;
     }
 
     public static final class Provider extends StringListTrait.Provider<ServiceResolvedConditionKeysTrait> {

--- a/smithy-aws-iam-traits/src/main/resources/META-INF/smithy/aws.iam.smithy
+++ b/smithy-aws-iam-traits/src/main/resources/META-INF/smithy/aws.iam.smithy
@@ -16,12 +16,13 @@ string actionPermissionDescription
 /// Applies condition keys by name to a resource or operation.
 @trait(selector: ":test(resource, operation)")
 list conditionKeys {
-    member: IamIdentifier
+    member: ConditionKeyName
 }
 
 /// Uses the associated member’s value as this condition key’s value.
 /// Needed when the member name doesn't match the condition key name.
 @trait(selector: "member")
+@pattern("^(([A-Za-z0-9][A-Za-z0-9-\\.]{0,62}:)?[^:\\s]+)$")
 string conditionKeyValue
 
 /// Defines the set of condition keys that appear within a service in addition to
@@ -85,7 +86,7 @@ list requiredActions {
 /// as opposed to being pulled from the request.
 @trait(selector: "service")
 list serviceResolvedConditionKeys {
-    member: IamIdentifier
+    member: ConditionKeyName
 }
 
 /// The principal types that can use the service or operation.

--- a/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/ConditionKeyValueTraitTest.java
+++ b/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/ConditionKeyValueTraitTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 
@@ -21,8 +22,15 @@ public class ConditionKeyValueTraitTest {
                 .assemble()
                 .unwrap();
 
+        ServiceShape service = result.expectShape(ShapeId.from("smithy.example#MyService"), ServiceShape.class);
         Shape shape = result.expectShape(ShapeId.from("smithy.example#EchoInput$id1"));
         ConditionKeyValueTrait trait = shape.expectTrait(ConditionKeyValueTrait.class);
         assertThat(trait.getValue(), equalTo("smithy:ActionContextKey1"));
+        assertThat(trait.resolveConditionKey(service), equalTo("smithy:ActionContextKey1"));
+
+        Shape shape2 = result.expectShape(ShapeId.from("smithy.example#EchoInput$id2"));
+        ConditionKeyValueTrait trait2 = shape2.expectTrait(ConditionKeyValueTrait.class);
+        assertThat(trait2.getValue(), equalTo("AnotherContextKey"));
+        assertThat(trait2.resolveConditionKey(service), equalTo("myservice:AnotherContextKey"));
     }
 }

--- a/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/ServiceResolvedConditionKeysTraitTest.java
+++ b/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/ServiceResolvedConditionKeysTraitTest.java
@@ -7,11 +7,11 @@ package software.amazon.smithy.aws.iam.traits;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
-import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.utils.ListUtils;
 
 public class ServiceResolvedConditionKeysTraitTest {
     @Test
@@ -22,8 +22,11 @@ public class ServiceResolvedConditionKeysTraitTest {
                 .assemble()
                 .unwrap();
 
-        Shape shape = result.expectShape(ShapeId.from("smithy.example#MyService"));
+        ServiceShape shape = result.expectShape(ShapeId.from("smithy.example#MyService"), ServiceShape.class);
         ServiceResolvedConditionKeysTrait trait = shape.expectTrait(ServiceResolvedConditionKeysTrait.class);
-        assertThat(trait.getValues(), equalTo(Collections.singletonList("smithy:ServiceResolveContextKey")));
+        assertThat(trait.getValues(),
+                equalTo(ListUtils.of("myservice:ServiceResolvedContextKey", "AnotherResolvedContextKey")));
+        assertThat(trait.resolveConditionKeys(shape),
+                equalTo(ListUtils.of("myservice:ServiceResolvedContextKey", "myservice:AnotherResolvedContextKey")));
     }
 }

--- a/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/condition-key-value.smithy
+++ b/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/condition-key-value.smithy
@@ -2,9 +2,15 @@ $version: "2.0"
 
 namespace smithy.example
 
-@aws.iam#defineConditionKeys(
+use aws.api#service
+use aws.iam#conditionKeyValue
+use aws.iam#defineConditionKeys
+
+@defineConditionKeys(
     "smithy:ActionContextKey1": { type: "String" }
+    "AnotherContextKey": { type: "String" }
 )
+@service(sdkId: "My", arnNamespace: "myservice")
 service MyService {
     version: "2019-02-20",
     operations: [Echo]
@@ -15,6 +21,9 @@ operation Echo {
 }
 
 structure EchoInput {
-    @aws.iam#conditionKeyValue("smithy:ActionContextKey1")
+    @conditionKeyValue("smithy:ActionContextKey1")
     id1: String
+
+    @conditionKeyValue("AnotherContextKey")
+    id2: String
 }

--- a/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/errorfiles/invalid-condition-keys-service-resolved.errors
+++ b/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/errorfiles/invalid-condition-keys-service-resolved.errors
@@ -1,1 +1,1 @@
-[ERROR] smithy.example#MyService: This condition keys resolved by the `smithy.example#MyService` service refer to undefined condition key(s) [`smithy:invalidkey`]. Expected one of the following defined condition keys: [`smithy:ActionContextKey1`] | ConditionKeys
+[ERROR] smithy.example#MyService: The condition keys resolved by the `smithy.example#MyService` service refer to undefined condition key(s) [`smithy:invalidkey`]. Expected one of the following defined condition keys: [`smithy:ActionContextKey1`] | ConditionKeys

--- a/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/errorfiles/valid-condition-key-value.smithy
+++ b/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/errorfiles/valid-condition-key-value.smithy
@@ -2,12 +2,15 @@ $version: "2.0"
 
 namespace smithy.example
 
+use aws.api#service
 use aws.iam#conditionKeyValue
+use aws.iam#defineConditionKeys
 
-@aws.iam#defineConditionKeys(
+@defineConditionKeys(
     "smithy:ActionContextKey1": { type: "String" }
+    "myservice:ActionContextKey2": { type: "String" }
 )
-@aws.api#service(sdkId: "My")
+@service(sdkId: "My", arnNamespace: "myservice")
 service MyService {
     version: "2019-02-20",
     operations: [Echo]
@@ -18,6 +21,9 @@ operation Echo {
 }
 
 structure EchoInput {
-    @aws.iam#conditionKeyValue("smithy:ActionContextKey1")
+    @conditionKeyValue("smithy:ActionContextKey1")
     id1: String
+
+    @conditionKeyValue("ActionContextKey2")
+    id2: String
 }

--- a/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/errorfiles/valid-condition-keys-service-resolved.smithy
+++ b/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/errorfiles/valid-condition-keys-service-resolved.smithy
@@ -1,16 +1,15 @@
 $version: "2.0"
-
 namespace smithy.example
 
-@aws.api#service(sdkId: "My")
-@aws.iam#defineConditionKeys(
-    "smithy:ServiceResolveContextKey": { type: "String" }
+use aws.api#service
+use aws.iam#defineConditionKeys
+use aws.iam#serviceResolvedConditionKeys
+
+@service(sdkId: "My", arnNamespace: "myservice")
+@defineConditionKeys(
+    "myservice:ServiceResolveContextKey": { type: "String" }
 )
-@aws.iam#serviceResolvedConditionKeys(["smithy:ServiceResolveContextKey"])
+@serviceResolvedConditionKeys(["ServiceResolveContextKey"])
 service MyService {
     version: "2019-02-20",
-    operations: [Echo]
 }
-
-
-operation Echo {}

--- a/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/service-resolved-condition-keys.smithy
+++ b/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/service-resolved-condition-keys.smithy
@@ -1,11 +1,16 @@
 $version: "2.0"
 namespace smithy.example
 
-@aws.api#service(sdkId: "My")
-@aws.iam#defineConditionKeys(
-    "smithy:ServiceResolveContextKey": { type: "String" }
+use aws.api#service
+use aws.iam#defineConditionKeys
+use aws.iam#serviceResolvedConditionKeys
+
+@service(sdkId: "My", arnNamespace: "myservice")
+@defineConditionKeys(
+    "myservice:ServiceResolvedContextKey": { type: "String" }
+    "myservice:AnotherResolvedContextKey": { type: "String" }
 )
-@aws.iam#serviceResolvedConditionKeys(["smithy:ServiceResolveContextKey"])
+@serviceResolvedConditionKeys(["myservice:ServiceResolvedContextKey", "AnotherResolvedContextKey"])
 service MyService {
     version: "2019-02-20",
 }

--- a/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/successful-condition-keys.smithy
+++ b/smithy-aws-iam-traits/src/test/resources/software/amazon/smithy/aws/iam/traits/successful-condition-keys.smithy
@@ -27,7 +27,7 @@ service MyService {
   resources: [Resource1]
 }
 
-@conditionKeys(["aws:accountId", "myservice:bar"])
+@conditionKeys(["aws:accountId", "bar"])
 operation Operation1 {}
 
 @conditionKeys(["aws:accountId", "foo:baz"])


### PR DESCRIPTION
This commit makes an arnNamespace prefix in a full condition key (`arnNamespace:name`) optional in all IAM traits that support specifying the condition keys. Trait definitions are relaxed, utility methods are provided, and validators and the ConditionKeysIndex are updated to use resolve the full names based on the service in context.

Minor optimization of validation and index computation is also done.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
