### PR TITLE
Ignore prettier4j 0.3.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "com.opencastsoftware:prettier4j"
+        versions: [ "0.3.1" ]


### PR DESCRIPTION
There's a regression in prettier4j that causes it to not wrap lines correctly. This makes dependabot ignore that version.

See:
https://github.com/smithy-lang/smithy/pull/2601

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
