### PR TITLE
Fix false positive for mixed in member removal warnings

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/transform/RemoveShapes.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/transform/RemoveShapes.java
@@ -73,7 +73,9 @@ final class RemoveShapes {
                                 memberShape.getMemberName())));
         for (ShapeId mixinId : container.getMixins()) {
             Shape mixinShape = model.expectShape(mixinId);
-            if (mixinShape.getMemberNames().contains(shape.getId().getMember().get())) {
+            // If the member is copied from a mixin and this mixin is not to be removed.
+            if (mixinShape.getMemberNames().contains(shape.getId().getMember().get())
+                    && !toRemove.contains(mixinShape)) {
                 LOGGER.warning(format("Removing mixed in member `%s` from mixin shape `%s` "
                         + "in `%s` will result in an inconsistent model.",
                         memberShape.getMemberName(),


### PR DESCRIPTION
#### Background
Add additional check to prevent false positive warning messages being produced when the mixin shape itself is also to be removed. eg., the execution of `getModelWithoutTraitShapes`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
