### PR TITLE
Fix incorrect property name in protocol tests' body

### DIFF
--- a/smithy-aws-protocol-tests/model/awsJson1_0/query-compatible.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/query-compatible.smithy
@@ -51,7 +51,7 @@ structure NoCustomCodeError {
 
 apply NoCustomCodeError @httpResponseTests([
     {
-        id: "QueryCompatibleAwsJson10CborNoCustomCodeError"
+        id: "QueryCompatibleAwsJson10NoCustomCodeError"
         documentation: "Parses simple errors with no query error code"
         protocol: awsJson1_0
         params: { message: "Hi" }

--- a/smithy-aws-protocol-tests/model/awsJson1_0/query-compatible.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/query-compatible.smithy
@@ -60,7 +60,7 @@ apply NoCustomCodeError @httpResponseTests([
         body: """
             {
                 "__type": "aws.protocoltests.json10#NoCustomCodeError",
-                "Message": "Hi"
+                "message": "Hi"
             }"""
         bodyMediaType: "application/json"
         vendorParamsShape: ErrorCodeParams
@@ -85,7 +85,7 @@ apply CustomCodeError @httpResponseTests([
         body: """
             {
                 "__type": "aws.protocoltests.json10#CustomCodeError",
-                "Message": "Hi"
+                "message": "Hi"
             }"""
         bodyMediaType: "application/json"
         vendorParamsShape: ErrorCodeParams

--- a/smithy-aws-protocol-tests/model/rpcv2Cbor/query-compatible.smithy
+++ b/smithy-aws-protocol-tests/model/rpcv2Cbor/query-compatible.smithy
@@ -59,7 +59,7 @@ apply NoCustomCodeError @httpResponseTests([
         params: { message: "Hi" }
         code: 400
         headers: { "smithy-protocol": "rpc-v2-cbor", "Content-Type": "application/cbor" }
-        body: "uQACZl9fdHlwZXgtYXdzLnByb3RvY29sdGVzdHMucnBjdjJjYm9yI05vQ3VzdG9tQ29kZUVycm9yZ01lc3NhZ2ViSGk="
+        body: "uQACZl9fdHlwZXgtYXdzLnByb3RvY29sdGVzdHMucnBjdjJjYm9yI05vQ3VzdG9tQ29kZUVycm9yZ21lc3NhZ2ViSGk="
         bodyMediaType: "application/cbor"
         vendorParamsShape: ErrorCodeParams
         vendorParams: { code: "NoCustomCodeError" }
@@ -80,7 +80,7 @@ apply CustomCodeError @httpResponseTests([
         params: { message: "Hi" }
         code: 400
         headers: { "smithy-protocol": "rpc-v2-cbor", "Content-Type": "application/cbor", "x-amzn-query-error": "Customized;Sender" }
-        body: "uQACZl9fdHlwZXgrYXdzLnByb3RvY29sdGVzdHMucnBjdjJjYm9yI0N1c3RvbUNvZGVFcnJvcmdNZXNzYWdlYkhp"
+        body: "uQACZl9fdHlwZXgrYXdzLnByb3RvY29sdGVzdHMucnBjdjJjYm9yI0N1c3RvbUNvZGVFcnJvcmdtZXNzYWdlYkhp"
         bodyMediaType: "application/cbor"
         vendorParamsShape: ErrorCodeParams
         vendorParams: { code: "Customized", type: "Sender" }


### PR DESCRIPTION
#### Background
The original property name `"Message"` is causing problem in protocol tests due to name mismatch , so we change this name to `"message"` in this PR.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
