### PR TITLE
Fix jsonName conversion for OpenAPI examples

### DIFF
--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java
@@ -112,7 +112,7 @@ abstract class AbstractRestProtocol<T extends Trait> implements OpenApiProtocol<
     @Deprecated
     Node transformSmithyValueToProtocolValue(Node value) {
         return value;
-    };
+    }
 
     /**
      * Converts Smithy values in Node form to a data exchange format used by a protocol (e.g., XML).

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1Protocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1Protocol.java
@@ -166,7 +166,7 @@ public final class AwsRestJson1Protocol extends AbstractRestProtocol<RestJson1Tr
     }
 
     @Override
-    Node transformSmithyValueToProtocolValue(Node value) {
+    Node transformSmithyValueToProtocolValue(Context<RestJson1Trait> context, Shape shape, Node value) {
         return value;
     }
 }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1Protocol.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AwsRestJson1Protocol.java
@@ -167,6 +167,6 @@ public final class AwsRestJson1Protocol extends AbstractRestProtocol<RestJson1Tr
 
     @Override
     Node transformSmithyValueToProtocolValue(Context<RestJson1Trait> context, Shape shape, Node value) {
-        return value;
+        return value.accept(new JsonValueNodeTransformer(context, shape));
     }
 }

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/JsonValueNodeTransformer.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/JsonValueNodeTransformer.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.openapi.fromsmithy.protocols;
+
+import java.util.Map;
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.BooleanNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NodeVisitor;
+import software.amazon.smithy.model.node.NullNode;
+import software.amazon.smithy.model.node.NumberNode;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.JsonNameTrait;
+import software.amazon.smithy.openapi.fromsmithy.Context;
+
+/**
+ * Applies the jsonName trait to a node value if applicable.
+ */
+public class JsonValueNodeTransformer implements NodeVisitor<Node> {
+    private final Context<?> context;
+    private final Shape shape;
+
+    /**
+     * Construct a JsonValueNodeTransformer.
+     *
+     * @param context Conversion context. Used to determine if jsonName should be used.
+     * @param shape The shape of the node being converted.
+     */
+    public JsonValueNodeTransformer(Context<?> context, Shape shape) {
+        this.context = context;
+        this.shape = shape;
+    }
+
+    @Override
+    public Node booleanNode(BooleanNode node) {
+        return node;
+    }
+
+    @Override
+    public Node nullNode(NullNode node) {
+        return node;
+    }
+
+    @Override
+    public Node numberNode(NumberNode node) {
+        return node;
+    }
+
+    @Override
+    public Node stringNode(StringNode node) {
+        return node;
+    }
+
+    @Override
+    public Node arrayNode(ArrayNode node) {
+        ArrayNode.Builder resultBuilder = ArrayNode.builder();
+        Shape listShape = shape.asMemberShape()
+                .map(m -> context.getModel().expectShape(m.getTarget()))
+                .orElse(shape);
+
+        Shape target = context.getModel().expectShape(listShape.asListShape().get().getMember().getTarget());
+        JsonValueNodeTransformer elementTransformer = new JsonValueNodeTransformer(context, target);
+        for (Node element : node.getElements()) {
+            resultBuilder.withValue(element.accept(elementTransformer));
+        }
+        return resultBuilder.build();
+    }
+
+    @Override
+    public Node objectNode(ObjectNode node) {
+        Shape actual = shape.asMemberShape()
+                .map(m -> context.getModel().expectShape(m.getTarget()))
+                .orElse(shape);
+
+        if (shape.isMapShape()) {
+            return mapNode(actual.asMapShape().get(), node);
+        }
+        return structuredNode(actual, node);
+    }
+
+    private Node structuredNode(Shape structure, ObjectNode node) {
+        ObjectNode.Builder resultBuilder = ObjectNode.builder();
+        for (Map.Entry<StringNode, Node> entry : node.getMembers().entrySet()) {
+            String key = entry.getKey().getValue();
+            if (structure.getMember(key).isPresent()) {
+                MemberShape member = structure.getMember(key).get();
+                Shape target = context.getModel().expectShape(member.getTarget());
+                JsonValueNodeTransformer entryTransformer = new JsonValueNodeTransformer(context, target);
+                resultBuilder.withMember(getKey(member), entry.getValue().accept(entryTransformer));
+            } else {
+                resultBuilder.withMember(key, entry.getValue());
+            }
+        }
+        return resultBuilder.build();
+    }
+
+    private String getKey(MemberShape member) {
+        if (!context.getJsonSchemaConverter().getConfig().getUseJsonName()) {
+            return member.getMemberName();
+        }
+        return member.getTrait(JsonNameTrait.class)
+                .map(JsonNameTrait::getValue)
+                .orElse(member.getMemberName());
+    }
+
+    private Node mapNode(MapShape map, ObjectNode node) {
+        ObjectNode.Builder resultBuilder = ObjectNode.builder();
+        Shape target = context.getModel().expectShape(map.getValue().getTarget());
+        JsonValueNodeTransformer entryTransformer = new JsonValueNodeTransformer(context, target);
+        for (Map.Entry<StringNode, Node> entry : node.getMembers().entrySet()) {
+            resultBuilder.withMember(entry.getKey(), entry.getValue().accept(entryTransformer));
+        }
+        return resultBuilder.build();
+    }
+}

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/examples-test.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/examples-test.openapi.json
@@ -149,7 +149,7 @@
                     "description": "withdrawTestDoc",
                     "value": {
                       "location": "Denver",
-                      "bankName": "Chase",
+                      "bank": "Chase",
                       "atmRecording": "dGVzdHZpZGVv"
                     }
                   }
