### PR TITLE
Improve Smithy landing page and documentation page

### DIFF
--- a/docs/_templates/sidebar/brand.html
+++ b/docs/_templates/sidebar/brand.html
@@ -1,0 +1,8 @@
+<a class="sidebar-brand" href="/index.html">
+  {% if theme_light_logo %}
+  <div class="sidebar-brand-icon">
+    <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" alt="Logo">
+    <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" alt="Logo">
+  </div>
+  {% endif %}
+</a>

--- a/docs/landing-page/public/locales/en/translation.json
+++ b/docs/landing-page/public/locales/en/translation.json
@@ -11,7 +11,7 @@
     "items": [
       {
         "title": "Quickstart",
-        "href": "/2.0/quickstart.html",
+        "href": "https://smithy.io/2.0/quickstart.html#weather-service",
         "className": "sm:hidden"
       },
       { "title": "Documentation", "href": "/2.0/index.html" },
@@ -20,8 +20,8 @@
         "href": "https://github.com/smithy-lang/smithy-examples"
       },
       {
-        "title": "Ecosystem",
-        "href": "https://github.com/smithy-lang/awesome-smithy"
+        "title": "Awesome Smithy",
+        "href": "https://github.com/smithy-lang/awesome-smithy?tab=readme-ov-file#awesome-smithy"
       }
     ]
   },

--- a/docs/landing-page/src/components/landing-page/Heading/Tagline.tsx
+++ b/docs/landing-page/src/components/landing-page/Heading/Tagline.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button.tsx";
 
 export const Tagline = () => {
   const { t } = useTranslation("translation", { keyPrefix: "title" });
@@ -13,6 +14,13 @@ export const Tagline = () => {
         </span>
       </h1>
       <p className="pt-7 text-lg">{t("subtitle")}</p>
+      <div className="mt-8">
+        <a className="flex flex-col md:flex-row" href="/2.0/quickstart.html">
+          <Button variant="gradient-outline" darkBg className="hidden sm:flex">
+            Get Started
+          </Button>
+        </a>
+      </div>
     </div>
   );
 };

--- a/docs/landing-page/src/components/landing-page/Heading/index.tsx
+++ b/docs/landing-page/src/components/landing-page/Heading/index.tsx
@@ -5,6 +5,8 @@ import { SmithyPopGradient } from "@/components/ui/SmithyPopGradient";
 import { Card, CardHeader } from "@/components/ui/card";
 import { IdePanel } from "@/components/ui/ide-panel";
 import { ServiceExample } from "../ServiceExample";
