### PR TITLE
Show actual events in test runner

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/testrunner/SmithyTestCase.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/testrunner/SmithyTestCase.java
@@ -116,7 +116,7 @@ public final class SmithyTestCase {
                 .filter(event -> !isModelDeprecationEvent(event))
                 .collect(Collectors.toList());
 
-        return new SmithyTestCase.Result(getModelLocation(), unmatchedEvents, extraEvents);
+        return new SmithyTestCase.Result(getModelLocation(), unmatchedEvents, extraEvents, actualEvents);
     }
 
     private static boolean compareEvents(ValidationEvent expected, ValidationEvent actual) {
@@ -197,15 +197,18 @@ public final class SmithyTestCase {
         private final String modelLocation;
         private final Collection<ValidationEvent> unmatchedEvents;
         private final Collection<ValidationEvent> extraEvents;
+        private final Collection<ValidationEvent> actualEvents;
 
         Result(
                 String modelLocation,
                 Collection<ValidationEvent> unmatchedEvents,
-                Collection<ValidationEvent> extraEvents
+                Collection<ValidationEvent> extraEvents,
+                Collection<ValidationEvent> actualEvents
         ) {
             this.modelLocation = modelLocation;
             this.unmatchedEvents = Collections.unmodifiableCollection(new TreeSet<>(unmatchedEvents));
             this.extraEvents = Collections.unmodifiableCollection(new TreeSet<>(extraEvents));
+            this.actualEvents = Collections.unmodifiableCollection(new TreeSet<>(actualEvents));
         }
 
         @Override
@@ -235,6 +238,13 @@ public final class SmithyTestCase {
                 }
                 builder.append('\n');
             }
+
+            builder.append("\nActual events\n"
+                    + "-------------\n");
+            for (ValidationEvent event : actualEvents) {
+                builder.append(event.toString().replace("\n", "\\n")).append("\n");
+            }
+            builder.append('\n');
 
             return builder.toString();
         }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/testrunner/SmithyTestCaseTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/testrunner/SmithyTestCaseTest.java
@@ -119,7 +119,8 @@ public class SmithyTestCaseTest {
         SmithyTestCase.Result result = new SmithyTestCase.Result(
                 "/foo/bar.json",
                 ListUtils.of(e1, e2),
-                ListUtils.of(e1, e2));
+                ListUtils.of(e1, e2),
+                ListUtils.of());
 
         assertThat(result.toString(),
                 equalTo("=======================\n"
@@ -136,6 +137,11 @@ public class SmithyTestCaseTest {
                         + "Encountered unexpected events\n"
                         + "-----------------------------\n"
                         + "[DANGER] foo.baz#Bar: a | FooBar N/A:0:0\n"
-                        + "[DANGER] foo.baz#Bar: b | FooBar N/A:0:0\n\n"));
+                        + "[DANGER] foo.baz#Bar: b | FooBar N/A:0:0\n"
+                        + "\n"
+                        + "\n"
+                        + "Actual events\n"
+                        + "-------------\n"
+                        + "\n"));
     }
 }


### PR DESCRIPTION
Updates the validation test runner to show the actual events emitted, to help figure out what's wrong, like if you have a typo, for example.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
