### PR TITLE
Fix declarative endpoint traits toNode

### DIFF
--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/PartitionEndpointSpecialCase.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/PartitionEndpointSpecialCase.java
@@ -5,6 +5,7 @@
 package software.amazon.smithy.rulesengine.aws.traits;
 
 import java.util.Objects;
+import java.util.Optional;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.Node;
@@ -77,11 +78,16 @@ public final class PartitionEndpointSpecialCase
     @Override
     public Node toNode() {
         return Node.objectNodeBuilder()
-                .withMember(ENDPOINT, endpoint)
-                .withMember(REGION, region)
-                .withMember(DUAL_STACK, dualStack.toString())
-                .withMember(FIPS, fips.toString())
+                .withOptionalMember(ENDPOINT, Optional.ofNullable(endpoint).map(Node::from))
+                .withOptionalMember(REGION, Optional.ofNullable(region).map(Node::from))
+                .withOptionalMember(DUAL_STACK, Optional.ofNullable(dualStack).map(Node::from))
+                .withOptionalMember(FIPS, Optional.ofNullable(fips).map(Node::from))
                 .build();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(endpoint, region, dualStack, fips);
     }
 
     @Override
@@ -97,6 +103,21 @@ public final class PartitionEndpointSpecialCase
     @Override
     public SourceLocation getSourceLocation() {
         return FromSourceLocation.super.getSourceLocation();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PartitionEndpointSpecialCase that = (PartitionEndpointSpecialCase) o;
+        return Objects.equals(endpoint, that.endpoint)
+                && Objects.equals(region, that.region)
+                && Objects.equals(dualStack, that.dualStack)
+                && Objects.equals(fips, that.fips);
     }
 
     /**

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/PartitionEndpointSpecialCase.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/PartitionEndpointSpecialCase.java
@@ -86,11 +86,6 @@ public final class PartitionEndpointSpecialCase
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(endpoint, region, dualStack, fips);
-    }
-
-    @Override
     public Builder toBuilder() {
         return new Builder()
                 .endpoint(endpoint)
@@ -118,6 +113,11 @@ public final class PartitionEndpointSpecialCase
                 && Objects.equals(region, that.region)
                 && Objects.equals(dualStack, that.dualStack)
                 && Objects.equals(fips, that.fips);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(endpoint, region, dualStack, fips);
     }
 
     /**

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/PartitionSpecialCase.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/PartitionSpecialCase.java
@@ -84,6 +84,25 @@ public final class PartitionSpecialCase implements FromSourceLocation, ToNode, T
         return FromSourceLocation.super.getSourceLocation();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PartitionSpecialCase that = (PartitionSpecialCase) o;
+        return Objects.equals(endpoint, that.endpoint)
+                && Objects.equals(dualStack, that.dualStack)
+                && Objects.equals(fips, that.fips);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(endpoint, dualStack, fips);
+    }
+
     /**
      * Creates a {@link PartitionSpecialCase} instance from the given Node information.
      *

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/RegionSpecialCase.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/RegionSpecialCase.java
@@ -5,6 +5,7 @@
 package software.amazon.smithy.rulesengine.aws.traits;
 
 import java.util.Objects;
+import java.util.Optional;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.Node;
@@ -75,9 +76,10 @@ public final class RegionSpecialCase implements FromSourceLocation, ToNode, ToSm
     public Node toNode() {
         return Node.objectNodeBuilder()
                 .withMember(ENDPOINT, endpoint)
-                .withMember(DUAL_STACK, dualStack.toString())
-                .withMember(FIPS, fips.toString())
-                .withMember(SIGNING_REGION, signingRegion)
+                .withOptionalMember(DUAL_STACK, Optional.ofNullable(dualStack).map(Node::from))
+                .withOptionalMember(FIPS, Optional.ofNullable(fips).map(Node::from))
+                .withOptionalMember(DUAL_STACK, Optional.ofNullable(dualStack).map(Node::from))
+                .withOptionalMember(SIGNING_REGION, Optional.ofNullable(signingRegion).map(Node::from))
                 .build();
     }
 
@@ -94,6 +96,26 @@ public final class RegionSpecialCase implements FromSourceLocation, ToNode, ToSm
     @Override
     public SourceLocation getSourceLocation() {
         return FromSourceLocation.super.getSourceLocation();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RegionSpecialCase that = (RegionSpecialCase) o;
+        return Objects.equals(endpoint, that.endpoint)
+                && Objects.equals(dualStack, that.dualStack)
+                && Objects.equals(fips, that.fips)
+                && Objects.equals(signingRegion, that.signingRegion);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(endpoint, dualStack, fips, signingRegion);
     }
 
     /**

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/StandardPartitionalEndpointsTrait.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/StandardPartitionalEndpointsTrait.java
@@ -77,6 +77,7 @@ public final class StandardPartitionalEndpointsTrait extends AbstractTrait
     @Override
     public Builder toBuilder() {
         return new Builder()
+                .sourceLocation(getSourceLocation())
                 .partitionEndpointSpecialCases(partitionEndpointSpecialCases)
                 .endpointPatternType(endpointPatternType);
     }

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/StandardPartitionalEndpointsTrait.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/StandardPartitionalEndpointsTrait.java
@@ -81,6 +81,24 @@ public final class StandardPartitionalEndpointsTrait extends AbstractTrait
                 .endpointPatternType(endpointPatternType);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StandardPartitionalEndpointsTrait that = (StandardPartitionalEndpointsTrait) o;
+        return partitionEndpointSpecialCases.equals(that.partitionEndpointSpecialCases)
+                && endpointPatternType.equals(that.endpointPatternType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partitionEndpointSpecialCases, endpointPatternType);
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/StandardRegionalEndpointsTrait.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/StandardRegionalEndpointsTrait.java
@@ -85,6 +85,7 @@ public final class StandardRegionalEndpointsTrait extends AbstractTrait
     @Override
     public Builder toBuilder() {
         return new Builder()
+                .sourceLocation(getSourceLocation())
                 .partitionSpecialCases(partitionSpecialCases)
                 .regionSpecialCases(regionSpecialCases);
     }

--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/StandardRegionalEndpointsTrait.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/traits/StandardRegionalEndpointsTrait.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
@@ -86,6 +87,24 @@ public final class StandardRegionalEndpointsTrait extends AbstractTrait
         return new Builder()
                 .partitionSpecialCases(partitionSpecialCases)
                 .regionSpecialCases(regionSpecialCases);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StandardRegionalEndpointsTrait that = (StandardRegionalEndpointsTrait) o;
+        return partitionSpecialCases.equals(that.partitionSpecialCases)
+                && regionSpecialCases.equals(that.regionSpecialCases);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partitionSpecialCases, regionSpecialCases);
     }
 
     public static Builder builder() {

--- a/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/traits/StandardPartitionalEndpointsTraitTest.java
+++ b/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/traits/StandardPartitionalEndpointsTraitTest.java
@@ -30,7 +30,7 @@ class StandardPartitionalEndpointsTraitTest {
         assertEquals(trait,
                 new StandardPartitionalEndpointsTrait.Provider()
                         .createTrait(StandardPartitionalEndpointsTrait.ID,
-                                trait.toBuilder().sourceLocation(trait.getSourceLocation()).build().toNode()));
+                                trait.toBuilder().build().toNode()));
 
         trait = getTraitFromService(model, "ns.foo#Service2");
 
@@ -54,7 +54,7 @@ class StandardPartitionalEndpointsTraitTest {
         assertEquals(trait,
                 new StandardPartitionalEndpointsTrait.Provider()
                         .createTrait(StandardPartitionalEndpointsTrait.ID,
-                                trait.toBuilder().sourceLocation(trait.getSourceLocation()).build().toNode()));
+                                trait.toBuilder().build().toNode()));
 
         trait = getTraitFromService(model, "ns.foo#Service3");
 
@@ -72,7 +72,7 @@ class StandardPartitionalEndpointsTraitTest {
         assertEquals(trait,
                 new StandardPartitionalEndpointsTrait.Provider()
                         .createTrait(StandardPartitionalEndpointsTrait.ID,
-                                trait.toBuilder().sourceLocation(trait.getSourceLocation()).build().toNode()));
+                                trait.toBuilder().build().toNode()));
     }
 
     private StandardPartitionalEndpointsTrait getTraitFromService(Model model, String service) {

--- a/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/traits/StandardPartitionalEndpointsTraitTest.java
+++ b/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/traits/StandardPartitionalEndpointsTraitTest.java
@@ -27,6 +27,10 @@ class StandardPartitionalEndpointsTraitTest {
 
         assertEquals(trait.getEndpointPatternType(), EndpointPatternType.SERVICE_DNSSUFFIX);
         assertEquals(trait.getPartitionEndpointSpecialCases().size(), 0);
+        assertEquals(trait,
+                new StandardPartitionalEndpointsTrait.Provider()
+                        .createTrait(StandardPartitionalEndpointsTrait.ID,
+                                trait.toBuilder().sourceLocation(trait.getSourceLocation()).build().toNode()));
 
         trait = getTraitFromService(model, "ns.foo#Service2");
 
@@ -47,6 +51,11 @@ class StandardPartitionalEndpointsTraitTest {
         assertEquals(case2.getRegion(), "us-west-2");
         assertNull(case2.getFips());
 
+        assertEquals(trait,
+                new StandardPartitionalEndpointsTrait.Provider()
+                        .createTrait(StandardPartitionalEndpointsTrait.ID,
+                                trait.toBuilder().sourceLocation(trait.getSourceLocation()).build().toNode()));
+
         trait = getTraitFromService(model, "ns.foo#Service3");
 
         assertEquals(trait.getEndpointPatternType(), EndpointPatternType.AWS_RECOMMENDED);
@@ -59,6 +68,11 @@ class StandardPartitionalEndpointsTraitTest {
         assertEquals(case1.getRegion(), "us-west-2");
         assertNull(case1.getDualStack());
         assertNull(case1.getFips());
+
+        assertEquals(trait,
+                new StandardPartitionalEndpointsTrait.Provider()
+                        .createTrait(StandardPartitionalEndpointsTrait.ID,
+                                trait.toBuilder().sourceLocation(trait.getSourceLocation()).build().toNode()));
     }
 
     private StandardPartitionalEndpointsTrait getTraitFromService(Model model, String service) {

--- a/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/traits/StandardRegionalEndpointsTraitTest.java
+++ b/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/traits/StandardRegionalEndpointsTraitTest.java
@@ -29,7 +29,7 @@ class StandardRegionalEndpointsTraitTest {
         assertEquals(trait.getRegionSpecialCases().size(), 0);
         assertEquals(trait,
                 new StandardRegionalEndpointsTrait.Provider().createTrait(StandardRegionalEndpointsTrait.ID,
-                        trait.toBuilder().sourceLocation(trait.getSourceLocation()).build().toNode()));
+                        trait.toBuilder().build().toNode()));
 
         trait = getTraitFromService(model, "ns.foo#Service2");
 
@@ -37,7 +37,7 @@ class StandardRegionalEndpointsTraitTest {
         assertEquals(trait.getRegionSpecialCases().size(), 0);
         assertEquals(trait,
                 new StandardRegionalEndpointsTrait.Provider().createTrait(StandardRegionalEndpointsTrait.ID,
-                        trait.toBuilder().sourceLocation(trait.getSourceLocation()).build().toNode()));
+                        trait.toBuilder().build().toNode()));
 
         trait = getTraitFromService(model, "ns.foo#Service3");
 
@@ -62,7 +62,7 @@ class StandardRegionalEndpointsTraitTest {
         assertEquals(regionSpecialCase.getDualStack(), true);
         assertEquals(trait,
                 new StandardRegionalEndpointsTrait.Provider().createTrait(StandardRegionalEndpointsTrait.ID,
-                        trait.toBuilder().sourceLocation(trait.getSourceLocation()).build().toNode()));
+                        trait.toBuilder().build().toNode()));
 
         Node.assertEquals(trait.toNode(), trait.toBuilder().build().toNode());
     }

--- a/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/traits/StandardRegionalEndpointsTraitTest.java
+++ b/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/traits/StandardRegionalEndpointsTraitTest.java
@@ -27,11 +27,17 @@ class StandardRegionalEndpointsTraitTest {
 
         assertEquals(trait.getPartitionSpecialCases().size(), 0);
         assertEquals(trait.getRegionSpecialCases().size(), 0);
+        assertEquals(trait,
+                new StandardRegionalEndpointsTrait.Provider().createTrait(StandardRegionalEndpointsTrait.ID,
+                        trait.toBuilder().sourceLocation(trait.getSourceLocation()).build().toNode()));
 
         trait = getTraitFromService(model, "ns.foo#Service2");
 
         assertEquals(trait.getPartitionSpecialCases().size(), 0);
         assertEquals(trait.getRegionSpecialCases().size(), 0);
+        assertEquals(trait,
+                new StandardRegionalEndpointsTrait.Provider().createTrait(StandardRegionalEndpointsTrait.ID,
+                        trait.toBuilder().sourceLocation(trait.getSourceLocation()).build().toNode()));
 
         trait = getTraitFromService(model, "ns.foo#Service3");
 
@@ -50,7 +56,13 @@ class StandardRegionalEndpointsTraitTest {
         assertNull(partitionSpecialCase2.getFips());
 
         List<RegionSpecialCase> regionSpecialCases = trait.getRegionSpecialCases().get("us-east-1");
-        assertEquals(regionSpecialCases.size(), 0);
+        assertEquals(regionSpecialCases.size(), 1);
+        RegionSpecialCase regionSpecialCase = regionSpecialCases.get(0);
+        assertEquals(regionSpecialCase.getEndpoint(), "https://myservice.amazonaws.com");
+        assertEquals(regionSpecialCase.getDualStack(), true);
+        assertEquals(trait,
+                new StandardRegionalEndpointsTrait.Provider().createTrait(StandardRegionalEndpointsTrait.ID,
+                        trait.toBuilder().sourceLocation(trait.getSourceLocation()).build().toNode()));
 
         Node.assertEquals(trait.toNode(), trait.toBuilder().build().toNode());
     }

--- a/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/traits/standardRegionalEndpoints.smithy
+++ b/smithy-aws-endpoints/src/test/resources/software/amazon/smithy/rulesengine/aws/traits/standardRegionalEndpoints.smithy
@@ -29,6 +29,10 @@ service Service2 {
     },
     regionSpecialCases: {
         "us-east-1": [
+            {
+                endpoint: "https://myservice.amazonaws.com",
+                dualStack: true
+            }
         ]
     }
 )


### PR DESCRIPTION
#### Background
Calling `toNode` on standardRegionalEndpoints or standardPartitionalEndpoints can raise NPE when special cases are missing non-required members.

This PR fixes that and adds equals/toHash methods as well.

#### Testing
* Modified existing tests to test that traits converted to node and back are equal.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
