### PR TITLE
Add model discovery args to smithy select

### DIFF
--- a/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
+++ b/smithy-cli/src/main/java/software/amazon/smithy/cli/commands/SelectCommand.java
@@ -62,6 +62,7 @@ final class SelectCommand implements Command {
     @Override
     public int execute(Arguments arguments, Env env) {
         arguments.addReceiver(new ConfigOptions());
+        arguments.addReceiver(new DiscoveryOptions());
         arguments.addReceiver(new BuildOptions());
         arguments.addReceiver(new Options());
 


### PR DESCRIPTION
The gradle plugin's select isn't very useful without being able to pass along the classpath gradle is responsible for producing.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
