### PR TITLE
Add guidance about Unknown members for unions

### DIFF
--- a/designs/defaults-and-model-evolution.md
+++ b/designs/defaults-and-model-evolution.md
@@ -359,7 +359,8 @@ an appropriate default value for the member:
 * enum, intEnum, union: The unknown variant. These types SHOULD define an
   unknown variant to account for receiving unknown members.
 * union: The unknown variant. Client code generators for unions SHOULD
-  define an unknown variant to account for newly added members.
+  define an unknown variant to account for newly added members. Union shape
+  members SHOULD NOT be named "Unknown" or "UnknownVariant" to avoid conflicts.
 * structure: an empty structure, if possible, otherwise a deserialization
   error.
 

--- a/docs/source-2.0/spec/aggregate-types.rst
+++ b/docs/source-2.0/spec/aggregate-types.rst
@@ -230,7 +230,8 @@ for the member:
 * list: []
 * map: {}
 * enum, intEnum, union: The unknown variant. These types SHOULD define an
-  unknown variant to account for receiving unknown members.
+  unknown variant to account for receiving unknown members. Union shape members
+  SHOULD NOT be named "Unknown" or "UnknownVariant" to avoid conflicts.
 * union: The unknown variant. Code generators for unions SHOULD define an
   unknown variant to account for newly added members.
 * structure: {} if possible, otherwise a deserialization error.


### PR DESCRIPTION
#### Background
Part of an action item from an internal ticket. An AWS service wanted to name one of their union members as "Unknown" and it conflicted with the Unknown sub-class that is generated. With this updated guidance, if clients SHOULD generate an Unknown union member, then similarly, the model SHOULD NOT have a shape name that can conflict with that.

#### Testing
None

#### Links
None

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
