### PR TITLE
Rename `awslabs/smithy*` to `smithy-lang/smithy*`

### DIFF
--- a/.github/workflows/checkout-and-build-smithy/action.yml
+++ b/.github/workflows/checkout-and-build-smithy/action.yml
@@ -18,7 +18,7 @@ runs:
 
     - uses: actions/checkout@v4
       with:
-        repository: awslabs/smithy
+        repository: smithy-lang/smithy
         path: smithy
 
     - run: cd ./smithy && ./gradlew clean build publishToMavenLocal

--- a/.github/workflows/sdk-codegen-ci.yml
+++ b/.github/workflows/sdk-codegen-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout smithy-typescript
         uses: actions/checkout@v4
         with:
-          repository: awslabs/smithy-typescript
+          repository: smithy-lang/smithy-typescript
           path: smithy-typescript
 
       - name: Build smithy-typescript
@@ -105,7 +105,7 @@ jobs:
       - name: Checkout smithy-kotlin
         uses: actions/checkout@v4
         with:
-          repository: awslabs/smithy-kotlin
+          repository: smithy-lang/smithy-kotlin
           path: smithy-kotlin
 
       - name: Build smithy-kotlin
@@ -151,7 +151,7 @@ jobs:
       - name: Checkout smithy-swift
         uses: actions/checkout@v4
         with:
-          repository: awslabs/smithy-swift
+          repository: smithy-lang/smithy-swift
           path: Sources/SmithySwift/smithy-swift
 
       - name: Build smithy-swift
@@ -206,7 +206,7 @@ jobs:
       - name: Check out smithy-rs
         uses: actions/checkout@v4
         with:
-          repository: awslabs/smithy-rs
+          repository: smithy-lang/smithy-rs
           ref: main
           path: smithy-rs
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This library is licensed under the Apache 2.0 License.
 [specs]: https://smithy.io/2.0/spec/
 [javadocs]: https://smithy.io/javadoc/latest/
 [quickstart]: https://smithy.io/2.0/quickstart.html
-[Smithy Gradle Plugin]: https://github.com/awslabs/smithy-gradle-plugin/
+[Smithy Gradle Plugin]: https://github.com/smithy-lang/smithy-gradle-plugin/
 [Smithy CLI]: https://smithy.io/2.0/guides/smithy-cli/index.html
 [`smithy-build.json`]: https://smithy.io/2.0/guides/building-models/build-config.html#using-smithy-build-json
 [building]: https://smithy.io/2.0/guides/smithy-build-json.html

--- a/designs/defaults-and-model-evolution.md
+++ b/designs/defaults-and-model-evolution.md
@@ -816,4 +816,4 @@ different services.
 
 ### What are the `@input` and `@output` traits?
 
