### PR TITLE
Add max retry and retry delay setting to JReleaser

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,8 @@ configure<JReleaserExtension> {
                     active = Active.ALWAYS
                     url = "https://central.sonatype.com/api/v1/publisher"
                     stagingRepository(stagingDir().get().asFile.path)
+                    maxRetries = 100
+                    retryDelay = 60
                 }
             }
         }


### PR DESCRIPTION
#### Background
Add `maxRetries` and `retryDelay` to JReleaser to remedy timeout issues during Maven Central publishing.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