@@ -470,7 +470,7 @@
           "location": {
             "type": "string"
           },
-          "bankName": {
+          "bank": {
             "type": "string"
           },
           "atmRecording": {

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/examples-test.smithy
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/examples-test.smithy
@@ -1,3 +1,5 @@
+$version: "2"
+
 namespace smithy.examplestrait
 
 use aws.protocols#restJson1
@@ -76,6 +78,7 @@ operation Withdraw {
 
         location: String
 
+        @jsonName("bank")
         bankName: String
 
         atmRecording: exampleVideo

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/examples-test.smithy
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/protocols/examples-test.smithy
@@ -4,56 +4,86 @@ use aws.protocols#restJson1
 
 @restJson1
 service Banking {
-    version: "2022-06-26",
-    operations: [Deposit, Withdraw]
+    version: "2022-06-26"
+    operations: [
+        Deposit
+        Withdraw
+    ]
 }
 
 @idempotent
 @http(method: "PUT", uri: "/account/{username}", code: 200)
 operation Deposit {
-    input: DepositInput,
-    output: DepositOutput,
-    errors: [InvalidUsername, InvalidAmount]
+    input := {
+        @httpHeader("accountNumber")
+        accountNumber: String
+
+        @required
+        @httpLabel
+        username: String
+
+        @httpQuery("accountHistory")
+        accountHistory: ExampleList
+
+        @httpPayload
+        depositAmount: String
+    }
+
+    output := {
+        @httpHeader("username")
+        username: String
+
+        @httpHeader("authenticationResult")
+        authenticationResult: ExampleList
+
+        textMessage: String
+
+        emailMessage: String
+    }
+
+    errors: [
+        InvalidUsername
+        InvalidAmount
+    ]
 }
 
 @idempotent
 @http(method: "PATCH", uri: "/account/withdraw", code: 200)
 operation Withdraw {
-    input: WithdrawInput,
-    output: WithdrawOutput,
-    errors: [InvalidUsername]
-}
+    input := {
+        @httpHeader("accountNumber")
+        accountNumber: String
 
-@input
-structure DepositInput {
-    @httpHeader("accountNumber")
-    accountNumber: String,
+        @httpHeader("username")
+        username: String
 
-    @required
-    @httpLabel
-    username: String,
+        @httpQueryParams
+        withdrawParams: ExampleMap
 
-    @httpQuery("accountHistory")
-    accountHistory: ExampleList,
+        time: date
 
-    @httpPayload
-    depositAmount: String
-}
+        withdrawAmount: String
 
-@input
-structure WithdrawInput {
-    @httpHeader("accountNumber")
-    accountNumber: String,
+        withdrawOption: String
+    }
 
-    @httpHeader("username")
-    username: String,
+    output := {
+        @httpHeader("branch")
+        branch: String
 
-    @httpQueryParams()
-    withdrawParams: ExampleMap,
+        @httpHeader("result")
+        accountHistory: ExampleList
 
-    time: date,
-    withdrawAmount: String,
-    withdrawOption: String
+        location: String
+
+        bankName: String
+
+        atmRecording: exampleVideo
+    }
+
+    errors: [
+        InvalidUsername
+    ]
 }
 
 list ExampleList {
@@ -61,7 +91,7 @@ list ExampleList {
 }
 
 map ExampleMap {
-    key: String,
+    key: String
     value: String
 }
 
@@ -71,35 +101,10 @@ blob exampleVideo
 @timestampFormat("http-date")
 timestamp date
 
-@output
-structure DepositOutput {
-    @httpHeader("username")
-    username: String,
-
-    @httpHeader("authenticationResult")
-    authenticationResult: ExampleList,
-
-    textMessage: String,
-    emailMessage: String
-}
-
-@output
-structure WithdrawOutput {
-    @httpHeader("branch")
-    branch: String,
-
-    @httpHeader("result")
-    accountHistory: ExampleList,
-
-    location: String,
-    bankName: String,
-    atmRecording: exampleVideo
-}
-
 @error("client")
 structure InvalidUsername {
     @httpHeader("internalErrorCode")
-    internalErrorCode: String,
+    internalErrorCode: String
 
     @httpPayload
     errorMessage: String
@@ -107,107 +112,90 @@ structure InvalidUsername {
 
 @error("server")
 structure InvalidAmount {
-    errorMessage1: String,
-    errorMessage2: String,
+    errorMessage1: String
+    errorMessage2: String
     errorMessage3: String
 }
 
-apply Deposit @examples(
-    [
-        {
-            title: "Deposit valid example",
-            documentation: "depositTestDoc",
-            input: {
-                accountNumber: "102935",
-                username: "sichanyoo",
-                accountHistory: ["10", "-25", "50"],
-                depositAmount: "200"
-            },
-            output: {
-                username: "sichanyoo",
-                authenticationResult: ["pass1", "pass2", "pass3"],
-                textMessage: "You deposited 200-text",
-                emailMessage: "You deposited 200-email"
-            },
-        },
-
-        {
-            title: "Deposit invalid username example",
-            documentation: "depositTestDoc2",
-            input: {
-                username: "sichanyoo",
-                accountHistory: ["-200", "200", "10"],
-                depositAmount: "-200"
-            },
-            error: {
-                shapeId: InvalidUsername,
-                content: {
-                    internalErrorCode: "4gsw2-34",
-                    errorMessage: "ERROR: Invalid username."
-                }
-            },
-        },
-
-        {
-            title: "Deposit invalid amount example",
-            documentation: "depositTestDoc3",
-            input: {
-                accountNumber: "203952",
-                username: "obidos",
-                accountHistory: ["2000", "50000", "100"],
-                depositAmount: "-100"
-            },
-            error: {
-                shapeId: InvalidAmount,
-                content: {
-                    errorMessage1: "ERROR: Invalid amount.",
-                    errorMessage2: "2gdx4-34",
-                    errorMessage3: "2gcbe-98"
-                }
-            },
+apply Deposit @examples([
+    {
+        title: "Deposit valid example"
+        documentation: "depositTestDoc"
+        input: {
+            accountNumber: "102935"
+            username: "sichanyoo"
+            accountHistory: ["10", "-25", "50"]
+            depositAmount: "200"
         }
-    ]
-)
-
-apply Withdraw @examples(
-    [
-        {
-            title: "Withdraw valid example",
-            documentation: "withdrawTestDoc",
-            input: {
-                accountNumber: "124634",
-                username: "amazon",
-                withdrawParams: {"location" : "Denver", "bankName" : "Chase"},
-                time: "Tue, 29 Apr 2014 18:30:38 GMT",
-                withdrawAmount: "-35",
-                withdrawOption: "ATM"
-            },
-            output: {
-                branch: "Denver-203",
-                accountHistory: ["34", "5", "-250"],
-                location: "Denver",
-                bankName: "Chase",
-                atmRecording: "dGVzdHZpZGVv"
-            },
-        },
-
-        {
-            title: "Withdraw invalid username example",
-            documentation: "withdrawTestDoc2",
-            input: {
-                accountNumber: "231565",
-                username: "peccy",
-                withdrawParams: {"location" : "Seoul", "bankName" : "Chase"},
-                withdrawAmount: "-450",
-                withdrawOption: "Venmo"
-            },
-            error: {
-                shapeId: InvalidUsername,
-                content: {
-                    internalErrorCode: "8dfws-21",
-                    errorMessage: "ERROR: Invalid username."
-                }
-            },
+        output: {
+            username: "sichanyoo"
+            authenticationResult: ["pass1", "pass2", "pass3"]
+            textMessage: "You deposited 200-text"
+            emailMessage: "You deposited 200-email"
         }
-    ]
-)
+    }
+    {
+        title: "Deposit invalid username example"
+        documentation: "depositTestDoc2"
+        input: {
+            username: "sichanyoo"
+            accountHistory: ["-200", "200", "10"]
+            depositAmount: "-200"
+        }
+        error: {
+            shapeId: InvalidUsername
+            content: { internalErrorCode: "4gsw2-34", errorMessage: "ERROR: Invalid username." }
+        }
+    }
+    {
+        title: "Deposit invalid amount example"
+        documentation: "depositTestDoc3"
+        input: {
+            accountNumber: "203952"
+            username: "obidos"
+            accountHistory: ["2000", "50000", "100"]
+            depositAmount: "-100"
+        }
+        error: {
+            shapeId: InvalidAmount
+            content: { errorMessage1: "ERROR: Invalid amount.", errorMessage2: "2gdx4-34", errorMessage3: "2gcbe-98" }
+        }
+    }
+])
+
+apply Withdraw @examples([
+    {
+        title: "Withdraw valid example"
+        documentation: "withdrawTestDoc"
+        input: {
+            accountNumber: "124634"
+            username: "amazon"
+            withdrawParams: { location: "Denver", bankName: "Chase" }
+            time: "Tue, 29 Apr 2014 18:30:38 GMT"
+            withdrawAmount: "-35"
+            withdrawOption: "ATM"
+        }
+        output: {
+            branch: "Denver-203"
+            accountHistory: ["34", "5", "-250"]
+            location: "Denver"
+            bankName: "Chase"
+            atmRecording: "dGVzdHZpZGVv"
+        }
+    }
+    {
+        title: "Withdraw invalid username example"
+        documentation: "withdrawTestDoc2"
+        input: {
+            accountNumber: "231565"
+            username: "peccy"
+            withdrawParams: { location: "Seoul", bankName: "Chase" }
+            withdrawAmount: "-450"
+            withdrawOption: "Venmo"
+        }
+        error: {
+            shapeId: InvalidUsername
+            content: { internalErrorCode: "8dfws-21", errorMessage: "ERROR: Invalid username." }
+        }
+    }
+])


### PR DESCRIPTION
When converting to OpenAPI for the restJson1 protocol, we convert member names if they have the jsonName trait. However, we were *not* converting those member names in examples. This updates example conversion to respect member name, if present and enabled.

Fixes #2659

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
