### PR TITLE
Migrate from nexus2 to mavenCentral deployer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,13 +79,10 @@ configure<JReleaserExtension> {
     // https://jreleaser.org/guide/latest/examples/maven/maven-central.html#_gradle
     deploy {
         maven {
-            nexus2 {
+            mavenCentral {
                 create("maven-central") {
                     active = Active.ALWAYS
-                    url = "https://aws.oss.sonatype.org/service/local"
-                    snapshotUrl = "https://aws.oss.sonatype.org/content/repositories/snapshots"
-                    closeRepository = true
-                    releaseRepository = true
+                    url = "https://central.sonatype.com/api/v1/publisher"
                     stagingRepository(stagingDir().get().asFile.path)
                 }
             }


### PR DESCRIPTION
#### Background
- Nexus2 is being sunset and we must move away from it
- This change switches to the central portal deployer
  - Nothing else is needed for this migration

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
