### PR TITLE
Improve aws.partition function

### DIFF
--- a/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/language/functions/partition/Partition.java
+++ b/smithy-aws-endpoints/src/main/java/software/amazon/smithy/rulesengine/aws/language/functions/partition/Partition.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.rulesengine.aws.language.functions.partition;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.Node;
@@ -34,6 +35,7 @@ public final class Partition implements ToSmithyBuilder<Partition>, FromSourceLo
     private final Map<String, RegionOverride> regions;
     private final PartitionOutputs outputs;
     private final SourceLocation sourceLocation;
+    private Pattern compiledRegionRegex;
 
     private Partition(Builder builder) {
         this.sourceLocation = builder.getSourceLocation();
@@ -89,6 +91,20 @@ public final class Partition implements ToSmithyBuilder<Partition>, FromSourceLo
      */
     public String getRegionRegex() {
         return regionRegex;
+    }
+
+    /**
+     * Get the compiled region regular expression of the partition.
+     *
+     * @return the compiled region regex.
+     */
+    public Pattern getCompiledRegionRegex() {
+        Pattern result = compiledRegionRegex;
+        if (result == null) {
+            result = Pattern.compile(regionRegex);
+            compiledRegionRegex = result;
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
Only compiles partition regular expressions once.
Reuses a cached AWS_PARTITION values.
Exposes method for smithy-java to use.


#### Background
* What do these changes do? 
* Why are they important?

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
