### PR TITLE
Add ASM to the relocated dependencies

### DIFF
--- a/smithy-cli/build.gradle.kts
+++ b/smithy-cli/build.gradle.kts
@@ -191,6 +191,7 @@ tasks {
         relocate("org.apache", "software.amazon.smithy.cli.shaded.apache")
         relocate("org.sonatype", "software.amazon.smithy.cli.shaded.sonatype")
         relocate("org.codehaus", "software.amazon.smithy.cli.shaded.codehaus")
+        relocate("org.objectweb", "software.amazon.smithy.cli.shaded.objectweb")
 
         // If other javax packages are ever pulled in, we'll need to update this list. This is more deliberate about
         // what's shaded to ensure that things like javax.net.ssl.SSLSocketFactory are not inadvertently shaded.


### PR DESCRIPTION
Maven now has a dependency on it. This change adds it to the relocated dependencies to avoid runtime conflicts with other consumers of the library.


#### Background
* What do these changes do? 
* Why are they important?

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
