### PR TITLE
Add additional properties to OpenApiConfig

### DIFF
--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiConfig.java
@@ -98,6 +98,7 @@ public class OpenApiConfig extends JsonSchemaConfig {
     private boolean syncCorsPreflightIntegration = false;
     private ErrorStatusConflictHandlingStrategy onErrorStatusConflict;
     private OpenApiVersion version = OpenApiVersion.VERSION_3_0_2;
+    private Map<String, String> additionalProperties = Collections.emptyMap();
 
     public OpenApiConfig() {
         super();
@@ -373,6 +374,18 @@ public class OpenApiConfig extends JsonSchemaConfig {
      */
     public void setOnErrorStatusConflict(ErrorStatusConflictHandlingStrategy onErrorStatusConflict) {
         this.onErrorStatusConflict = Objects.requireNonNull(onErrorStatusConflict);
+    }
+
+    public Map<String, String> getAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    /**
+     * Sets additional non-standard config properties that might be used by other components
+     * @param additionalProperties Map of additional properties
+     */
+    public void setAdditionalProperties(Map<String, String> additionalProperties) {
+        this.additionalProperties = additionalProperties;
     }
 
     /**


### PR DESCRIPTION
#### Background
* The `JsonSchemaMapper` and `OpenApiMapper` have access to `OpenApiConfig`. In some cases (see related [smithy4s PR](github.com/disneystreaming/alloy/pull/224)), there is a need to pass additional information to such mappers. This PR adds `Map<String, String> additionalProperties` field to enable that

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
