### PR TITLE
Use the correct operation name in the URI

### DIFF
--- a/smithy-aws-protocol-tests/model/rpcv2Cbor/non-query-compatible.smithy
+++ b/smithy-aws-protocol-tests/model/rpcv2Cbor/non-query-compatible.smithy
@@ -26,7 +26,7 @@ service NonQueryCompatibleRpcV2Protocol {
         method: "POST"
         headers: { "smithy-protocol": "rpc-v2-cbor", Accept: "application/cbor" }
         forbidHeaders: ["x-amzn-query-mode"]
-        uri: "/service/NonQueryCompatibleRpcV2Protocol/operation/QueryIncompatibleOperation"
+        uri: "/service/NonQueryCompatibleRpcV2Protocol/operation/NonQueryCompatibleOperation"
         body: ""
     }
 ])


### PR DESCRIPTION
#### Background

Last change to the test changed the operation name to keep consistency with the rests of the naming but missed updating the URI of the request as well. This change fixes that.

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
