### PR TITLE
Add a tag to identify service-specific protocol tests

### DIFF
--- a/smithy-aws-protocol-tests/model/awsJson1_1/services/machinelearning.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/services/machinelearning.smithy
@@ -22,6 +22,7 @@ use smithy.test#httpRequestTests
 @xmlNamespace(
     uri: "http://machinelearning.amazonaws.com/doc/2014-12-12/",
 )
+@tags(["aws-service-test"])
 service AmazonML_20141212 {
     version: "2014-12-12",
     operations: [

--- a/smithy-aws-protocol-tests/model/restJson1/services/apigateway.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/services/apigateway.smithy
@@ -19,6 +19,7 @@ use smithy.test#httpRequestTests
 )
 @restJson1
 @title("Amazon API Gateway")
+@tags(["aws-service-test"])
 service BackplaneControlService {
     version: "2015-07-09",
     operations: [

--- a/smithy-aws-protocol-tests/model/restJson1/services/glacier.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/services/glacier.smithy
@@ -27,6 +27,7 @@ use smithy.test#httpRequestTests
 @xmlNamespace(
     uri: "http://glacier.amazonaws.com/doc/2012-06-01/",
 )
+@tags(["aws-service-test"])
 service Glacier {
     version: "2012-06-01",
     operations: [

--- a/smithy-aws-protocol-tests/model/restXml/services/s3.smithy
+++ b/smithy-aws-protocol-tests/model/restXml/services/s3.smithy
@@ -17,7 +17,7 @@ use aws.api#service
 use aws.auth#sigv4
 use aws.customizations#s3UnwrappedXmlOutput
 use aws.protocols#restXml
-use aws.protocols#httpChecksum
+use aws.protocoltests.config#AwsConfig
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
@@ -38,6 +38,7 @@ use smithy.test#httpResponseTests
 @xmlNamespace(
     uri: "http://s3.amazonaws.com/doc/2006-03-01/",
 )
+@tags(["aws-service-test"])
 service AmazonS3 {
     version: "2006-03-01",
     operations: [
@@ -67,7 +68,7 @@ service AmazonS3 {
         params: {
             Bucket: "mybucket",
         },
-        vendorParamsShape: aws.protocoltests.config#AwsConfig,
+        vendorParamsShape: AwsConfig,
         vendorParams: {
             scopedConfig: {
                 client: {
@@ -91,7 +92,7 @@ service AmazonS3 {
         params: {
             Bucket: "mybucket",
         },
-        vendorParamsShape: aws.protocoltests.config#AwsConfig,
+        vendorParamsShape: AwsConfig,
         vendorParams: {
             scopedConfig: {
                 client: {
@@ -118,7 +119,7 @@ service AmazonS3 {
         params: {
             Bucket: "mybucket",
         },
-        vendorParamsShape: aws.protocoltests.config#AwsConfig,
+        vendorParamsShape: AwsConfig,
         vendorParams: {
             scopedConfig: {
                 client: {
@@ -147,7 +148,7 @@ service AmazonS3 {
         params: {
             Bucket: "mybucket",
         },
-        vendorParamsShape: aws.protocoltests.config#AwsConfig,
+        vendorParamsShape: AwsConfig,
         vendorParams: {
             scopedConfig: {
                 client: {
@@ -177,7 +178,7 @@ service AmazonS3 {
         params: {
             Bucket: "mybucket",
         },
-        vendorParamsShape: aws.protocoltests.config#AwsConfig,
+        vendorParamsShape: AwsConfig,
         vendorParams: {
             scopedConfig: {
                 client: {
@@ -207,7 +208,7 @@ service AmazonS3 {
         params: {
             Bucket: "mybucket",
         },
-        vendorParamsShape: aws.protocoltests.config#AwsConfig,
+        vendorParamsShape: AwsConfig,
         vendorParams: {
             scopedConfig: {
                 client: {
@@ -238,7 +239,7 @@ service AmazonS3 {
         params: {
             Bucket: "mybucket",
         },
-        vendorParamsShape: aws.protocoltests.config#AwsConfig,
+        vendorParamsShape: AwsConfig,
         vendorParams: {
             scopedConfig: {
                 client: {
@@ -295,7 +296,7 @@ operation ListObjectsV2 {
             Bucket: "mybucket",
             Key: "my key.txt"
         },
-        vendorParamsShape: aws.protocoltests.config#AwsConfig,
+        vendorParamsShape: AwsConfig,
         vendorParams: {
             scopedConfig: {
                 client: {
@@ -324,7 +325,7 @@ operation ListObjectsV2 {
             Bucket: "mybucket",
             Key: "foo/bar/my key.txt"
         },
-        vendorParamsShape: aws.protocoltests.config#AwsConfig,
+        vendorParamsShape: AwsConfig,
         vendorParams: {
             scopedConfig: {
                 client: {
@@ -360,7 +361,7 @@ operation DeleteObjectTagging {
             Bucket: "mybucket",
             Key: "../key.txt"
         },
-        vendorParamsShape: aws.protocoltests.config#AwsConfig,
+        vendorParamsShape: AwsConfig,
         vendorParams: {
             scopedConfig: {
                 client: {
@@ -387,7 +388,7 @@ operation DeleteObjectTagging {
             Bucket: "mybucket",
             Key: "foo/../key.txt"
         },
-        vendorParamsShape: aws.protocoltests.config#AwsConfig,
+        vendorParamsShape: AwsConfig,
         vendorParams: {
             scopedConfig: {
                 client: {


### PR DESCRIPTION
#### Background

Currently AWS protocol tests include tests that are specific for some AWS services and not generally applicable to any given protocol. This change adds a tag to the service such that clients can filter out non-standard client tests.
