### PR TITLE
Update graddle/wrapper-validation-action version from v3 to v4.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v4
+      - uses: gradle/actions/wrapper-validation@v4
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
@@ -79,7 +79,7 @@ jobs:
           repository: aws/api-models-aws
           path: api-models-aws
 
-      - uses: gradle/wrapper-validation-action@v4
+      - uses: gradle/actions/wrapper-validation@v4
 
       - name: Setup JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/wrapper-validation-action@v4
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
@@ -79,7 +79,7 @@ jobs:
           repository: aws/api-models-aws
           path: api-models-aws
 
-      - uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/wrapper-validation-action@v4
 
       - name: Setup JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
#### Background
Recent PR experienced connection errors like the following:

```
Error: Multiple errors returned
Error: Error 0: connect ETIMEDOUT 104.16.72.101:443
Error: connect ETIMEDOUT 104.16.72.101:443
    at createConnectionError (node:net:1652:[14](https://github.com/smithy-lang/smithy/actions/runs/15330227683/job/43134921095?pr=2647#step:3:16))
    at Timeout.internalConnectMultipleTimeout (node:net:1711:38)
    at listOnTimeout (node:internal/timers:583:11)
    at process.processTimers (node:internal/timers:519:7)
Error: Error 1: connect ENETUNREACH 2606:4700::6810:4965:443 - Local (:::0)
Error: connect ENETUNREACH 2606:4700::6810:4965:443 - Local (:::0)
    at internalConnectMultiple (node:net:1186:[16](https://github.com/smithy-lang/smithy/actions/runs/15330227683/job/43134921095?pr=2647#step:3:18))
    at Timeout.internalConnectMultipleTimeout (node:net:[17](https://github.com/smithy-lang/smithy/actions/runs/15330227683/job/43134921095?pr=2647#step:3:19)16:5)
    at listOnTimeout (node:internal/timers:583:11)
    at process.processTimers (node:internal/timers:519:7)
Error: Error 2: connect ETIMEDOUT 104.16.73.101:443
Error: connect ETIMEDOUT 104.16.73.101:443
    at createConnectionError (node:net:1652:14)
    at Timeout.internalConnectMultipleTimeout (node:net:1711:38)
    at listOnTimeout (node:internal/timers:583:11)
    at process.processTimers (node:internal/timers:519:7)
Error: Error 3: connect ENETUNREACH 2606:4700::6810:4865:443 - Local (:::0)
Error: connect ENETUNREACH 2606:4700::6810:4865:443 - Local (:::0)
    at internalConnectMultiple (node:net:1[18](https://github.com/smithy-lang/smithy/actions/runs/15330227683/job/43134921095?pr=2647#step:3:20)6:16)
    at Timeout.internalConnectMultipleTimeout (node:net:1716:5)
    at listOnTimeout (node:internal/timers:583:11)
    at process.processTimers (node:internal/timers:5[19](https://github.com/smithy-lang/smithy/actions/runs/15330227683/job/43134921095?pr=2647#step:3:21):7)
```

Found this error was caused by the validation-action version from one similar [GitHub issue](https://github.com/gradle/wrapper-validation-action/issues/40). 
I followed the [official gradle Github Workflow](https://github.com/gradle/actions/tree/main/wrapper-validation) and  updated the `gradle/wrapper-validation-action@v3` to `gradle/actions/wrapper-vadlidation@v4`  to avoid errors in future PRs.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
