### PR TITLE
Improve isVirtualHostableBucket function

### DIFF
--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/language/functions/IsVirtualHostableS3Bucket.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/language/functions/IsVirtualHostableS3Bucket.java
@@ -6,7 +6,6 @@ package software.amazon.smithy.rulesengine.aws.language.functions;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
 import software.amazon.smithy.rulesengine.language.evaluation.type.Type;
 import software.amazon.smithy.rulesengine.language.evaluation.value.Value;
 import software.amazon.smithy.rulesengine.language.syntax.ToExpression;
@@ -15,6 +14,7 @@ import software.amazon.smithy.rulesengine.language.syntax.expressions.Expression
 import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.FunctionDefinition;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.FunctionNode;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.LibraryFunction;
+import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.ParseUrl;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
@@ -69,11 +69,6 @@ public final class IsVirtualHostableS3Bucket extends LibraryFunction {
      * A {@link FunctionDefinition} for the {@link IsVirtualHostableS3Bucket} function.
      */
     public static final class Definition implements FunctionDefinition {
-        private static final Pattern DOTS_ALLOWED = Pattern.compile("[a-z\\d][a-z\\d\\-.]{1,61}[a-z\\d]");
-        private static final Pattern DOTS_DISALLOWED = Pattern.compile("[a-z\\d][a-z\\d\\-]{1,61}[a-z\\d]");
-        private static final Pattern IP_ADDRESS = Pattern.compile("(\\d+\\.){3}\\d+");
-        private static final Pattern DASH_DOT_SEPARATOR = Pattern.compile(".*[.-]{2}.*");
-
         private Definition() {}
 
         @Override
@@ -95,21 +90,72 @@ public final class IsVirtualHostableS3Bucket extends LibraryFunction {
         public Value evaluate(List<Value> arguments) {
             String hostLabel = arguments.get(0).expectStringValue().getValue();
             boolean allowDots = arguments.get(1).expectBooleanValue().getValue();
-            if (allowDots) {
-                return Value.booleanValue(
-                        DOTS_ALLOWED.matcher(hostLabel).matches()
-                                // Don't allow ip address
-                                && !IP_ADDRESS.matcher(hostLabel).matches()
-                                // Don't allow names like bucket-.name or bucket.-name
-                                && !DASH_DOT_SEPARATOR.matcher(hostLabel).matches());
-            } else {
-                return Value.booleanValue(DOTS_DISALLOWED.matcher(hostLabel).matches());
-            }
+            return Value.booleanValue(isVirtualHostableBucket(hostLabel, allowDots));
         }
 
         @Override
         public IsVirtualHostableS3Bucket createFunction(FunctionNode functionNode) {
             return new IsVirtualHostableS3Bucket(functionNode);
         }
+    }
+
+    /**
+     * Checks if the given hostLabel string is a virtual hostable bucket name.
+     *
+     * @param hostLabel Host label to check.
+     * @param allowDots Whether to allow dots in the host label.
+     * @return true if it is compatible.
+     */
+    public static boolean isVirtualHostableBucket(String hostLabel, boolean allowDots) {
+        // Bucket names must be between 3 (min) and 63 (max) characters long.
+        int bucketLength = hostLabel == null ? 0 : hostLabel.length();
+        if (bucketLength < 3 || bucketLength > 63) {
+            return false;
+        }
+
+        // Bucket names must begin and end with a letter or number.
+        if (!isAlphanumeric(hostLabel.charAt(0)) || !isAlphanumeric(hostLabel.charAt(bucketLength - 1))) {
+            return false;
+        }
+
+        // Bucket names can consist only of lowercase letters, numbers, periods (.), and hyphens (-).
+        if (!allowDots) {
+            for (int i = 1; i < bucketLength - 1; i++) { // already validated 0 and N - 1.
+                if (!isValidBucketSegmentChar(hostLabel.charAt(i))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // Check for consecutive dots or hyphens
+        char last = hostLabel.charAt(0);
+        for (int i = 1; i < bucketLength; i++) {
+            char c = hostLabel.charAt(i);
+            // Don't allow "bucket-.foo" or "bucket.-foo"
+            if (c == '.') {
+                if (last == '.' || last == '-') {
+                    return false;
+                }
+            } else if (c == '-') {
+                if (last == '.') {
+                    return false;
+                }
+            } else if (!isAlphanumeric(c)) {
+                return false;
+            }
+            last = c;
+        }
+
+        // Bucket names must not be formatted as an IP address (for example, 192.168.5.4).
+        return !ParseUrl.isIpAddr(hostLabel);
+    }
+
+    private static boolean isAlphanumeric(char c) {
+        return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+    }
+
+    private static boolean isValidBucketSegmentChar(char c) {
+        return isAlphanumeric(c) || c == '-';
     }
 }

--- a/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/language/functions/IsVirtualHostableS3BucketTest.java
+++ b/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/language/functions/IsVirtualHostableS3BucketTest.java
@@ -34,6 +34,7 @@ public class IsVirtualHostableS3BucketTest {
             "a.-b, true, false", // Dot followed by dash
 
             "192.168.1.1, true, false", // IP address
+            "999.999.999.999, true, false", // Invalid IP address format, but looks like an IP
             "192.168.1.word, true, true", // IP-like but with letters
 
             "a-b.c-d, true, true", // Complex valid name with dots and dashes

--- a/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/language/functions/IsVirtualHostableS3BucketTest.java
+++ b/smithy-aws-endpoints/src/test/java/software/amazon/smithy/rulesengine/aws/language/functions/IsVirtualHostableS3BucketTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.rulesengine.aws.language.functions;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class IsVirtualHostableS3BucketTest {
+    @ParameterizedTest
+    @CsvSource({
+            "ab, false, false", // Too short (2 chars)
+            "abc, false, true", // Min length (3 chars)
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, false, true", // Max length (63 chars)
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, false, false", // Too long (64 chars)
+
+            "-abc, false, false", // Starts with dash
+            ".abc, true, false", // Starts with dot
+            "abc-, false, false", // Ends with dash
+            "abc., true, false", // Ends with dot
+
+            "abc, false, true", // Simple alphanumeric, no dots allowed
+            "a-b-c, false, true", // With dashes, no dots allowed
+            "a.b-c, false, false", // With dots when not allowed
+
+            "abc, true, true", // Simple alphanumeric, dots allowed
+            "a-b-c, true, true", // With dashes, dots allowed
+            "a.b-c, true, true", // With dots when allowed
+
+            "a..b, true, false", // Consecutive dots
+            "a-.b, true, false", // Dash followed by dot
+            "a.-b, true, false", // Dot followed by dash
+
+            "192.168.1.1, true, false", // IP address
+            "192.168.1.word, true, true", // IP-like but with letters
+
+            "a-b.c-d, true, true", // Complex valid name with dots and dashes
+            "a0b1c2, true, true", // Alphanumeric mix
+            "123, true, true", // Only numbers
+            "abc123, true, true", // Letters followed by numbers
+            "123abc, true, true", // Numbers followed by letters
+            "a0.b1.c2, true, true", // Alphanumeric with dots
+
+            "abc_def, true, false", // Contains underscore
+            "abcDef, true, false", // Contains uppercase
+            "abc#def, true, false" // Contains special char
+    })
+    public void isVirtualHostableBucket(String value, boolean allowDots, boolean expected) {
+        boolean actual = IsVirtualHostableS3Bucket.isVirtualHostableBucket(value, allowDots);
+
+        if (expected != actual) {
+            Assertions.fail("Expected `" + value + "`, allowDots=" + allowDots + " to be " + expected);
+        }
+    }
+}

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/expressions/functions/ParseUrl.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/expressions/functions/ParseUrl.java
@@ -174,10 +174,7 @@ public final class ParseUrl extends LibraryFunction {
                         || (ch2 < '0' || ch2 > '9')) {
                     return false;
                 }
-                int value = ((ch0 - '0') * 100) + ((ch1 - '0') * 10) + (ch2 - '0');
-                if (value > 255) {
-                    return false;
-                }
+                // This is a heuristic; We are intentionally not checking for the range 000-255.
             } else {
                 return false;
             }

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/expressions/functions/ParseUrl.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/expressions/functions/ParseUrl.java
@@ -29,7 +29,7 @@ public final class ParseUrl extends LibraryFunction {
     public static final Identifier PATH = Identifier.of("path");
     public static final Identifier NORMALIZED_PATH = Identifier.of("normalizedPath");
     public static final Identifier IS_IP = Identifier.of("isIp");
-    private static final Definition DEFINITION = new Definition();
+    public static final Definition DEFINITION = new Definition();
 
     private ParseUrl(FunctionNode functionNode) {
         super(DEFINITION, functionNode);


### PR DESCRIPTION
This commit removes the use of three regular expressions and string splitting when checking if a value is a virtual hostable bucket. This should help with both startup and runtime performance. It also exposes a static method for performing this check that I'll use in smithy-java.


#### Background
* What do these changes do? 
* Why are they important?

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
