### PR TITLE
Return the specific type of the trait as other protocols do

### DIFF
--- a/smithy-protocol-traits/src/main/java/software/amazon/smithy/protocol/traits/Rpcv2CborTrait.java
+++ b/smithy-protocol-traits/src/main/java/software/amazon/smithy/protocol/traits/Rpcv2CborTrait.java
@@ -140,7 +140,7 @@ public final class Rpcv2CborTrait extends AbstractTrait implements ToSmithyBuild
         }
 
         @Override
-        public Trait createTrait(ShapeId target, Node value) {
+        public Rpcv2CborTrait createTrait(ShapeId target, Node value) {
             Rpcv2CborTrait result = fromNode(value);
             result.setNodeCache(value);
             return result;


### PR DESCRIPTION
Smithy Java expected to be able to create traits using the provider with the specific type (Rpcv2CborTrait in this case) instead of having to cast it. Other protocol traits for AWS work this way.


#### Background
* What do these changes do? 
* Why are they important?

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
