### PR TITLE
Improve EndpointTests built-in validation

### DIFF
--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/parameters/Parameter.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/parameters/Parameter.java
@@ -119,6 +119,15 @@ public final class Parameter extends SyntaxElement implements ToSmithyBuilder<Pa
     }
 
     /**
+     * Gets the parameter name.
+     *
+     * @return returns the parameter name as a {@link String}.
+     */
+    public String getNameString() {
+        return name.toString();
+    }
+
+    /**
      * Gets the parameter in template form.
      *
      * @return returns the template form of the parameter.

--- a/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/traits/EndpointTestsTest.java
+++ b/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/traits/EndpointTestsTest.java
@@ -31,7 +31,7 @@ public final class EndpointTestsTest {
         EndpointTestsTrait ruleSetTrait = serviceShape.getTrait(EndpointTestsTrait.class).get();
         List<EndpointTestCase> testCases = ruleSetTrait.getTestCases();
 
-        assertThat(2, equalTo(testCases.size()));
+        assertThat(3, equalTo(testCases.size()));
         assertThat(EndpointTestCase.builder()
                 .documentation("a documentation string")
                 .params(ObjectNode.builder()

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/invalid-test-missing-built-in-value.errors
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/invalid-test-missing-built-in-value.errors
@@ -1,0 +1,3 @@
+[WARNING] smithy.example#ExampleService: This shape applies a trait that is unstable: smithy.rules#endpointRuleSet | UnstableTrait
+[WARNING] smithy.example#ExampleService: This shape applies a trait that is unstable: smithy.rules#endpointTests | UnstableTrait
+[ERROR] smithy.example#ExampleService: Operation input does not supply a value for the `SDK::Endpoint` built-in parameter and the `endpoint` parameter does not set a default. | EndpointTestsTrait

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/invalid-test-missing-built-in-value.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/invalid-test-missing-built-in-value.smithy
@@ -12,16 +12,16 @@ use smithy.rules#endpointTests
             type: "string"
             builtIn: "SDK::Endpoint"
             documentation: "docs"
-            default: "https://example.com"
-            required: true
         }
     }
     rules: [
         {
-            conditions: []
             documentation: "Passthrough"
-            error: "Failed to resolve."
-            type: "error"
+            conditions: []
+            endpoint: {
+                url: "https://example.com"
+            }
+            type: "endpoint"
         }
     ]
 })
@@ -29,30 +29,29 @@ use smithy.rules#endpointTests
     version: "1.0"
     testCases: [
         {
+            params: {
+                endpoint: "https://example.com"
+            }
             operationInputs: [{
                 operationName: "GetThing"
-                operationParams: {
-                    "buzz": "a buzz value"
-                }
             }]
             expect: {
-                error: "Failed to resolve."
+                endpoint: {
+                    url: "https://example.com"
+                }
             }
         }
     ]
 })
 @suppress(["RuleSetParameter.TestCase.Unused"])
-service InvalidService {
-    version: "2022-01-01"
+service ExampleService {
+    version: "2020-07-02"
     operations: [GetThing]
 }
 
-@readonly
 operation GetThing {
     input := {
-        @required
         fizz: String
-        buzz: String
-        fuzz: String
     }
 }
+

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/missing-input-target.errors
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/missing-input-target.errors
@@ -1,2 +1,3 @@
+[WARNING] smithy.example#InvalidService: This shape applies a trait that is unstable: smithy.rules#endpointRuleSet | UnstableTrait
 [WARNING] smithy.example#InvalidService: This shape applies a trait that is unstable: smithy.rules#endpointTests | UnstableTrait
 [DANGER] smithy.example#InvalidService: The operationInput value for an endpoint test does not match the operation's input shape: Invalid structure member `fizz` found for `smithy.example#GetThingInput` | EndpointTestsTrait.smithy.example#GetThingInput.fizz

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/missing-input-target.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/missing-input-target.smithy
@@ -2,39 +2,60 @@ $version: "2.0"
 
 namespace smithy.example
 
+use smithy.rules#endpointRuleSet
 use smithy.rules#endpointTests
 
+@endpointRuleSet({
+    version: "1.0"
+    parameters: {
+        endpoint: {
+            type: "string"
+            builtIn: "SDK::Endpoint"
+            documentation: "docs"
+            default: "https://example.com"
+            required: true
+        }
+    }
+    rules: [
+        {
+            conditions: []
+            documentation: "Passthrough"
+            endpoint: {
+                url: "{endpoint}"
+            }
+            type: "endpoint"
+        }
+    ]
+})
+@endpointTests({
+    version: "1.0"
+    testCases: [
+        {
+            params: {}
+            operationInputs: [
+                {
+                    operationName: "GetThing"
+                    operationParams: {
+                        fizz: "something"
+                        buzz: "a buzz value"
+                    }
+                }
+            ]
+            expect: {
+                endpoint: {
+                    url: "https://example.com"
+                }
+            }
+        }
+    ]
+})
+@suppress(["RuleSetParameter.TestCase.Unused"])
 service InvalidService {
     version: "2022-01-01"
     operations: [
         GetThing
     ]
 }
-
-apply InvalidService @endpointTests({
-    version: "1.0"
-    testCases: [
-        {
-            params: { stringFoo: "c d", boolFoo: true }
-            operationInputs: [
-                {
-                    operationName: "GetThing"
-                    operationParams: { fizz: "something", buzz: "a buzz value" }
-                }
-            ]
-            expect: {
-                endpoint: {
-                    url: "https://example.com"
-                    properties: {}
-                    headers: {
-                        single: ["foo"]
-                        multi: ["foo", "bar", "baz"]
-                    }
-                }
-            }
-        }
-    ]
-})
 
 @readonly
 operation GetThing {

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/missing-required-values.errors
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/missing-required-values.errors
@@ -1,2 +1,3 @@
+[WARNING] smithy.example#InvalidService: This shape applies a trait that is unstable: smithy.rules#endpointRuleSet | UnstableTrait
 [WARNING] smithy.example#InvalidService: This shape applies a trait that is unstable: smithy.rules#endpointTests | UnstableTrait
 [DANGER] smithy.example#InvalidService: The operationInput value for an endpoint test does not match the operation's input shape: Missing required structure member `fizz` for `smithy.example#GetThingInput` | EndpointTestsTrait

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/non-default-builtin-values.errors
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/non-default-builtin-values.errors
@@ -1,0 +1,4 @@
+[WARNING] smithy.example#ExampleService: This shape applies a trait that is unstable: smithy.rules#endpointRuleSet | UnstableTrait
+[WARNING] smithy.example#ExampleService: This shape applies a trait that is unstable: smithy.rules#endpointTests | UnstableTrait
+[ERROR] smithy.example#ExampleService: Test case does not supply the `"https://another.example.com"` value for the `endpoint` parameter's `SDK::Endpoint` built-in. | EndpointTestsTrait
+[ERROR] smithy.example#ExampleService: Test case does not supply the `"https://some.example.com"` value for the `endpoint` parameter's `SDK::Endpoint` built-in. | EndpointTestsTrait

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/non-default-builtin-values.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/non-default-builtin-values.smithy
@@ -1,0 +1,92 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use smithy.rules#endpointRuleSet
+use smithy.rules#endpointTests
+
+@endpointRuleSet({
+    version: "1.0"
+    parameters: {
+        endpoint: {
+            type: "string"
+            builtIn: "SDK::Endpoint"
+            documentation: "docs"
+            default: "https://example.com"
+            required: true
+        }
+    }
+    rules: [
+        {
+            documentation: "Passthrough"
+            conditions: []
+            endpoint: {
+                url: "https://example.com"
+            }
+            type: "endpoint"
+        }
+    ]
+})
+@endpointTests({
+    version: "1.0"
+    testCases: [
+        {
+            params: {
+                endpoint: "https://another.example.com"
+            }
+            operationInputs: [{
+                operationName: "GetThing"
+                builtInParams: {
+                    "SDK::Endpoint": "https://custom.example.com"
+                }
+            }]
+            expect: {
+                endpoint: {
+                    url: "https://example.com"
+                }
+            }
+        }
+        {
+            params: {
+                endpoint: "https://some.example.com"
+            }
+            operationInputs: [{
+                operationName: "GetThing"
+                builtInParams: {}
+            }]
+            expect: {
+                endpoint: {
+                    url: "https://example.com"
+                }
+            }
+        }
+        {
+            params: {
+                endpoint: "https://valid.example.com"
+            }
+            operationInputs: [{
+                operationName: "GetThing"
+                builtInParams: {
+                    "SDK::Endpoint": "https://valid.example.com"
+                }
+            }]
+            expect: {
+                endpoint: {
+                    url: "https://example.com"
+                }
+            }
+        }
+    ]
+})
+@suppress(["RuleSetParameter.TestCase.Unused"])
+service ExampleService {
+    version: "2020-07-02"
+    operations: [GetThing]
+}
+
+operation GetThing {
+    input := {
+        fizz: String
+    }
+}
+

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/traits-test-model.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/traits-test-model.smithy
@@ -130,6 +130,33 @@ apply ExampleService @endpointTests({
                 }
             }
         }
+        {
+            "params": {
+                "stringFoo": "c d",
+                "boolFoo": true,
+            },
+            "operationInputs": [{
+                "operationName": "GetThing",
+                "clientParams": {
+                    "stringFoo": "client value"
+                },
+                "operationParams": {
+                    "buzz": "a buzz value",
+                    "fizz": "a required value"
+                },
+                "builtInParams": {}
+            }],
+            "expect": {
+                "endpoint": {
+                    "url": "https://example.com",
+                    "properties": {},
+                    "headers": {
+                        "single": ["foo"],
+                        "multi": ["foo", "bar", "baz"]
+                    }
+                }
+            }
+        }
     ]
 })
 


### PR DESCRIPTION
This commit adds new validation for built-in parameters when used with the `endpointTests` trait.

1. Validates that built-in values with defaults are specified to the correct value if they are mismatched in `operationInput` cases.
2. Validates that built-in values without defaults are specified in `operationInput` cases.

Also fixes skipping DANGER/ERROR in endpoint test validation and adds a convenience method to the `Parameter` class.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
