### PR TITLE
Add a test for explicit payload member and empty body responses

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
@@ -281,6 +281,20 @@ apply HttpPayloadWithStructure @httpResponseTests([
     }
 ])
 
+apply HttpPayloadWithStructure @httpResponseTests([
+    {
+        id: "RestJsonHttpPayloadWithStructureAndEmptyResponseBody",
+        documentation: "Serializes a structure in the payload",
+        protocol: restJson1,
+        code: 200,
+        body: "",
+        bodyMediaType: "application/json",
+        params: {
+            nested: null
+        }
+    }
+])
+
 structure HttpPayloadWithStructureInputOutput {
     @httpPayload
     nested: NestedPayload,

--- a/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-payload.smithy
@@ -288,7 +288,6 @@ apply HttpPayloadWithStructure @httpResponseTests([
         protocol: restJson1,
         code: 200,
         body: "",
-        bodyMediaType: "application/json",
         params: {
             nested: null
         }


### PR DESCRIPTION
#### Background

Add a new protocol tests for the JSON REST protocol. When we have a response object with a member that's bound to the HTTP payload, such as

```smithy
@output
structure HttpPayloadWithStructureInputOutput {
    @httpPayload
    nested: NestedPayload,
}
```

And the response body is empty, then the member MUST be set to `null`.

Regression for this case was reported to the Java SDK V2 and fixed on [#6111](https://github.com/aws/aws-sdk-java-v2/pull/6111).

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
