### PR TITLE
Fix docgen when encountering `@enum` trait

### DIFF
--- a/smithy-docgen/src/it/java/software/amazon/smithy/docgen/PluginTest.java
+++ b/smithy-docgen/src/it/java/software/amazon/smithy/docgen/PluginTest.java
@@ -72,6 +72,9 @@ public class PluginTest {
         assertTrue(files.contains(Path.of("/requirements.txt")));
         assertTrue(files.contains(Path.of("/content", "conf.py")));
         assertTrue(files.contains(Path.of("/content", "index.md")));
+
+        // Assert that the transform to upgrade enum strings is applied.
+        assertTrue(files.contains(Path.of("/content", "shapes", "LegacyEnumTrait.md")));
     }
 
     private static Model getModel(String path) {

--- a/smithy-docgen/src/it/resources/software/amazon/smithy/docgen/main.smithy
+++ b/smithy-docgen/src/it/resources/software/amazon/smithy/docgen/main.smithy
@@ -210,6 +210,10 @@ operation TypeRefinementTraits with [AllAuth] {
         clientOptional: String
 
         enumValue: NonMatchingEnum
+
+        legacyEnum: LegacyEnumTrait
+
+        legacyEnumThatStaysString: LegacyEnumThatStaysString
     }
 
     output := {
@@ -230,6 +234,30 @@ enum NonMatchingEnum {
     /// Note that the actual wire value is completely different.
     BAR = "example"
 }
+
+/// Some old modeled enum shape.
+@enum([
+    {
+        value: "RED"
+        name: "RED"
+    }
+    {
+        value: "GREEN"
+        name: "GREEN"
+    }
+])
+string LegacyEnumTrait
+
+/// Some old modeled enum shape without names.
+@enum([
+    {
+        value: "RED"
+    }
+    {
+        value: "GREEN"
+    }
+])
+string LegacyEnumThatStaysString
 
 /// A list that allows null values.
 @sparse

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/SmithyDocPlugin.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/SmithyDocPlugin.java
@@ -46,6 +46,7 @@ public final class SmithyDocPlugin implements SmithyBuildPlugin {
         DocSettings settings = runner.settings(DocSettings.class, pluginContext.getSettings());
         runner.service(settings.service());
         runner.performDefaultCodegenTransforms();
+        runner.changeStringEnumsToEnumShapes(false);
         runner.run();
         LOGGER.fine("Finished documentation generation.");
     }

--- a/smithy-docgen/src/main/java/software/amazon/smithy/docgen/generators/StructuredShapeGenerator.java
+++ b/smithy-docgen/src/main/java/software/amazon/smithy/docgen/generators/StructuredShapeGenerator.java
@@ -18,6 +18,7 @@ import software.amazon.smithy.docgen.sections.ShapeMembersSection;
 import software.amazon.smithy.docgen.sections.ShapeSection;
 import software.amazon.smithy.docgen.sections.ShapeSubheadingSection;
 import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -80,6 +81,12 @@ public final class StructuredShapeGenerator implements BiConsumer<Shape, MemberL
 
     @Override
     public void accept(Shape shape, MemberListingType listingType) {
+        // Legacy enums using the trait on a string shape should be upgraded
+        // to `enum` shapes. If not, skip them here.
+        if (shape.isStringShape() && shape.hasTrait(EnumTrait.ID)) {
+            return;
+        }
+
         var symbol = context.symbolProvider().toSymbol(shape);
         context.writerDelegator().useShapeWriter(shape, writer -> {
             writer.pushState(new ShapeSection(context, shape));


### PR DESCRIPTION
This commit updates the behavior of `smithy-docgen` to attempt the automatic upgrade of string `@enum`s to Smithy's `enum` shapes. This upgrade does not generate enum names, as they may be different from other sources.

If a shape cannot be upgraded to an `enum`, it is ignored during content generation.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