+import { Button } from "@/components/ui/button.tsx";
+import { Navigation } from "lucide-react";
 
 interface HeadingProps {
   serviceExampleRef: React.RefObject<HTMLDivElement>;
@@ -13,25 +15,27 @@ interface HeadingProps {
 export const Heading = (props: HeadingProps) => {
   return (
     <SmithyPopGradient withSparks>
-      <div className="py-16 px-8 flex flex-col md:flex-row justify-around grow items-center">
-        <Tagline />
+      <div className="max-w-7xl mx-auto">
+        <div className="py-16 px-8 flex flex-col md:flex-row justify-around grow items-center">
+          <Tagline />
 
-        <Card
-          variant={"default"}
-          className="bg-white text-center mt-12 mx-12 w-fit lg:w-auto lg:mt-0 border-white"
-          ref={props.serviceExampleRef}
-        >
-          <CardHeader className="text-smithy-black">
-            <div className="flex flex-col lg:w-[450px] lg:flex-row lg:justify-between lg:items-center">
-              <div className="text-2xl m-auto mb-4 lg:w-24 text-center lg:text-left text-smithy-purple lg:m-0 lg:ml-8">
-                Smithy Service Example
+          <Card
+            variant={"default"}
+            className="bg-white text-center mt-12 mx-12 w-fit lg:w-auto lg:mt-0 border-white"
+            ref={props.serviceExampleRef}
+          >
+            <CardHeader className="text-smithy-black">
+              <div className="flex flex-col lg:w-[450px] lg:flex-row lg:justify-between lg:items-center">
+                <div className="text-2xl m-auto mb-4 lg:w-24 text-center lg:text-left text-smithy-purple lg:m-0 lg:ml-8">
+                  Smithy Service Example
+                </div>
+                <IdePanel>
+                  <ServiceExample />
+                </IdePanel>
               </div>
-              <IdePanel>
-                <ServiceExample />
-              </IdePanel>
-            </div>
-          </CardHeader>
-        </Card>
+            </CardHeader>
+          </Card>
+        </div>
       </div>
     </SmithyPopGradient>
   );

--- a/docs/landing-page/src/components/landing-page/InformationCircles/index.stories.tsx
+++ b/docs/landing-page/src/components/landing-page/InformationCircles/index.stories.tsx
@@ -7,6 +7,7 @@ const meta = {
   component: InformationCircles,
   args: {
     circleUrls: ["/icons/dark/swift.svg"],
+    name: "Swift",
   },
   parameters: {
     layout: "fullscreen",

--- a/docs/landing-page/src/components/landing-page/SubHeading/index.tsx
+++ b/docs/landing-page/src/components/landing-page/SubHeading/index.tsx
@@ -19,60 +19,62 @@ export const SubHeading = (props: SubHeadingProps) => {
   const buildRef = useRef<HTMLDivElement>(null);
 
   return (
-    <div className="pt-20 px-2 lg:px-8 py-12">
-      <div className="flex flex-col lg:flex-row lg:justify-around lg:grow lg:items-start items-center">
-        <Section
-          title={t("section1.title")}
-          description={t("section1.description")}
-          className={sectionClassOverrides}
-        />
+    <div className="max-w-7xl mx-auto">
+      <div className="pt-20 px-2 lg:px-8 py-12">
+        <div className="flex flex-col lg:flex-row lg:justify-around lg:grow lg:items-start items-center">
+          <Section
+            title={t("section1.title")}
+            description={t("section1.description")}
+            className={sectionClassOverrides}
+          />
 
-        <SmithyGlow className="bg-[position:center_center] w-fit lg:w-[600px] bg-[size:115%_103%] lg:bg-[size:110%] lg:relative lg:-top-12">
-          <div className="mx-4 my-12 lg:m-12">
-            <Card
-              variant={"gradient-border"}
-              className="bg-smithy-black text-center"
-              ref={props.modelRef}
-            >
-              <CardHeader className="text-smithy-red-15 my-0 lg:my-5">
-                <div className="flex flex-col lg:w-[450px] justify-between gap-4 lg:gap-14 items-center lg:flex-row">
-                  <div className="text-2xl w-24 text-center lg:text-left">
-                    {t("model")}
-                  </div>
-                  <IdePanel>
-                    <div className="w-48 lg:w-64 py-7 text-left pl-5 text-smithy-red-33 bg-stone-800 rounded-b-xl">
-                      <div>/{t("build")}</div>
-                      <div>/{t("validate")}</div>
-                      <div>/{t("transform")}</div>
-                      <div>/{t("share")}</div>
+          <SmithyGlow className="bg-[position:center_center] w-fit lg:w-[600px] bg-[size:115%_103%] lg:bg-[size:110%] lg:relative lg:-top-12">
+            <div className="mx-4 my-12 lg:m-12">
+              <Card
+                variant={"gradient-border"}
+                className="bg-smithy-black text-center"
+                ref={props.modelRef}
+              >
+                <CardHeader className="text-smithy-red-15 my-0 lg:my-5">
+                  <div className="flex flex-col lg:w-[450px] justify-between gap-4 lg:gap-14 items-center lg:flex-row">
+                    <div className="text-2xl w-24 text-center lg:text-left">
+                      {t("model")}
                     </div>
-                  </IdePanel>
-                </div>
-              </CardHeader>
-            </Card>
-          </div>
-        </SmithyGlow>
-      </div>
+                    <IdePanel>
+                      <div className="w-48 lg:w-64 py-7 text-left pl-5 text-smithy-red-33 bg-stone-800 rounded-b-xl">
+                        <div>/{t("build")}</div>
+                        <div>/{t("validate")}</div>
+                        <div>/{t("transform")}</div>
+                        <div>/{t("share")}</div>
+                      </div>
+                    </IdePanel>
+                  </div>
+                </CardHeader>
+              </Card>
+            </div>
+          </SmithyGlow>
+        </div>
 
-      <div className="flex flex-col lg:flex-row justify-around grow items-center lg:items-start">
-        <Section
-          title={t("section2.title")}
-          description={t("section2.description")}
-          className={sectionClassOverrides}
-        />
+        <div className="flex flex-col lg:flex-row justify-around grow items-center lg:items-start">
+          <Section
+            title={t("section2.title")}
+            description={t("section2.description")}
+            className={sectionClassOverrides}
+          />
 
-        <div className="my-6 lg:m-12 lg:px-6">
-          <div className="flex w-full lg:w-[450px] justify-center gap-14 items-center">
-            <Web smithyBuildRef={buildRef} />
+          <div className="my-6 lg:m-12 lg:px-6">
+            <div className="flex w-full lg:w-[450px] justify-center gap-14 items-center">
+              <Web smithyBuildRef={buildRef} />
+            </div>
           </div>
         </div>
-      </div>
 
-      <LineConnector
-        startComponent={props.modelRef}
-        endComponent={buildRef}
-        className="hidden lg:block"
-      />
+        <LineConnector
+          startComponent={props.modelRef}
+          endComponent={buildRef}
+          className="hidden lg:block"
+        />
+      </div>
     </div>
   );
 };

--- a/docs/landing-page/src/components/landing-page/useSupportedLanguagesHook.tsx
+++ b/docs/landing-page/src/components/landing-page/useSupportedLanguagesHook.tsx
@@ -13,18 +13,21 @@ export const useSupportedLanguages = (props?: useSupportedLanguagesProps) => {
     const serverUrls = [
       {
         src: "/icons/duke.svg",
+        name: "Java",
         alt: t("java.alt"),
         trademark: t("java.trademark"),
         location: "https://github.com/smithy-lang/smithy-java",
       },
       {
         src: "/icons/ts.svg",
+        name: "TypeScript",
         alt: t("ts.alt"),
         trademark: t("ts.trademark"),
-        location: "https://github.com/awslabs/smithy-typescript",
+        location: "https://github.com/smithy-lang/smithy-typescript",
       },
       {
         src: "/icons/rust.svg",
+        name: "Rust",
         alt: t("rust.alt"),
         trademark: (
           <>
@@ -42,6 +45,7 @@ export const useSupportedLanguages = (props?: useSupportedLanguagesProps) => {
       },
       {
         src: "/icons/scala.svg",
+        name: "Scala",
         alt: t("scala.alt"),
         trademark: t("scala.trademark"),
         location: "https://github.com/disneystreaming/smithy4s",
@@ -50,30 +54,35 @@ export const useSupportedLanguages = (props?: useSupportedLanguagesProps) => {
     const clientUrls = [
       {
         src: "/icons/python.svg",
+        name: "Python",
         alt: t("python.alt"),
         trademark: t("python.trademark"),
         location: "https://github.com/smithy-lang/smithy-python",
       },
       {
         src: "/icons/go.svg",
+        name: "Go",
         alt: t("go.alt"),
         trademark: t("go.trademark"),
         location: "https://github.com/aws/smithy-go",
       },
       {
         src: "/icons/kotlin.svg",
+        name: "Kotlin",
         alt: t("kotlin.alt"),
         trademark: t("kotlin.trademark"),
         location: "https://github.com/awslabs/smithy-kotlin",
       },
       {
         src: "/icons/swift.svg",
+        name: "Swift",
         alt: t("swift.alt"),
         trademark: t("swift.trademark"),
         location: "https://github.com/awslabs/smithy-swift",
       },
       {
         src: "/icons/ruby.png",
+        name: "Ruby",
         alt: t("ruby.alt"),
         trademark: t("ruby.trademark"),
         location: "https://github.com/awslabs/smithy-ruby",

--- a/docs/landing-page/src/components/navigation/index.tsx
+++ b/docs/landing-page/src/components/navigation/index.tsx
@@ -13,7 +13,6 @@ import { MenuLinks } from "./MenuLinks";
 export const TopNavigation = () => {
   const { t } = useTranslation("translation", { keyPrefix: "navigation" });
   const githubAlt = t("githubLabel");
-  const getStartedAlt = t("getStartedLabel");
   return (
     <div className="bg-smithy-black text-white h-[var(--nav-offset)] fixed top-0 z-50">
       <NavigationMenu>
@@ -33,16 +32,6 @@ export const TopNavigation = () => {
             <MenuLinks className="hover:bg-gradient-to-l hover:from-primary hover:to-secondary inline-block hover:text-transparent hover:bg-clip-text" />
           </NavigationMenuItem>
           <NavigationMenuItem className="flex-1 flex justify-end items-end">
-            <a href="/2.0/quickstart.html" aria-label={getStartedAlt}>
-              <Button
-                variant="gradient-outline"
-                darkBg
-                className="hidden sm:flex"
-                aria-label={getStartedAlt}
-              >
-                {t("Get Started")}
-              </Button>
-            </a>
             <a
               target="_black"
               rel="noopener noreferrer"

--- a/docs/landing-page/src/components/ui/CircleSection.stories.tsx
+++ b/docs/landing-page/src/components/ui/CircleSection.stories.tsx
@@ -9,9 +9,9 @@ const meta = {
     title: "hello world",
     description: "some random text",
     circleUrls: [
-      { src: "/icons/dark/swift.svg" },
-      { src: "/icons/dark/javaScript.svg" },
-      { src: "/icons/dark/rust.svg" },
+      { src: "/icons/dark/swift.svg", name: "Swift" },
+      { src: "/icons/dark/javaScript.svg", name: "JavaScript" },
+      { src: "/icons/dark/rust.svg", name: "Rust" },
     ],
   },
   parameters: {

--- a/docs/landing-page/src/components/ui/CircleSection.tsx
+++ b/docs/landing-page/src/components/ui/CircleSection.tsx
@@ -4,6 +4,7 @@ import { Section, type SectionProps } from "@/components/ui/Section";
 
 export interface CircleSectionProps extends SectionProps {
   circleUrls: (React.ImgHTMLAttributes<HTMLImageElement> & {
+    name: string;
     location?: string;
   })[];
 }
@@ -20,13 +21,18 @@ export const CircleSection = (props: CircleSectionProps) => {
           <a
             key={imgProps.src}
             href={imgProps.location}
-            className="hover:bg-gradient-to-r hover:from-secondary hover:to-primary hover:text-primary-foreground hover:shadow-lg rounded-full"
+            className="hover:bg-gradient-to-r hover:from-secondary hover:to-primary hover:text-primary-foreground hover:shadow-lg rounded-full relative group"
           >
             <div className="flex justify-center bg-[rgb(241,239,237)] rounded-full hover:bg-[rgb(241,239,237)]/80">
               <img
                 {...imgProps}
                 className={cn("h-20 w-20 p-4 ", imgProps.className)}
               />
+            </div>
+
+            <div className="absolute z-50 px-3 py-2 text-sm text-white bg-smithy-black rounded-md shadow-md whitespace-nowrap top-full mt-2 left-1/2 transform -translate-x-1/2 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-opacity duration-200">
+              {imgProps.name}
+              <div className="absolute w-2 h-2 bg-smithy-black rotate-45 top-[-4px] left-1/2 -translate-x-1/2" />
             </div>
           </a>
         ))}


### PR DESCRIPTION
Improvement list:
- Update "Ecosystem" button to "Awesome Smithy" and its link
- Add hover tooltip for client and server circles
- Add max width for heading and sub-heading blocks
- Move "Quickstart" button from top navigation bar to heading block and rename "Get Started"
- Update "Get Started" button's redirect  URL
- Set Smithy documentation sidebar logo to redirect to current Smithy landing page
- Modify correct URL for TypeScript section

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
