### PR TITLE
Fix endpointTests missing required param validation

### DIFF
--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-builtins.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/invalid/invalid-builtins.smithy
@@ -68,6 +68,7 @@ use smithy.rules#endpointTests
         }
     ]
 })
+@suppress(["RuleSetParameter.TestCase.Unused"])
 service ExampleService {
     version: "2022-01-01",
     operations: [GetThing]

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/valid/default-values.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/valid/default-values.smithy
@@ -140,6 +140,7 @@ use smithy.rules#staticContextParams
         }
     ]
 })
+@suppress(["RuleSetParameter.TestCase.Unused"])
 service FizzBuzz {
     version: "2022-01-01",
     operations: [GetThing]

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/invalid-test-missing-required-built-in.errors
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/invalid-test-missing-required-built-in.errors
@@ -1,0 +1,3 @@
+[WARNING] smithy.example#ExampleService: This shape applies a trait that is unstable: smithy.rules#endpointRuleSet | UnstableTrait
+[WARNING] smithy.example#ExampleService: This shape applies a trait that is unstable: smithy.rules#endpointTests | UnstableTrait
+[ERROR] smithy.example#ExampleService: Required parameter `endpoint` is missing in at least one test case | RuleSetParameter.TestCase.RequiredMissing

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/invalid-test-missing-required-built-in.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/traits/errorfiles/invalid-test-missing-required-built-in.smithy
@@ -1,0 +1,59 @@
+$version: "2.0"
+
+namespace smithy.example
+
+use smithy.rules#endpointRuleSet
+use smithy.rules#endpointTests
+
+@endpointRuleSet({
+    version: "1.0"
+    parameters: {
+        endpoint: {
+            type: "string"
+            builtIn: "SDK::Endpoint"
+            documentation: "docs"
+            required: true
+        }
+    }
+    rules: [
+        {
+            documentation: "Passthrough"
+            conditions: []
+            endpoint: {
+                url: "https://example.com"
+            }
+            type: "endpoint"
+        }
+    ]
+})
+@endpointTests({
+    version: "1.0"
+    testCases: [
+        {
+            params: {}
+            operationInputs: [{
+                operationName: "GetThing"
+                builtInParams: {
+                    "SDK::Endpoint": "https://example.com"
+                }
+            }]
+            expect: {
+                endpoint: {
+                    url: "https://example.com"
+                }
+            }
+        }
+    ]
+})
+@suppress(["RuleSetParameter.TestCase.Unused"])
+service ExampleService {
+    version: "2020-07-02"
+    operations: [GetThing]
+}
+
+operation GetThing {
+    input := {
+        fizz: String
+    }
+}
+


### PR DESCRIPTION
This commit removes extraneous code that cause parameters to be double counted in test cases. This would cacade into a mismatch in counts between test cases and parameters.

This extra counting was introduced in the endpoint ruleset refactoring incorrectly. Existing rulesets continue to work and a new test case shows the correct failure mode.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
