### PR TITLE
Node null check fix

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/NullableIndex.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/knowledge/NullableIndex.java
@@ -179,8 +179,9 @@ public class NullableIndex implements KnowledgeIndex {
                 }
                 // fall-through.
             case LIST:
-                // Map values and list members are only null if they have the @sparse trait.
-                return container.hasTrait(SparseTrait.ID);
+                // Map values and list members are only null if they have the @sparse trait
+                // OR if the target is a Document since Document can hold a null value
+                return container.hasTrait(SparseTrait.ID) || target.isDocumentShape();
             default:
                 return false;
         }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
@@ -674,6 +674,24 @@ public class NodeValidationVisitorTest {
                 containsString(
                         "a: Non-sparse map shape `ns.foo#Map` cannot contain null values"));
     }
+    
+    @Test
+    public void nullNonSparseDocumentMapValue() {
+        // This should not raise any errors since null is a valid Document value
+        ObjectNode map = ObjectNode.builder()
+                .withMember("a", Node.nullNode())
+                .build();
+        NodeValidationVisitor visitor = NodeValidationVisitor.builder()
+                .value(map)
+                .model(MODEL)
+                .allowOptionalNull(true)
+                .build();
+        List<ValidationEvent> events = MODEL
+                .expectShape(ShapeId.from("ns.foo#DocumentMap"))
+                .accept(visitor);
+
+        assertThat(events, hasSize(0));
+    }
 
     @Test
     public void nullSparseMapValue() {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/validation/node-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/validation/node-validator.json
@@ -109,8 +109,14 @@
             "type": "string",
             "traits": {
                 "smithy.api#enum": [
-                    {"value": "foo", "name": "FOO"},
-                    {"value": "bar", "name": "BAR"}
+                    {
+                        "value": "foo",
+                        "name": "FOO"
+                    },
+                    {
+                        "value": "bar",
+                        "name": "BAR"
+                    }
                 ]
             }
         },
@@ -205,6 +211,15 @@
             },
             "traits": {
                 "smithy.api#sparse": {}
+            }
+        },
+        "ns.foo#DocumentMap": {
+            "type": "map",
+            "key": {
+                "target": "ns.foo#KeyString"
+            },
+            "value": {
+                "target": "smithy.api#Document"
             }
         },
         "ns.foo#Structure": {

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/validation/node-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/validation/node-validator.json
@@ -109,14 +109,8 @@
             "type": "string",
             "traits": {
                 "smithy.api#enum": [
-                    {
-                        "value": "foo",
-                        "name": "FOO"
-                    },
-                    {
-                        "value": "bar",
-                        "name": "BAR"
-                    }
+                    {"value": "foo", "name": "FOO"},
+                    {"value": "bar", "name": "BAR"}
                 ]
             }
         },


### PR DESCRIPTION
#### Background
* What do these changes do? 
Updates such that the node validator will not raise a false-positive related to a Document value being null.
* Why are they important?
Currently causing an error to flag in one of our projects where a trait has a `Map` shape with a target type of `Document`.

#### Testing
* How did you test these changes?
See unit test included.

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
