### PR TITLE
Remove restriction on Smithy API namespace to use trait-codegen

### DIFF
--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/TraitCodegenSettings.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/TraitCodegenSettings.java
@@ -29,7 +29,6 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
  */
 @SmithyUnstableApi
 public final class TraitCodegenSettings {
-    private static final String SMITHY_API_NAMESPACE = "smithy";
 
     private final String packageName;
     private final String smithyNamespace;
@@ -55,9 +54,6 @@ public final class TraitCodegenSettings {
     ) {
         this.packageName = Objects.requireNonNull(packageName);
         this.smithyNamespace = Objects.requireNonNull(smithyNamespace);
-        if (smithyNamespace.equals(SMITHY_API_NAMESPACE) || smithyNamespace.startsWith(SMITHY_API_NAMESPACE + ".")) {
-            throw new IllegalArgumentException("The `smithy` namespace and its sub-namespaces are reserved.");
-        }
         this.headerLines = Objects.requireNonNull(headerLines);
         this.excludeTags = Objects.requireNonNull(excludeTags);
     }


### PR DESCRIPTION
#### Background
We are planning to add new traits under the `smithy.*` namespace and want to use the `trait-codegen` plugin to generate classes for the same.  Having this settings restriction does not allow us to use the `trait-codegen` for defining our own traits in `smithy.*` namespace.

So we discussed internally and decided to remove the restriction on using `smithy.*` namespace.



#### Testing
* How did you test these changes?

`./gradlew build`


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
