### PR TITLE
Trait codegen: less restrictive namespace check

### DIFF
--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/TraitCodegenSettings.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/TraitCodegenSettings.java
@@ -55,8 +55,8 @@ public final class TraitCodegenSettings {
     ) {
         this.packageName = Objects.requireNonNull(packageName);
         this.smithyNamespace = Objects.requireNonNull(smithyNamespace);
-        if (smithyNamespace.startsWith(SMITHY_API_NAMESPACE)) {
-            throw new IllegalArgumentException("The `smithy` namespace is reserved.");
+        if (smithyNamespace.equals(SMITHY_API_NAMESPACE) || smithyNamespace.startsWith(SMITHY_API_NAMESPACE + ".")) {
+            throw new IllegalArgumentException("The `smithy` namespace and its sub-namespaces are reserved.");
         }
         this.headerLines = Objects.requireNonNull(headerLines);
         this.excludeTags = Objects.requireNonNull(excludeTags);


### PR DESCRIPTION
Allow namespaces like `smithy4s`, but not `smithy` or `smithy.api` or other sub-`smithy` namespaces.


#### Background
* What do these changes do? 
* Why are they important?

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