-See https://github.com/awslabs/smithy/blob/main/designs/operation-input-output-and-unit-types.md
+See https://github.com/smithy-lang/smithy/blob/main/designs/operation-input-output-and-unit-types.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ html_theme_options = {
     "footer_icons": [
         {
             "name": "GitHub",
-            "url": "https://github.com/awslabs/smithy",
+            "url": "https://github.com/smithy-lang/smithy",
             "html": """
                 <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16">
                     <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
@@ -54,7 +54,7 @@ html_theme_options = {
             "class": "",
         }
     ],
-    "source_repository": "https://github.com/awslabs/smithy/",
+    "source_repository": "https://github.com/smithy-lang/smithy/",
     "source_branch": "main",
     "sidebar_hide_name": True
 }

--- a/docs/source-2.0/guides/building-codegen/creating-codegen-repo.rst
+++ b/docs/source-2.0/guides/building-codegen/creating-codegen-repo.rst
@@ -22,12 +22,12 @@ Example codegen repositories
 
 Here are a few example Smithy codegen repos created by AWS:
 
-- https://github.com/awslabs/smithy-typescript
+- https://github.com/smithy-lang/smithy-typescript
 - https://github.com/aws/smithy-go
-- https://github.com/awslabs/smithy-rs
-- https://github.com/awslabs/smithy-ruby
-- https://github.com/awslabs/smithy-kotlin
-- https://github.com/awslabs/smithy-swift
+- https://github.com/smithy-lang/smithy-rs
+- https://github.com/smithy-lang/smithy-ruby
+- https://github.com/smithy-lang/smithy-kotlin
+- https://github.com/smithy-lang/smithy-swift
 
 
 Codegen repo layout
@@ -210,7 +210,7 @@ remote repository. You can add packages to Maven local using Gradle:
     ./gradlew :smithy-mylang-codegen:pTML
 
 If you need to use unreleased changes to
-`awslabs/smithy <https://github.com/smithy-lang/smithy>`__, then clone the
+`smithy-lang/smithy <https://github.com/smithy-lang/smithy>`__, then clone the
 repository and run:
 
 .. code-block:: none

--- a/docs/source-2.0/guides/building-codegen/decoupling-codegen-with-symbols.rst
+++ b/docs/source-2.0/guides/building-codegen/decoupling-codegen-with-symbols.rst
@@ -263,7 +263,7 @@ For example:
     1. The ``enum`` implements `SymbolDependencyContainer`_, an abstraction
        for composing dependencies.
     2. This example is taken from
-       `smithy-typescript <https://github.com/awslabs/smithy-typescript/blob/main/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java>`__,
+       `smithy-typescript <https://github.com/smithy-lang/smithy-typescript/blob/main/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptDependency.java>`__,
        which shows other possibilities like how to define unconditional
        dependencies that are needed by every client.
 
@@ -321,9 +321,9 @@ language are accounted for during codegen.
 A selection of existing ``SymbolProviders`` can be found at:
 
 1. TypeScript:
-   https://github.com/awslabs/smithy-typescript/blob/main/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
+   https://github.com/smithy-lang/smithy-typescript/blob/main/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/SymbolVisitor.java
 2. Python:
-   https://github.com/awslabs/smithy-python/blob/develop/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolVisitor.java
+   https://github.com/smithy-lang/smithy-python/blob/develop/codegen/smithy-python-codegen/src/main/java/software/amazon/smithy/python/codegen/SymbolVisitor.java
 3. Go:
    https://github.com/aws/smithy-go/blob/main/codegen/smithy-go-codegen/src/main/java/software/amazon/smithy/go/codegen/SymbolVisitor.java
 

--- a/docs/source-2.0/guides/building-codegen/mapping-shapes-to-languages.rst
+++ b/docs/source-2.0/guides/building-codegen/mapping-shapes-to-languages.rst
@@ -508,7 +508,7 @@ use a `TopologicalIndex <https://github.com/smithy-lang/smithy/blob/main/smithy-
 
 .. seealso::
 
-    `Rust design doc <https://github.com/awslabs/smithy-rs/blob/main/design/src/smithy/recursive_shapes.md>`__
+    `Rust design doc <https://github.com/smithy-lang/smithy-rs/blob/main/design/src/smithy/recursive_shapes.md>`__
     for how they handled recursive shapes.
 
 

--- a/docs/source-2.0/guides/building-codegen/overview-and-concepts.rst
+++ b/docs/source-2.0/guides/building-codegen/overview-and-concepts.rst
@@ -44,7 +44,7 @@ client using the ``foo-client-codegen`` plugin found on the classpath.
 
 .. seealso::
 
-   - `Smithy Gradle plugin <https://github.com/awslabs/smithy-gradle-plugin>`__
+   - `Smithy Gradle plugin <https://github.com/smithy-lang/smithy-gradle-plugin>`__
    - `DirectedCodegen <https://github.com/smithy-lang/smithy/blob/main/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/DirectedCodegen.java>`__
      to more easily implement codegen
    - :doc:`configuring-the-generator`
@@ -76,9 +76,9 @@ choices were made and leave a record for future contributors.
 Example Smithy codegen design documents:
 
 - https://smithy-lang.github.io/smithy-rs/design/
-- https://github.com/awslabs/smithy-kotlin/tree/main/docs/design
+- https://github.com/smithy-lang/smithy-kotlin/tree/main/docs/design
 - https://github.com/awslabs/aws-sdk-kotlin/tree/main/docs/design
-- https://github.com/awslabs/smithy-ruby/wiki
+- https://github.com/smithy-lang/smithy-ruby/wiki
 
 
 Phases of code generation

--- a/docs/source-2.0/guides/glossary.rst
+++ b/docs/source-2.0/guides/glossary.rst
@@ -31,7 +31,7 @@ Glossary
         `Gradle <https://gradle.org/>`__ is a build tool for Java, Kotlin, and
         other languages. Gradle is typically the build system used to develop
         Smithy code generators. The Smithy team
-        `maintains a Gradle plugin <https://github.com/awslabs/smithy-gradle-plugin>`__ for
+        `maintains a Gradle plugin <https://github.com/smithy-lang/smithy-gradle-plugin>`__ for
         running :term:`Smithy-Build` via Gradle.
 
     Integrations

--- a/docs/source-2.0/guides/gradle-plugin/gradle-migration-guide.rst
+++ b/docs/source-2.0/guides/gradle-plugin/gradle-migration-guide.rst
@@ -182,5 +182,5 @@ configure the ``smithyBuild`` task instead. Tasks that depended on
             -tasks["smithyBuildJar"].dependsOn("otherTask")
             +tasks["jar"].dependsOn("otherTask")
 
-.. _Smithy Gradle plugins: https://github.com/awslabs/smithy-gradle-plugin/
+.. _Smithy Gradle plugins: https://github.com/smithy-lang/smithy-gradle-plugin/
 .. _Configuration: https://docs.gradle.org/current/dsl/org.gradle.api.artifacts.Configuration.html

--- a/docs/source-2.0/guides/gradle-plugin/index.rst
+++ b/docs/source-2.0/guides/gradle-plugin/index.rst
@@ -748,8 +748,8 @@ the formatter by setting the format setting on the plugin extension to false:
             format = false
         }
 
-.. _examples directory: https://github.com/awslabs/smithy-gradle-plugin/tree/main/examples
-.. _Smithy Gradle plugins: https://github.com/awslabs/smithy-gradle-plugin/
+.. _examples directory: https://github.com/smithy-lang/smithy-gradle-plugin/tree/main/examples
+.. _Smithy Gradle plugins: https://github.com/smithy-lang/smithy-gradle-plugin/
 .. _Gradle: https://gradle.org/
 .. _smithy-base: https://github.com/smithy-lang/smithy-gradle-plugin#smithy-base-plugin
 .. _smithy-jar: https://github.com/smithy-lang/smithy-gradle-plugin#smithy-jar-plugin

--- a/docs/source-2.0/guides/model-translations/converting-to-openapi.rst
+++ b/docs/source-2.0/guides/model-translations/converting-to-openapi.rst
@@ -2221,7 +2221,7 @@ The conversion process is highly extensible through
 .. _x-amz-meta-* headers: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
 .. _Amazon API Gateway extensions: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions.html
 .. _service providers: https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html
-.. _Smithy Gradle plugin: https://github.com/awslabs/smithy-gradle-plugin
+.. _Smithy Gradle plugin: https://github.com/smithy-lang/smithy-gradle-plugin
 .. _x-amazon-apigateway-binary-media-types: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-binary-media-types.html
 .. _x-amazon-apigateway-request-validators: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validators.html
 .. _x-amazon-apigateway-request-validator: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-request-validator.html

--- a/docs/source-2.0/guides/model-translations/generating-cloudformation-resources.rst
+++ b/docs/source-2.0/guides/model-translations/generating-cloudformation-resources.rst
@@ -685,7 +685,7 @@ service providers. See the `Javadocs`_ for more information.
 .. _develop the resource provider: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-develop.html
 .. _CloudFormation Command Line Interface: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html
 .. _Smithy Resource: https://smithy.io/2.0/spec/service-types.html#resource
-.. _Smithy Gradle plugin: https://github.com/awslabs/smithy-gradle-plugin
+.. _Smithy Gradle plugin: https://github.com/smithy-lang/smithy-gradle-plugin
 .. _type name: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html#schema-properties-typeName
 .. _Javadocs: https://smithy.io/javadoc/__smithy_version__/software/amazon/smithy/aws/cloudformation/schema/fromsmithy/Smithy2CfnExtension.html
 .. _the handlers section: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-schema.html#schema-properties-handlers

--- a/docs/source-2.0/quickstart.rst
+++ b/docs/source-2.0/quickstart.rst
@@ -760,6 +760,6 @@ The complete ``weather.smithy`` model should look like:
         }
     }
 
-.. _examples directory: https://github.com/awslabs/smithy-gradle-plugin/tree/main/examples
-.. _Smithy Gradle Plugin: https://github.com/awslabs/smithy-gradle-plugin/
+.. _examples directory: https://github.com/smithy-lang/smithy-gradle-plugin/tree/main/examples
+.. _Smithy Gradle Plugin: https://github.com/smithy-lang/smithy-gradle-plugin/
 .. _gradle installed: https://gradle.org/install/

--- a/mkdocs
+++ b/mkdocs
@@ -25,7 +25,7 @@ fi
 
 # Clone a copy of smithy into a staging directory
 rm -rf /tmp/_smithy-docs
-git clone git@github.com:awslabs/smithy.git --branch gh-pages --single-branch /tmp/_smithy-docs
+git clone git@github.com:smithy-lang/smithy.git --branch gh-pages --single-branch /tmp/_smithy-docs
 cd /tmp/_smithy-docs
 git checkout gh-pages
 cd -

--- a/smithy-aws-protocol-tests/model/restXmlWithNamespace/main.smithy
+++ b/smithy-aws-protocol-tests/model/restXmlWithNamespace/main.smithy
@@ -16,7 +16,7 @@ use smithy.test#httpResponseTests
 /// in the `restXml` directory, but the service under test here has
 /// the `xmlNamespace` trait applied to it.
 ///
-/// See https://github.com/awslabs/smithy/issues/616
+/// See https://github.com/smithy-lang/smithy/issues/616
 @service(sdkId: "Rest Xml Protocol Namespace")
 @sigv4(name: "restxmlwithnamespace")
 @xmlNamespace(uri: "https://example.com")

--- a/smithy-build/README.md
+++ b/smithy-build/README.md
@@ -5,4 +5,4 @@ projections of a model, and generate build artifacts.
 
 
 - [Online documentation](https://smithy.io/2.0/guides/building-models/build-config.html)
-- [Documentation source](https://github.com/awslabs/smithy/blob/main/docs/source/guides/building-models/build-config.rst)
+- [Documentation source](https://github.com/smithy-lang/smithy/blob/main/docs/source/guides/building-models/build-config.rst)


### PR DESCRIPTION
#### Background
* Renames `awslabs/smithy*` to `smithy-lang/smithy*` outside of CHANGELOG and 1.0 docs
* The `smithy*` were moved from awslabs to smithy-lang

#### Testing
CI

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
