### PR TITLE
Document suppressed severity in validate command

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidatorOptions.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/ValidatorOptions.java
@@ -33,8 +33,8 @@ final class ValidatorOptions implements ArgumentReceiver {
         printer.param(SEVERITY,
                 null,
                 "SEVERITY",
-                "Set the minimum reported validation severity (one of NOTE, "
-                        + "WARNING [default setting], DANGER, ERROR).");
+                "Set the minimum reported validation severity (one of SUPPRESSED, "
+                        + "NOTE, WARNING [default setting], DANGER, ERROR).");
         printer.param(SHOW_VALIDATORS,
                 null,
                 "VALIDATORS",


### PR DESCRIPTION
This documents that the suppressed severity can be selected in the validate command. There was already a test for it, but it got missed in the docs.

Resolves #2613

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
