### PR TITLE
Backport previous releases into changelog format

### DIFF
--- a/.changes/releases/0.9.3.json
+++ b/.changes/releases/0.9.3.json
@@ -1,0 +1,118 @@
+{
+  "version": "0.9.3",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Clean up `CodeWriter` modifiers",
+      "pull_requests": [
+        "[#143](https://github.com/awslabs/smithy/pull/143)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add typed `ObjectNode` member expectation functions",
+      "pull_requests": [
+        "[#144](https://github.com/awslabs/smithy/pull/144)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add `expectShapeId` for fully-qualified shape ID",
+      "pull_requests": [
+        "[#147](https://github.com/awslabs/smithy/pull/147)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add helper to `EnumTrait` to check if it has names",
+      "pull_requests": [
+        "[#148](https://github.com/awslabs/smithy/pull/148)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add `Symbol` references",
+      "pull_requests": [
+        "[#149](https://github.com/awslabs/smithy/pull/149)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add `ReservedWords` builder for simpler construction",
+      "pull_requests": [
+        "[#150](https://github.com/awslabs/smithy/pull/150)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Allow using path expressions in paginator outputs",
+      "pull_requests": [
+        "[#152](https://github.com/awslabs/smithy/pull/152)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add method to get non-trait shapes",
+      "pull_requests": [
+        "[#153](https://github.com/awslabs/smithy/pull/153)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add method to write class resource to manifest",
+      "pull_requests": [
+        "[#157](https://github.com/awslabs/smithy/pull/157)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Allow `authType` to be specified",
+      "pull_requests": [
+        "[#160](https://github.com/awslabs/smithy/pull/160)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix collection and gradle doc issues",
+      "pull_requests": [
+        "[#145](https://github.com/awslabs/smithy/pull/145)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Make `AuthorizerDefinition` definition private",
+      "pull_requests": [
+        "[#146](https://github.com/awslabs/smithy/pull/146)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix put handling on `ResourceShape`",
+      "pull_requests": [
+        "[#158](https://github.com/awslabs/smithy/pull/158)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix parse error when `apply` is at eof",
+      "pull_requests": [
+        "[#159](https://github.com/awslabs/smithy/pull/159)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Prevent `list`/`set` member from targeting container",
+      "pull_requests": [
+        "[#162](https://github.com/awslabs/smithy/pull/162)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Allow model assembling from symlink model files / directory",
+      "pull_requests": [
+        "[#163](https://github.com/awslabs/smithy/pull/163)"
+      ]
+    }
+  ],
+  "date": "2019-09-16"
+}

--- a/.changes/releases/0.9.4.json
+++ b/.changes/releases/0.9.4.json
@@ -1,0 +1,90 @@
+{
+  "version": "0.9.4",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Add support for AWS Client Endpoint Discovery",
+      "pull_requests": [
+        "[#165](https://github.com/awslabs/smithy/pull/165)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Refactor event streams to target members",
+      "pull_requests": [
+        "[#171](https://github.com/awslabs/smithy/pull/171)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add support for aliasing referenced `Symbol`s",
+      "pull_requests": [
+        "[#168](https://github.com/awslabs/smithy/pull/168)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add support for `Symbol`s to introduce dependencies",
+      "pull_requests": [
+        "[#169](https://github.com/awslabs/smithy/pull/169)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add ability to manually escape reserved words in `ReservedWordSymbolProvider`",
+      "pull_requests": [
+        "[#174](https://github.com/awslabs/smithy/pull/174)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add method to gather dependencies for `Symbol`s",
+      "pull_requests": [
+        "[#170](https://github.com/awslabs/smithy/pull/170)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add a caching `SymbolProvider`",
+      "pull_requests": [
+        "[#167](https://github.com/awslabs/smithy/pull/167)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improve the usability of `CodeWroter#openBlock`",
+      "pull_requests": [
+        "[#175](https://github.com/awslabs/smithy/pull/175)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improve the usability of `PluginContext`",
+      "pull_requests": [
+        "[#181](https://github.com/awslabs/smithy/pull/181)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Disable URLConnection cache in CLI",
+      "pull_requests": [
+        "[#180](https://github.com/awslabs/smithy/pull/180)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix issue with generated authentication for CORS checks",
+      "pull_requests": [
+        "[#179](https://github.com/awslabs/smithy/pull/179)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Set the `defaultTimestampFormat` to `epoch-seconds` for `aws.rest-json`\nprotocols in OpenAPI",
+      "pull_requests": [
+        "[#184](https://github.com/awslabs/smithy/pull/184)"
+      ]
+    }
+  ],
+  "date": "2019-10-09"
+}

--- a/.changes/releases/0.9.5.json
+++ b/.changes/releases/0.9.5.json
@@ -1,0 +1,76 @@
+{
+  "version": "0.9.5",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Allow overriding state management in CodeWriter",
+      "pull_requests": [
+        "[#186](https://github.com/awslabs/smithy/pull/186)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Allow the `xmlFlattened` trait to be applied to members",
+      "pull_requests": [
+        "[#191](https://github.com/awslabs/smithy/pull/191)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add helper to determine HTTP-based timestamp formats",
+      "pull_requests": [
+        "[#193](https://github.com/awslabs/smithy/pull/193)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Allow specifying XML namespace prefixes",
+      "pull_requests": [
+        "[#195](https://github.com/awslabs/smithy/pull/195)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add `SymbolContainer`, an abstraction over `Symbol`s that enables easily\ncreating and aggregating `Symbols`",
+      "pull_requests": [
+        "[#202](https://github.com/awslabs/smithy/pull/202)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Escape popped state content",
+      "pull_requests": [
+        "[#187](https://github.com/awslabs/smithy/pull/187)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Make shape ID serialization consistent",
+      "pull_requests": [
+        "[#196](https://github.com/awslabs/smithy/pull/196)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Exclude private members targeted in JSON schema converters",
+      "pull_requests": [
+        "[#199](https://github.com/awslabs/smithy/pull/199)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix naming collisions in JSON schema output",
+      "pull_requests": [
+        "[#200](https://github.com/awslabs/smithy/pull/200)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Update `equals` to included typed bag parents",
+      "pull_requests": [
+        "[#201](https://github.com/awslabs/smithy/pull/201)"
+      ]
+    }
+  ],
+  "date": "2019-11-11"
+}

--- a/.changes/releases/0.9.6.json
+++ b/.changes/releases/0.9.6.json
@@ -1,0 +1,118 @@
+{
+  "version": "0.9.6",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Allow XML maps to be flattened",
+      "pull_requests": [
+        "[#205](https://github.com/awslabs/smithy/pull/205)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add and remove shape members to model automatically",
+      "pull_requests": [
+        "[#206](https://github.com/awslabs/smithy/pull/206)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Deprecate ShapeIndex in favor of Model",
+      "pull_requests": [
+        "[#209](https://github.com/awslabs/smithy/pull/209)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Allow the sensitive trait to be applied to all but operations, services, and\nresources",
+      "pull_requests": [
+        "[#212](https://github.com/awslabs/smithy/pull/212)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added 0.5.0 IDL and AST format",
+      "pull_requests": [
+        "[#213](https://github.com/awslabs/smithy/pull/213)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Allow min to equal max in range trait",
+      "pull_requests": [
+        "[#216](https://github.com/awslabs/smithy/pull/216)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation for length trait values",
+      "pull_requests": [
+        "[#217](https://github.com/awslabs/smithy/pull/217)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Limit streaming trait to top-level members",
+      "pull_requests": [
+        "[#221](https://github.com/awslabs/smithy/pull/221)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol compliance test traits",
+      "pull_requests": [
+        "[#226](https://github.com/awslabs/smithy/pull/226)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added ability to configure timestamp validation",
+      "pull_requests": [
+        "[#229](https://github.com/awslabs/smithy/pull/229)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Moved `TemplateEngine` implementation into FreeMarker implementation",
+      "pull_requests": [
+        "[#230](https://github.com/awslabs/smithy/pull/230)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `BoxIndex`",
+      "pull_requests": [
+        "[#234](https://github.com/awslabs/smithy/pull/234)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added more expect methods to `Shape` and `Model`",
+      "pull_requests": [
+        "[#237](https://github.com/awslabs/smithy/pull/237)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Update smithy-build to be streaming",
+      "pull_requests": [
+        "[#211](https://github.com/awslabs/smithy/pull/211)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Prevent bad list, set, and map recursion",
+      "pull_requests": [
+        "[#204](https://github.com/awslabs/smithy/pull/204)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Properly allow omitting endpoint discovery operation inputs",
+      "pull_requests": [
+        "[#220](https://github.com/awslabs/smithy/pull/220)"
+      ]
+    }
+  ],
+  "date": "2020-01-02"
+}

--- a/.changes/releases/0.9.7.json
+++ b/.changes/releases/0.9.7.json
@@ -1,0 +1,52 @@
+{
+  "version": "0.9.7",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Updated Operation syntax in the Smithy IDL",
+      "pull_requests": [
+        "[#253](https://github.com/awslabs/smithy/pull/253)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated specification for XML traits",
+      "pull_requests": [
+        "[#242](https://github.com/awslabs/smithy/pull/242)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add the `@aws.api#ec2QueryName-trait` trait",
+      "pull_requests": [
+        "[#251](https://github.com/awslabs/smithy/pull/251)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add AWS protocol test models",
+      "pull_requests": [
+        "[#246](https://github.com/awslabs/smithy/pull/246)",
+        "[#247](https://github.com/awslabs/smithy/pull/247)",
+        "[#250](https://github.com/awslabs/smithy/pull/250)",
+        "[#255](https://github.com/awslabs/smithy/pull/255)",
+        "[#258](https://github.com/awslabs/smithy/pull/258)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Use URLConnection cache setting in ModelAssembler",
+      "pull_requests": [
+        "[#244](https://github.com/awslabs/smithy/pull/244)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Use list of string for queryParams in the `httpRequestTests` trait",
+      "pull_requests": [
+        "[#240](https://github.com/awslabs/smithy/pull/240)"
+      ]
+    }
+  ],
+  "date": "2020-01-15"
+}

--- a/.changes/releases/0.9.8.json
+++ b/.changes/releases/0.9.8.json
@@ -1,0 +1,105 @@
+{
+  "version": "0.9.8",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Add `RenameShapes` model transformer",
+      "pull_requests": [
+        "[#318](https://github.com/awslabs/smithy/pull/318)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Build `ValidationEvents` are now sorted",
+      "pull_requests": [
+        "[#263](https://github.com/awslabs/smithy/pull/263)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Smithy CLI logging improvements",
+      "pull_requests": [
+        "[#263](https://github.com/awslabs/smithy/pull/263)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Model builds fail early when syntax errors occur",
+      "pull_requests": [
+        "[#264](https://github.com/awslabs/smithy/pull/264)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Warn when a deprecated trait is applied to a shape",
+      "pull_requests": [
+        "[#279](https://github.com/awslabs/smithy/pull/279)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix behavior of `schemaDocumentExtensions` when converting to OpenAPI",
+      "pull_requests": [
+        "[#320](https://github.com/awslabs/smithy/pull/320)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix discrepancies in `smithy-aws-protocol-tests`",
+      "pull_requests": [
+        "[#309](https://github.com/awslabs/smithy/pull/309)",
+        "[#321](https://github.com/awslabs/smithy/pull/321)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Properly format test case results",
+      "pull_requests": [
+        "[#271](https://github.com/awslabs/smithy/pull/271)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix dropping one character text block lines",
+      "pull_requests": [
+        "[#285](https://github.com/awslabs/smithy/pull/285)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Builds run parallel projections in parallel only if there are more than one",
+      "pull_requests": [
+        "[#263](https://github.com/awslabs/smithy/pull/263)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Run Smithy test suites as parameterized tests",
+      "pull_requests": [
+        "[#263](https://github.com/awslabs/smithy/pull/263)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Migrate protocol tests to new operation syntax",
+      "pull_requests": [
+        "[#260](https://github.com/awslabs/smithy/pull/260)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Build protocol tests with the Smithy Gradle plugin",
+      "pull_requests": [
+        "[#263](https://github.com/awslabs/smithy/pull/263)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Deprecate using explicitly `smithy.api` for trait removal",
+      "pull_requests": [
+        "[#306](https://github.com/awslabs/smithy/pull/306)"
+      ]
+    }
+  ],
+  "date": "2020-03-26"
+}

--- a/.changes/releases/0.9.9.json
+++ b/.changes/releases/0.9.9.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.9.9",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Add security to individual operations in OpenAPI conversion",
+      "pull_requests": [
+        "[#329](https://github.com/awslabs/smithy/pull/329)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix an issue with header casing for `x-api-key` integration with API Gateway",
+      "pull_requests": [
+        "[#330](https://github.com/awslabs/smithy/pull/330)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix discrepancies in `smithy-aws-protocol-tests`",
+      "pull_requests": [
+        "[#333](https://github.com/awslabs/smithy/pull/333)",
+        "[#335](https://github.com/awslabs/smithy/pull/335)",
+        "[#349](https://github.com/awslabs/smithy/pull/349)"
+      ]
+    }
+  ],
+  "date": "2020-04-01"
+}

--- a/.changes/releases/1.0.0.md
+++ b/.changes/releases/1.0.0.md
@@ -1,0 +1,271 @@
+## 1.0.0 (2020-05-04)
+
+***Note***: Changes marked with "[BC]" are breaking changes more accurately
+described in the specific section. A list of further intended breaking changes
+have a specific section near the end of this entry.
+
+### Features
+
+#### General
+
+- The model format version has been updated to `1.0` and contains several
+  updates: [BC] ([#357](https://github.com/awslabs/smithy/pull/357),
+  [#381](https://github.com/awslabs/smithy/pull/381))
+  - The JSON AST representation requires describing annotation traits as `{}`
+    instead of `true`.
+  - Annotation traits in the IDL are now provided as `@foo` or `@foo()`.
+    Explicit `@foo(true)` and `@foo(null)` support was removed.
+- Smithy models can now be serialized to the IDL.
+  ([#284](https://github.com/awslabs/smithy/pull/284))
+- Added a Node-based object mapper to simplify the process of building and using
+  Java components from Smithy `Node`s.
+  ([#301](https://github.com/awslabs/smithy/pull/301))
+  - Many packages have seen significant updates to use this functionality.
+    ([#305](https://github.com/awslabs/smithy/pull/305),
+    [#364](https://github.com/awslabs/smithy/pull/364))
+- Made error messages clearer when encountering duplicate shapes.
+  ([#324](https://github.com/awslabs/smithy/pull/324))
+- Model loaders now warn on additional shape properties instead of fail.
+  ([#374](https://github.com/awslabs/smithy/pull/374))
+- Added expect\* methods to the base `Shape`.
+  ([#314](https://github.com/awslabs/smithy/pull/314))
+- Added `@SmithyUnstableApi`, `@SmithyInternalApi` and `@SmithyGenerated` Java
+  annotations. ([#297](https://github.com/awslabs/smithy/pull/297))
+- `NodeValidationVisitor`s are marked as internal and/or unstable.
+  ([#375](https://github.com/awslabs/smithy/pull/375))
+- The `$version` control statement can now be set to only a major version (e.g.,
+  "1") to indicate that an implementation must support a version >= 1 and < 2.
+  `$version` can now be set to `major.minor` (e.g., "1.1") to indicate that an
+  implementation must support a version >= 1.1 and < 2.
+
+#### Trait updates
+
+- Individual protocols are now defined as individual traits that are annotated
+  with
+  [the `protocolDefinition` trait.](https://smithy.io/2.0/spec/protocol-traits.html#protocoldefinition-trait)
+  [BC] ([#273](https://github.com/awslabs/smithy/pull/273),
+  [#280](https://github.com/awslabs/smithy/pull/280),
+  [#379](https://github.com/awslabs/smithy/pull/379),
+  [#390](https://github.com/awslabs/smithy/pull/390))
+  - Previously listed
+    [AWS protocols now have trait implementations.](https://smithy.io/2.0/aws/index.html#aws-protocols)
+- Individual authentication schemes are now defined as individual traits that
+  are annotated with
+  [the `authDefinition` trait.](https://smithy.io/2.0/spec/authentication-traits.html#authdefinition-trait)
+  [BC] ([#273](https://github.com/awslabs/smithy/pull/273),
+  [#280](https://github.com/awslabs/smithy/pull/280))
+  - Previously listed
+    [authentication schemes now have trait implementations.](https://smithy.io/2.0/spec/authentication-traits.html)
+- The `smithy.api#enum` trait is now a list of enum definitions instead of a map
+  of string keys to enum definitions to improve clarity and encourage adding
+  more properties to definitions. [BC]
+  ([#326](https://github.com/awslabs/smithy/pull/326))
+- The `aws.api#streaming` trait is now applied to shapes directly instead of
+  members. [BC] ([#340](https://github.com/awslabs/smithy/pull/340))
+- The `smithy.api#eventStream` trait has been removed. Event streams are now
+  indicated by applying the `smithy.api#streaming` trait to unions. [BC]
+  ([#365](https://github.com/awslabs/smithy/pull/365))
+- The `smithy.api#requiresLength` trait has been split out of the
+  `smithy.api#streaming` trait to improve clarity around event stream modeling.
+  [BC] ([#368](https://github.com/awslabs/smithy/pull/368))
+- The `smithy.api#externalDocumentation` trait is now a map instead of a single
+  string to allow for multiple links per trait. [BC]
+  ([#363](https://github.com/awslabs/smithy/pull/363))
+- Added the `smithy.api#noReplace` trait to indicate a PUT lifecycle operation
+  cannot replace the existing resource.
+  ([#351](https://github.com/awslabs/smithy/pull/351))
+- Added the `smithy.api#unstable` trait to indicate a shape MAY change.
+  ([#290](https://github.com/awslabs/smithy/pull/290))
+- Simplified `aws.api#unsignedPayload` to be an annotation. [BC]
+  ([#270](https://github.com/awslabs/smithy/pull/270))
+- Annotation traits are now lossless when loaded with additional properties,
+  meaning they will contain those properties when serialized.
+  ([#385](https://github.com/awslabs/smithy/pull/385))
+
+#### Selector updates
+
+Selectors have received significant updates:
+([#388](https://github.com/awslabs/smithy/pull/388))
+
+- Attribute selectors can now evaluate scoped comparisons using `@foo:` to
+  define a scope and `@{bar}` to define a context value.
+  ([#391](https://github.com/awslabs/smithy/pull/391))
+- And logic, via `&&`, has been added to allow multiple attribute comparisons.
+  ([#391](https://github.com/awslabs/smithy/pull/391))
+- Support for selecting nested trait properties with `|`, including list/object
+  values and object keys, was added.
+- An opt-in `trait` relationship has been added.
+  ([#384](https://github.com/awslabs/smithy/pull/384))
+- The recursive neighbor selector, `~>`, has been added.
+  ([#386](https://github.com/awslabs/smithy/pull/386))
+- A not equal comparison, `!=`, was added.
+- An exists comparison, `?=`, was added.
+  ([#391](https://github.com/awslabs/smithy/pull/391))
+- Support for numbers in attribute selectors was added.
+- Numeric comparisons (`>`, `>=`, `<`, `<=`) were added.
+- The `(length)` function property was added.
+  ([#391](https://github.com/awslabs/smithy/pull/391))
+- Attribute selectors now support CSV values, allowing matching on one or more
+  target values.
+- The `:each` selector is now `:is` for clarity. [BC]
+- The `:of` selector is now removed. Use reverse neighbors instead (e.g.,
+  `member :test(< structure)`). [BC]
+- The semantics of the `:not` selector have changed significantly.
+  `:not(list > member > string)` now means "do not match list shapes that target
+  strings", whereas this previously meant, "do not match string shapes targeted
+  by lists". [BC]
+- Shape IDs with members must now be quoted. [BC]
+- Selector parsing and evaluating now tolerates unknown relationship types.
+  ([#377](https://github.com/awslabs/smithy/pull/377))
+
+#### Validation updates
+
+- Services must now contain a closure of shapes that have case-insensitively
+  unique names. [BC] ([#337](https://github.com/awslabs/smithy/pull/337))
+- `suppressions` has been updated to now only suppress validation events that
+  occur for an entire namespace or across the entire model. The `@suppress`
+  trait was added to suppress validation events for a specific shape. [BC]
+  ([#397](https://github.com/awslabs/smithy/pull/397)).
+- The `UnreferencedShape` validator has moved to `smithy-model` and is now
+  always run. [BC] ([#319](https://github.com/awslabs/smithy/pull/319))
+- `EmitEachSelector` and `EmitNoneSelector` were moved from `smithy-linters`
+  into `smithy-model`.
+
+#### JSON Schema conversion
+
+The conversion to JSON schema was significantly overhauled. [BC]
+([#274](https://github.com/awslabs/smithy/pull/274))
+
+- Configuration for the build plugin was significantly overhauled. [BC]
+  ([#364](https://github.com/awslabs/smithy/pull/364))
+- The strategy for shape inlining has been changed. [BC]
+- The strategy for naming shapes and handling shape id conflicts has been
+  changed. [BC]
+- Output schema error detection was improved.
+- The Java API surface has been reduced. [BC]
+- Added the ability to select schemas from a document using a JSON pointer.
+
+#### OpenAPI conversion
+
+The conversion to OpenAPI was significantly overhauled. [BC]
+([#275](https://github.com/awslabs/smithy/pull/275))
+
+- Configuration for the build plugin was significantly overhauled. [BC]
+  ([#364](https://github.com/awslabs/smithy/pull/364))
+- Protocol conversion was updated to utilize the new traits.
+  ([#275](https://github.com/awslabs/smithy/pull/275),
+  [#392](https://github.com/awslabs/smithy/pull/392))
+- Schemas are now generated for requests and responses instead of being inlined.
+  [BC]
+- Fixed several issues with CORS integrations.
+
+#### API Gateway OpenAPI conversion
+
+The API Gateway specific OpenAPI mappers have been updated. [BC]
+([#367](https://github.com/awslabs/smithy/pull/367))
+
+- The `ApiGatewayMapper` interface was added, allowing mappers to control which
+  API Gateway API type(s) they support.
+- Fixed several issues with CORS integrations.
+  ([#370](https://github.com/awslabs/smithy/pull/370))
+- Added support for JSON Patch-like OpenAPI schema changes based on JSON
+  Pointers. ([#293](https://github.com/awslabs/smithy/pull/293))
+- Added support for event streams in OpenAPI conversion.
+  ([#334](https://github.com/awslabs/smithy/pull/334))
+
+### Bug Fixes
+
+- Fixed an issue in JSON schema conversion where member traits were dropped in
+  some scenarios. ([#274](https://github.com/awslabs/smithy/pull/274))
+- Fixed an issue where authorization headers were not properly added to CORS
+  configurations. ([#328](https://github.com/awslabs/smithy/pull/328))
+- Fixed an issue where operation response headers were being applied to error
+  responses in OpenAPI conversions.
+  ([#275](https://github.com/awslabs/smithy/pull/275))
+- Fixed an issue where `apply` statements wouldn't resolve target shapes
+  properly in some cases. ([#287](https://github.com/awslabs/smithy/pull/287))
+- Fixed an issue with the selector for the `smithy.api#title` trait.
+  ([#387](https://github.com/awslabs/smithy/pull/387))
+- Fixed several issues with the `smithy.api#httpApiKeyAuth` trait and its
+  related conversions. ([#291](https://github.com/awslabs/smithy/pull/291))
+- Fixed a bug with timestamp validation in specific versions of Java.
+  ([#316](https://github.com/awslabs/smithy/pull/316))
+
+### Optimizations
+
+- The `TraitTargetValidator` now performs as few checks on and selections of the
+  entire model. ([#389](https://github.com/awslabs/smithy/pull/389))
+- The dependency on `jackson-core` was replaced with a vendored version of
+  `minimal-json` to reduce the chances of dependency conflicts. [BC]
+  ([#323](https://github.com/awslabs/smithy/pull/323))
+- Sped up model loading time by loading JSON models before IDL models to reduce
+  forward reference lookups.
+  ([#287](https://github.com/awslabs/smithy/pull/287))
+
+### Breaking changes
+
+- The `BooleanTrait` abstract class in `smithy-model` was renamed
+  `AnnotationTrait`. ([#381](https://github.com/awslabs/smithy/pull/381))
+- The traits in the `aws.apigateway` namespace have moved from
+  `smithy-aws-traits` to the `smithy-aws-apigateway-traits` package for more
+  granular use. ([#322](https://github.com/awslabs/smithy/pull/322))
+  - Tooling that referenced these traits has also been updated.
+- The traits in the `aws.iam` namespace have moved from `smithy-aws-traits` to
+  the `smithy-aws-iam-traits` package for more granular use.
+  ([#322](https://github.com/awslabs/smithy/pull/322))
+  - Tooling that referenced these traits has also been updated.
+- The `aws.api#ec2QueryName` trait has moved to `aws.protocols#ec2QueryName`.
+  ([#286](https://github.com/awslabs/smithy/pull/286))
+- The `aws.api#unsignedPayload ` trait has moved to `aws.auth#unsignedPayload `.
+  ([#286](https://github.com/awslabs/smithy/pull/286))
+- The `smithy-codegen-freemarker` package has been removed.
+  ([#382](https://github.com/awslabs/smithy/pull/382))
+- Traits can no longer be applied to public Smithy Prelude shapes.
+  ([#317](https://github.com/awslabs/smithy/pull/317))
+- Smithy's `Pattern` class is renamed to `SmithyPattern` to remove the conflict
+  with Java's regex `Pattern` class.
+  ([#315](https://github.com/awslabs/smithy/pull/315))
+- Removed the `Triple` class from `smithy-utils`.
+  ([#313](https://github.com/awslabs/smithy/pull/313))
+- Normalized class names for OpenAPI `SecurityScemeConverter` implementations.
+  ([#291](https://github.com/awslabs/smithy/pull/291))
+- Removed alias functionality from
+  `software.amazon.smithy.build.SmithyBuildPlugin` and
+  `software.amazon.smithy.build.ProjectionTransformer`.
+  ([#409](https://github.com/awslabs/smithy/pull/409))
+- Removed `software.amazon.smithy.model.shapes.Shape#visitor` and
+  `software.amazon.smithy.model.shapes.ShapeVisitor$Builder`. Use
+  `software.amazon.smithy.model.shapes.ShapeVisitor$Default` instead.
+  ([#413](https://github.com/awslabs/smithy/pull/413))
+- `software.amazon.smithy.model.Model#getTraitDefinitions` and `getTraitShapes`
+  were removed in favor of
+  `software.amazon.smithy.model.Model#getShapesWithTrait`.
+  ([#412](https://github.com/awslabs/smithy/pull/412))
+
+#### Deprecation cleanup
+
+- The deprecated IDL operation syntax has been removed
+  ([#373](https://github.com/awslabs/smithy/pull/373))
+- The deprecated `NodeFactory` interface has been removed.
+  ([#265](https://github.com/awslabs/smithy/pull/265))
+- The deprecated `ShapeIndex` class and all related APIs have been removed.
+  ([#266](https://github.com/awslabs/smithy/pull/266))
+- Support for the deprecated `0.4.0` model version has been removed.
+  ([#267](https://github.com/awslabs/smithy/pull/267))
+- The `aws.api#service` trait no longer supports the deprecated `sdkServiceId`,
+  `arnService`, or `productName` properties.
+  ([#268](https://github.com/awslabs/smithy/pull/268))
+- The deprecated `TemplateEngine` and `DefaultDataTemplateEngine` have been
+  removed. ([#268](https://github.com/awslabs/smithy/pull/268))
+- The deprecated `smithy.validators` and `smithy.suppressions` are no longer
+  used as aliases for validators and suppressions.
+  ([#268](https://github.com/awslabs/smithy/pull/268))
+- The `smithy.api#references` and `smithy.api#idRef` traits no longer support
+  relative shape IDs. ([#268](https://github.com/awslabs/smithy/pull/268))
+
+### Documentation
+
+A significant overhaul of the specification and guides has been completed. This
+includes a better flow to the spec, more complete guides, deeper documentation
+of AWS specific components, and a complete redesign. Many direct links to
+components of the documentation will have changed.

--- a/.changes/releases/1.0.1.json
+++ b/.changes/releases/1.0.1.json
@@ -1,0 +1,76 @@
+{
+  "version": "1.0.1",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "The `smithy.api#httpPayload` trait can now target document shapes.",
+      "pull_requests": [
+        "[#431](https://github.com/awslabs/smithy/pull/431)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated the IDL grammar to include many previously enforced parsing rules.",
+      "pull_requests": [
+        "[#434](https://github.com/awslabs/smithy/pull/434)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `select` command to the CLI to print out shapes from a model that\nmatch a selector.",
+      "pull_requests": [
+        "[#430](https://github.com/awslabs/smithy/pull/430)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `ast` command to the CLI to convert 0 or more Smithy models into a\nJSON AST.",
+      "pull_requests": [
+        "[#435](https://github.com/awslabs/smithy/pull/435)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a Dockerfile for building Smithy as a Docker image.",
+      "pull_requests": [
+        "[#427](https://github.com/awslabs/smithy/pull/427)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix several ambiguities and issues in the IDL grammar.",
+      "pull_requests": [
+        "[#434](https://github.com/awslabs/smithy/pull/434)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "JSON pretty printing of the AST now uses 4 spaces for indentation.",
+      "pull_requests": [
+        "[#435](https://github.com/awslabs/smithy/pull/435)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix CLI `--help` output alignment.",
+      "pull_requests": [
+        "[#429](https://github.com/awslabs/smithy/pull/429)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "The Smithy IDL parser has been rewritten and optimized.",
+      "pull_requests": [
+        "[#434](https://github.com/awslabs/smithy/pull/434)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Generate a class data share to speed up the CLI.",
+      "pull_requests": [
+        "[#429](https://github.com/awslabs/smithy/pull/429)"
+      ]
+    }
+  ],
+  "date": "2020-05-13"
+}

--- a/.changes/releases/1.0.10.json
+++ b/.changes/releases/1.0.10.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.0.10",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added a validation event when a syntactic shape ID is found that does not\ntarget an actual shape in the model.",
+      "pull_requests": [
+        "[#542](https://github.com/awslabs/smithy/pull/542)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug where forward reference resolution would use the incorrect\nnamespace when resolving operation and resource bindings.",
+      "pull_requests": [
+        "[#543](https://github.com/awslabs/smithy/pull/543)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Deprecated the reflection-based creation pattern for `KnowledgeIndex`\nimplementations.",
+      "pull_requests": [
+        "[#541](https://github.com/awslabs/smithy/pull/541)"
+      ]
+    }
+  ],
+  "date": "2020-08-26"
+}

--- a/.changes/releases/1.0.11.json
+++ b/.changes/releases/1.0.11.json
@@ -1,0 +1,77 @@
+{
+  "version": "1.0.11",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added a reverse-topological knowledge index to aid in code generation for\nlanguages that require types to be defined before they are referenced.",
+      "pull_requests": [
+        "[#545](https://github.com/awslabs/smithy/pull/545)",
+        "[#53](https://github.com/awslabs/smithy/pull/553)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `@httpResponseCode` trait to indicate that a structure member\nrepresents an HTTP response status code.",
+      "pull_requests": [
+        "[#546](https://github.com/awslabs/smithy/pull/546)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added (unstable) support for generating a \"Trace File\" to link code generated\nartifacts back to their modeled source.",
+      "pull_requests": [
+        "[#552](https://github.com/awslabs/smithy/pull/552)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `:topdown` selector that matches shapes hierarchically.",
+      "pull_requests": [
+        "[#539](https://github.com/awslabs/smithy/pull/539)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation for the `cloudTrailEventSource` property of the\n`@aws.api#service` trait.",
+      "pull_requests": [
+        "[#550](https://github.com/awslabs/smithy/pull/550)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated shape builders to properly update their member ShapeIds if the ShapeId\nof the builder changes.",
+      "pull_requests": [
+        "[#556](https://github.com/awslabs/smithy/pull/556)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added several more XML related protocol tests.",
+      "pull_requests": [
+        "[#547](https://github.com/awslabs/smithy/pull/547)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug where the `PaginatedIndex` did not properly support resolving\npaths.",
+      "pull_requests": [
+        "[#554](https://github.com/awslabs/smithy/pull/554)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified the documentation for the `cloudTrailEventSource` property of the\n`@aws.api#service` trait.",
+      "pull_requests": [
+        "[#550](https://github.com/awslabs/smithy/pull/550)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified that the `@aws.api#arn` trait has no impact on OpenAPI conversions.",
+      "pull_requests": [
+        "[#555](https://github.com/awslabs/smithy/pull/555)"
+      ]
+    }
+  ],
+  "date": "2020-09-10"
+}

--- a/.changes/releases/1.0.2.json
+++ b/.changes/releases/1.0.2.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0.2",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Fix an issue that would squash exceptions thrown for invalid suppressions.",
+      "pull_requests": [
+        "[#440](https://github.com/awslabs/smithy/pull/440)"
+      ]
+    }
+  ],
+  "date": "2020-05-18"
+}

--- a/.changes/releases/1.0.3.json
+++ b/.changes/releases/1.0.3.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0.3",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Prevent parsing overly deep Node values",
+      "pull_requests": [
+        "[#442](https://github.com/awslabs/smithy/pull/442)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix an issue with the OpenAPI conversion where synthesized structure inputs\nreference required properties that were removed.",
+      "pull_requests": [
+        "[#443](https://github.com/awslabs/smithy/pull/443)"
+      ]
+    }
+  ],
+  "date": "2020-05-26"
+}

--- a/.changes/releases/1.0.4.json
+++ b/.changes/releases/1.0.4.json
@@ -1,0 +1,42 @@
+{
+  "version": "1.0.4",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Ensure that when a property is removed from a JSON schema object, that a\ncorresponding \"required\" entry is also removed.",
+      "pull_requests": [
+        "[#452](https://github.com/awslabs/smithy/pull/452)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the (unstable) `@httpChecksumRequired` trait to indicate an operation\nrequires a checksum in its HTTP request.",
+      "pull_requests": [
+        "[#433](https://github.com/awslabs/smithy/pull/433)",
+        "[#453](https://github.com/awslabs/smithy/pull/453)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug in OpenApi conversion where removing authentication for an\noperation would result in the operation inheriting the global \"security\"\nconfiguration instead of having it set to none.",
+      "pull_requests": [
+        "[#451](https://github.com/awslabs/smithy/pull/451/)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added examples of building models to various guides.",
+      "pull_requests": [
+        "[#449](https://github.com/awslabs/smithy/pull/449)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed various documentation issues.",
+      "pull_requests": [
+        "[#449](https://github.com/awslabs/smithy/pull/449)"
+      ]
+    }
+  ],
+  "date": "2020-05-29"
+}

--- a/.changes/releases/1.0.5.json
+++ b/.changes/releases/1.0.5.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.0.5",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug in loading IDL files where resolving a forward reference that\nneeded another forward reference would throw an exception.",
+      "pull_requests": [
+        "[#458](https://github.com/awslabs/smithy/pull/458)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug where smithy-build imports were not resolved relative to their\n`smithy-build.json`.",
+      "pull_requests": [
+        "[#457](https://github.com/awslabs/smithy/pull/457)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug where the `PREFIX_HEADERS` HTTP binding location would not default\nits timestamp format to `HTTP_DATE`.",
+      "pull_requests": [
+        "[#456](https://github.com/awslabs/smithy/pull/456)"
+      ]
+    }
+  ],
+  "date": "2020-06-05"
+}

--- a/.changes/releases/1.0.6.json
+++ b/.changes/releases/1.0.6.json
@@ -1,0 +1,69 @@
+{
+  "version": "1.0.6",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Update `structure` and `union` shapes so member order is maintained as part of\nthe contract.",
+      "pull_requests": [
+        "[#465](https://github.com/awslabs/smithy/pull/465)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add validation for `document` types in protocols.",
+      "pull_requests": [
+        "[#474](https://github.com/awslabs/smithy/pull/474)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Provide suggestions for invalid Shape ID targets if a close match is found.",
+      "pull_requests": [
+        "[#466](https://github.com/awslabs/smithy/pull/466)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added message templates and trait binding to the `EmitEachSelector`.",
+      "pull_requests": [
+        "[#467](https://github.com/awslabs/smithy/pull/467)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added ability to add traits directly to the `ModelAssembler`.",
+      "pull_requests": [
+        "[#470](https://github.com/awslabs/smithy/pull/470)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Convert `awsJson1_1` protocol tests to Smithy IDL.",
+      "pull_requests": [
+        "[#472](https://github.com/awslabs/smithy/pull/472)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Update decimal values in protocol tests.",
+      "pull_requests": [
+        "[#471](https://github.com/awslabs/smithy/pull/471)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Update quick start guide with more examples.",
+      "pull_requests": [
+        "[#462](https://github.com/awslabs/smithy/pull/462)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed issues allowing `document` types in `@httpHeader` and\n`@httpPrefixHeaders` traits.",
+      "pull_requests": [
+        "[#474](https://github.com/awslabs/smithy/pull/474)"
+      ]
+    }
+  ],
+  "date": "2020-06-24"
+}

--- a/.changes/releases/1.0.7.json
+++ b/.changes/releases/1.0.7.json
@@ -1,0 +1,102 @@
+{
+  "version": "1.0.7",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Use the `@title` trait to improve generated documentation for JSON Schema\nunions that use `\"oneOf\"`.",
+      "pull_requests": [
+        "[#485](https://github.com/awslabs/smithy/pull/485)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added and updated several protocol tests for `restJson1`.",
+      "pull_requests": [
+        "[#490](https://github.com/awslabs/smithy/pull/490)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added and updated several protocol tests for `awsJson1_1`.",
+      "pull_requests": [
+        "[#484](https://github.com/awslabs/smithy/pull/484)",
+        "[#493](https://github.com/awslabs/smithy/pull/493)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol tests for `awsJson1_0`.",
+      "pull_requests": [
+        "[#496](https://github.com/awslabs/smithy/pull/496)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug where `passthroughBehavior` was misspelled as\n`passThroughBehavior` in APIGateway OpenAPI output for integrations and mock\nintegrations.",
+      "pull_requests": [
+        "[#495](https://github.com/awslabs/smithy/pull/495)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug where only the last line in a multiline doc comment on a member\nwould be successfully parsed.",
+      "pull_requests": [
+        "[#498](https://github.com/awslabs/smithy/pull/498)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed several issues in protocol tests.",
+      "pull_requests": [
+        "[#473](https://github.com/awslabs/smithy/pull/473)",
+        "[#476](https://github.com/awslabs/smithy/pull/476)",
+        "[#481](https://github.com/awslabs/smithy/pull/481)",
+        "[#491](https://github.com/awslabs/smithy/pull/491)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Refactored the specification to better explain the semantic model and its\nrepresentations.",
+      "pull_requests": [
+        "[#497](https://github.com/awslabs/smithy/pull/497)",
+        "[#482](https://github.com/awslabs/smithy/pull/482)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified guidance on using `@mediaType`.",
+      "pull_requests": [
+        "[#500](https://github.com/awslabs/smithy/pull/500)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Removed outdated namespace guidance.",
+      "pull_requests": [
+        "[#487](https://github.com/awslabs/smithy/pull/487)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed several minor issues.",
+      "pull_requests": [
+        "[#494](https://github.com/awslabs/smithy/pull/494)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Disallowed problematic identifiers misusing `_`.",
+      "pull_requests": [
+        "[#499](https://github.com/awslabs/smithy/pull/499)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Moved validation of members with the `@httpLabel` trait being marked required\nto the selector.",
+      "pull_requests": [
+        "[#480](https://github.com/awslabs/smithy/pull/480)"
+      ]
+    }
+  ],
+  "date": "2020-07-16"
+}

--- a/.changes/releases/1.0.8.json
+++ b/.changes/releases/1.0.8.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0.8",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Updated `Walker` to provide a stable sort for shapes.",
+      "pull_requests": [
+        "[#511](https://github.com/awslabs/smithy/pull/511)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved support for loading `ValidationEvent`s via `NodeMapper`.",
+      "pull_requests": [
+        "[#518](https://github.com/awslabs/smithy/pull/518)",
+        "[#516](https://github.com/awslabs/smithy/pull/516)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the ability to `disableFromNode` via `NodeMapper`.",
+      "pull_requests": [
+        "[#505](https://github.com/awslabs/smithy/pull/505)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed several issues in protocol tests.",
+      "pull_requests": [
+        "[#502](https://github.com/awslabs/smithy/pull/502)",
+        "[#507](https://github.com/awslabs/smithy/pull/507)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Stopped raising validation errors and running validation with `RenameShapes`\ntransformer.",
+      "pull_requests": [
+        "[#512](https://github.com/awslabs/smithy/pull/512)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Simplified conflict handling for shapes.",
+      "pull_requests": [
+        "[#514](https://github.com/awslabs/smithy/pull/514)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Simplified duplicate member detection and handling.",
+      "pull_requests": [
+        "[#513](https://github.com/awslabs/smithy/pull/513)"
+      ]
+    }
+  ],
+  "date": "2020-07-31"
+}

--- a/.changes/releases/1.0.9.json
+++ b/.changes/releases/1.0.9.json
@@ -1,0 +1,105 @@
+{
+  "version": "1.0.9",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Allow conflicting shape definitions if the fully built shapes are equivalent.",
+      "pull_requests": [
+        "[#520](https://github.com/awslabs/smithy/pull/520)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `@internal` trait to the prelude.",
+      "pull_requests": [
+        "[#531](https://github.com/awslabs/smithy/pull/531)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `excludeShapesByTrait` build transform that will remove any shapes\nmarked with one or more of the specified traits.",
+      "pull_requests": [
+        "[#531](https://github.com/awslabs/smithy/pull/531)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved support for newlines and indentation in `CodeWriter`.",
+      "pull_requests": [
+        "[#529](https://github.com/awslabs/smithy/pull/529)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for configuring the expression starting character in\n`CodeWriter`.",
+      "pull_requests": [
+        "[#529](https://github.com/awslabs/smithy/pull/529)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `payloadFormatVersion` property for API Gateway integrations.",
+      "pull_requests": [
+        "[#527](https://github.com/awslabs/smithy/pull/527)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add `deprecated` property to operations when converting to OpenAPI.",
+      "pull_requests": [
+        "[#535](https://github.com/awslabs/smithy/pull/535)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added several more protocol tests.",
+      "pull_requests": [
+        "[#528](https://github.com/awslabs/smithy/pull/528)",
+        "[#536](https://github.com/awslabs/smithy/pull/536)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed the selector for the `@httpQuery` trait.",
+      "pull_requests": [
+        "[#534](https://github.com/awslabs/smithy/pull/534)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed the selector for the `@httpPrefixHeaders` trait.",
+      "pull_requests": [
+        "[#533](https://github.com/awslabs/smithy/pull/533)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed some issues in protocol tests.",
+      "pull_requests": [
+        "[#526](https://github.com/awslabs/smithy/pull/526)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Removed the `abbreviation` property from the `@aws.api#service` trait.",
+      "pull_requests": [
+        "[#532](https://github.com/awslabs/smithy/pull/532)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Simplified prelude model loading.",
+      "pull_requests": [
+        "[#524](https://github.com/awslabs/smithy/pull/524)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Further simplified overall model loading.",
+      "pull_requests": [
+        "[#525](https://github.com/awslabs/smithy/pull/525)"
+      ]
+    }
+  ],
+  "date": "2020-08-21"
+}

--- a/.changes/releases/1.1.0.json
+++ b/.changes/releases/1.1.0.json
@@ -1,0 +1,56 @@
+{
+  "version": "1.1.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added the `removeTraitDefinitions` build transform to remove trait definitions\nfrom models but leave instances intact.",
+      "pull_requests": [
+        "[#558](https://github.com/awslabs/smithy/pull/558)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added payload binding validation to HTTP `DELETE` operations.",
+      "pull_requests": [
+        "[#566](https://github.com/awslabs/smithy/pull/566)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated `SmithyDiff` to emit events when traits are changed.",
+      "pull_requests": [
+        "[#561](https://github.com/awslabs/smithy/pull/561)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where some `StringListTrait` instances could lose\n`SourceLocation` information.",
+      "pull_requests": [
+        "[#564](https://github.com/awslabs/smithy/pull/564)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed some issues in protocol tests.",
+      "pull_requests": [
+        "[#560](https://github.com/awslabs/smithy/pull/560)",
+        "[#563](https://github.com/awslabs/smithy/pull/563)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Model components are now deduplicated based on location and value.",
+      "pull_requests": [
+        "[#565](https://github.com/awslabs/smithy/pull/565)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Normalize URL import filenames for better deduplication and reporting.",
+      "pull_requests": [
+        "[#562](https://github.com/awslabs/smithy/pull/562)"
+      ]
+    }
+  ],
+  "date": "2020-09-16"
+}

--- a/.changes/releases/1.10.0.json
+++ b/.changes/releases/1.10.0.json
@@ -1,0 +1,72 @@
+{
+  "version": "1.10.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Loosened the requirement of setting an `error` property when configuring\n`aws.api#clientEndpointDiscovery` trait.",
+      "pull_requests": [
+        "[#850](https://github.com/awslabs/smithy/pull/850)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a `restJson1` protocol test.",
+      "pull_requests": [
+        "[#845](https://github.com/awslabs/smithy/pull/845)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a warning when using the OpenAPI conversion `jsonAdd` setting to alter\nschemas.",
+      "pull_requests": [
+        "[#851](https://github.com/awslabs/smithy/pull/851)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `httpChecksum` trait.",
+      "pull_requests": [
+        "[#843](https://github.com/awslabs/smithy/pull/843)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Revert \"Tightened substitution pattern for Fn::Sub to match CloudFormation.\"",
+      "pull_requests": [
+        "[#858](https://github.com/awslabs/smithy/pull/858)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where `cors` trait `additionalExposedHeaders` were not added to\ngateway responses.",
+      "pull_requests": [
+        "[#852](https://github.com/awslabs/smithy/pull/852)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed various issues in protocol tests.",
+      "pull_requests": [
+        "[#849](https://github.com/awslabs/smithy/pull/849)",
+        "[#855](https://github.com/awslabs/smithy/pull/855)",
+        "[#857](https://github.com/awslabs/smithy/pull/857)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified behavior for the `aws.api#service` trait's `sdkId` member.",
+      "pull_requests": [
+        "[#848](https://github.com/awslabs/smithy/pull/848)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed various typos.",
+      "pull_requests": [
+        "[#853](https://github.com/awslabs/smithy/pull/853)",
+        "[#859](https://github.com/awslabs/smithy/pull/859)"
+      ]
+    }
+  ],
+  "date": "2021-07-14"
+}

--- a/.changes/releases/1.11.0.json
+++ b/.changes/releases/1.11.0.json
@@ -1,0 +1,70 @@
+{
+  "version": "1.11.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Updated CORS header configuration when converting to OpenAPI while using\n`sigv4` or `restJson1`.",
+      "pull_requests": [
+        "[#868](https://github.com/awslabs/smithy/pull/868)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the (unstable) `httpMalformedRequestTests` trait to validate service\nbehavior around malformed requests.",
+      "pull_requests": [
+        "[#871](https://github.com/awslabs/smithy/pull/871)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `smithy-diff` error when an enum entry is inserted.",
+      "pull_requests": [
+        "[#873](https://github.com/awslabs/smithy/pull/873)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a `restXml` protocol test.",
+      "pull_requests": [
+        "[#866](https://github.com/awslabs/smithy/pull/866)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a `httpChecksumRequired` protocol test.",
+      "pull_requests": [
+        "[#869](https://github.com/awslabs/smithy/pull/869)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Updated `NodeMapper` to properly handle `sourceLocation` for traits.",
+      "pull_requests": [
+        "[#865](https://github.com/awslabs/smithy/pull/865)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Removed warning when an operation using the HTTP `PATCH` method is marked with\nthe `@idempotent` trait.",
+      "pull_requests": [
+        "[#867](https://github.com/awslabs/smithy/pull/867)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed several issues where a `sourceLocation` wasn't propagated for traits.",
+      "pull_requests": [
+        "[#864](https://github.com/awslabs/smithy/pull/864)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed various documentation issues.",
+      "pull_requests": [
+        "[#870](https://github.com/awslabs/smithy/pull/870)",
+        "[#874](https://github.com/awslabs/smithy/pull/874)"
+      ]
+    }
+  ],
+  "date": "2021-08-03"
+}

--- a/.changes/releases/1.12.0.json
+++ b/.changes/releases/1.12.0.json
@@ -1,0 +1,133 @@
+{
+  "version": "1.12.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added support for binding common errors to a `service` shape.",
+      "pull_requests": [
+        "[#919](https://github.com/awslabs/smithy/pull/919)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Loosened the requirement of setting a `version` property when defining a\n`service`.",
+      "pull_requests": [
+        "[#918](https://github.com/awslabs/smithy/pull/918)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated `smithy-build` to fail when a build plugin cannot be found.",
+      "pull_requests": [
+        "[#909](https://github.com/awslabs/smithy/pull/909)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a `changeTypes` build transform.",
+      "pull_requests": [
+        "[#912](https://github.com/awslabs/smithy/pull/912)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for replacing simple shapes in `ModelTransformer`.",
+      "pull_requests": [
+        "[#900](https://github.com/awslabs/smithy/pull/900)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a `scheme` property to the `@httpApiKeyAuth` trait.",
+      "pull_requests": [
+        "[#893](https://github.com/awslabs/smithy/pull/893)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for specifying errors in the `@examples` trait.",
+      "pull_requests": [
+        "[#888](https://github.com/awslabs/smithy/pull/888)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added multi-character newline support in `CodeWriter`.",
+      "pull_requests": [
+        "[#892](https://github.com/awslabs/smithy/pull/892)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated semantic validation of modeled `OPTIONS` operations.",
+      "pull_requests": [
+        "[#890](https://github.com/awslabs/smithy/pull/890)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added several malformed request protocol tests.",
+      "pull_requests": [
+        "[#879](https://github.com/awslabs/smithy/pull/879)",
+        "[#882](https://github.com/awslabs/smithy/pull/882)",
+        "[#881](https://github.com/awslabs/smithy/pull/881)",
+        "[#898](https://github.com/awslabs/smithy/pull/898)",
+        "[#901](https://github.com/awslabs/smithy/pull/901)",
+        "[#905](https://github.com/awslabs/smithy/pull/905)",
+        "[#908](https://github.com/awslabs/smithy/pull/908)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol tests for path prefixes.",
+      "pull_requests": [
+        "[#899](https://github.com/awslabs/smithy/pull/899)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed how `NodeMapper` handles generic params.",
+      "pull_requests": [
+        "[#912](https://github.com/awslabs/smithy/pull/912)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed how the CLI logs messages and interacts with logging levels.",
+      "pull_requests": [
+        "[#910](https://github.com/awslabs/smithy/pull/910)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated guidance on ordering of `set` shapes.",
+      "pull_requests": [
+        "[#875](https://github.com/awslabs/smithy/pull/875)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarify that event streams contain modeled errors.",
+      "pull_requests": [
+        "[#891](https://github.com/awslabs/smithy/pull/891)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added an index that lists all traits.",
+      "pull_requests": [
+        "[#876](https://github.com/awslabs/smithy/pull/876)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed various documentation issues.",
+      "pull_requests": [
+        "[#884](https://github.com/awslabs/smithy/pull/884)",
+        "[#911](https://github.com/awslabs/smithy/pull/911)",
+        "[#927](https://github.com/awslabs/smithy/pull/927)"
+      ]
+    }
+  ],
+  "date": "2021-10-05"
+}

--- a/.changes/releases/1.13.0.json
+++ b/.changes/releases/1.13.0.json
@@ -1,0 +1,139 @@
+{
+  "version": "1.13.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added a `filterSuppressions` model transform.",
+      "pull_requests": [
+        "[#940](https://github.com/awslabs/smithy/pull/940)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated selector attributes to be stricter.",
+      "pull_requests": [
+        "[#946](https://github.com/awslabs/smithy/pull/946)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for generating the `required` property when generating\nCloudFormation Resource Schemas.",
+      "pull_requests": [
+        "[#937](https://github.com/awslabs/smithy/pull/937)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for generating the `handlers` property when generating\nCloudFormation Resource Schemas.",
+      "pull_requests": [
+        "[#939](https://github.com/awslabs/smithy/pull/939)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `@aws.iam#iamResource` trait to indicate properties of a Smithy\nresource in AWS IAM.",
+      "pull_requests": [
+        "[#948](https://github.com/awslabs/smithy/pull/948)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `@aws.iam#supportedPrincipleTypes` trait to indicate which IAM\nprincipal types can use a service or operation.",
+      "pull_requests": [
+        "[#941](https://github.com/awslabs/smithy/pull/941)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated model serializers to allow for serializing the prelude.",
+      "pull_requests": [
+        "[#955](https://github.com/awslabs/smithy/pull/955)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated JSON Schema conversion to maintain property order.",
+      "pull_requests": [
+        "[#932](https://github.com/awslabs/smithy/pull/932)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved `@httpApiKeyAuth` description when converting to OpenAPI.",
+      "pull_requests": [
+        "[#934](https://github.com/awslabs/smithy/pull/934)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated the error message received when http request body content issues are\nencountered.",
+      "pull_requests": [
+        "[#959](https://github.com/awslabs/smithy/pull/959)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated request tests for `restJson1` query strings.",
+      "pull_requests": [
+        "[#933](https://github.com/awslabs/smithy/pull/933)",
+        "[#958](https://github.com/awslabs/smithy/pull/958)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol tests for `restJson1` content types.",
+      "pull_requests": [
+        "[#924](https://github.com/awslabs/smithy/pull/924)",
+        "[#945](https://github.com/awslabs/smithy/pull/945)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed issues in model loading that required a service `version` property.",
+      "pull_requests": [
+        "[#936](https://github.com/awslabs/smithy/pull/936)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue that where CORS headers in OpenAPI conversions were not\ncase-insensitive.",
+      "pull_requests": [
+        "[#950](https://github.com/awslabs/smithy/pull/950)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed various issues in protocol tests.",
+      "pull_requests": [
+        "[#930](https://github.com/awslabs/smithy/pull/930)",
+        "[#933](https://github.com/awslabs/smithy/pull/933)",
+        "[#935](https://github.com/awslabs/smithy/pull/935)",
+        "[#944](https://github.com/awslabs/smithy/pull/944)",
+        "[#949](https://github.com/awslabs/smithy/pull/949)",
+        "[#954](https://github.com/awslabs/smithy/pull/954)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified host-related settings in the `@httpRequestTests` trait\ndocumentation.",
+      "pull_requests": [
+        "[#951](https://github.com/awslabs/smithy/pull/951)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified uri samples and descriptions.",
+      "pull_requests": [
+        "[#960](https://github.com/awslabs/smithy/pull/960)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed some issues in documentation.",
+      "pull_requests": [
+        "[#952](https://github.com/awslabs/smithy/pull/952)"
+      ]
+    }
+  ],
+  "date": "2021-10-29"
+}

--- a/.changes/releases/1.13.1.json
+++ b/.changes/releases/1.13.1.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.13.1",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug that caused the `apply` transform to not run its projections.",
+      "pull_requests": [
+        "[#969](https://github.com/awslabs/smithy/pull/969)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified uri label and greedy label documentation.",
+      "pull_requests": [
+        "[#965](https://github.com/awslabs/smithy/pull/965)",
+        "[#968](https://github.com/awslabs/smithy/pull/968)"
+      ]
+    }
+  ],
+  "date": "2021-11-02"
+}

--- a/.changes/releases/1.14.0.json
+++ b/.changes/releases/1.14.0.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.14.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added the `@aws.protocols#httpChecksum` trait to describe checksumming\nbehavior for operations.",
+      "pull_requests": [
+        "[#972](https://github.com/awslabs/smithy/pull/972)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug that used a JSON pointer instead of names when generating\nCloudFormation Resource Schema required properties.",
+      "pull_requests": [
+        "[#971](https://github.com/awslabs/smithy/pull/971)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified parsing of members marked with the `@httpQueryParams` trait.",
+      "pull_requests": [
+        "[#957](https://github.com/awslabs/smithy/pull/957)"
+      ]
+    }
+  ],
+  "date": "2021-11-10"
+}

--- a/.changes/releases/1.14.1.json
+++ b/.changes/releases/1.14.1.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.14.1",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Updated the `@aws.protocols#httpChecksum` trait to use uppercase algorithm\nnames.",
+      "pull_requests": [
+        "[#982](https://github.com/awslabs/smithy/pull/982)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where JSON Schema conversion wouldn't remove out-of-service\nreferences before deconflicting.",
+      "pull_requests": [
+        "[#978](https://github.com/awslabs/smithy/pull/978)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed IAM condition key inference not using the `@aws.iam#iamResource` trait.",
+      "pull_requests": [
+        "[#981](https://github.com/awslabs/smithy/pull/981)"
+      ]
+    }
+  ],
+  "date": "2021-11-15"
+}

--- a/.changes/releases/1.15.0.json
+++ b/.changes/releases/1.15.0.json
@@ -1,0 +1,63 @@
+{
+  "version": "1.15.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added protocol tests for quoted strings in headers.",
+      "pull_requests": [
+        "[#986](https://github.com/awslabs/smithy/pull/986)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed `filterSuppressions` transform's handling of members.",
+      "pull_requests": [
+        "[#989](https://github.com/awslabs/smithy/pull/989)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed http-content-type protocol tests.",
+      "pull_requests": [
+        "[#993](https://github.com/awslabs/smithy/pull/993)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed documentation regarding `@length` and `@auth` traits.",
+      "pull_requests": [
+        "[#988](https://github.com/awslabs/smithy/pull/988)",
+        "[#997](https://github.com/awslabs/smithy/pull/997)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added documentation for `httpMalformedRequestTests`.",
+      "pull_requests": [
+        "[#973](https://github.com/awslabs/smithy/pull/973)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Upgraded to use version `0.6.0` of the\n[Smithy Gradle Plugin](https://github.com/awslabs/smithy-gradle-plugin).",
+      "pull_requests": [
+        "[#996](https://github.com/awslabs/smithy/pull/996)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Reduced number of copies builders need to make when building up immutable\nobjects.",
+      "pull_requests": [
+        "[#995](https://github.com/awslabs/smithy/pull/995)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Ensured InputStreams in loader are closed.",
+      "pull_requests": [
+        "[#991](https://github.com/awslabs/smithy/pull/991)"
+      ]
+    }
+  ],
+  "date": "2021-12-02"
+}

--- a/.changes/releases/1.16.0.json
+++ b/.changes/releases/1.16.0.json
@@ -1,0 +1,93 @@
+{
+  "version": "1.16.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added `smithy.api#Unit` and `@input` and `@output` traits.",
+      "pull_requests": [
+        "[#980](https://github.com/awslabs/smithy/pull/980)",
+        "[#1005](https://github.com/awslabs/smithy/pull/1005)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Removed support for collection values for `@httpPrefixHeaders`.",
+      "pull_requests": [
+        "[#1022](https://github.com/awslabs/smithy/pull/1022)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a protocol test for handling path segments that contain regex\nexpressions.",
+      "pull_requests": [
+        "[#1018](https://github.com/awslabs/smithy/pull/1018)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Removed `jsonName` from the `awsJson` protocol tests and documentation.",
+      "pull_requests": [
+        "[#1026](https://github.com/awslabs/smithy/pull/1026)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Reverted changes to timestamp list header serialization protocol tests.",
+      "pull_requests": [
+        "[#1023](https://github.com/awslabs/smithy/pull/1023)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed links in the search results of Smithy's javadocs.",
+      "pull_requests": [
+        "[#1009](https://github.com/awslabs/smithy/pull/1009)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed duplication of validation events for conflicting names.",
+      "pull_requests": [
+        "[#999](https://github.com/awslabs/smithy/pull/999)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added links to Kotlin and Swift generators.",
+      "pull_requests": [
+        "[#1020](https://github.com/awslabs/smithy/pull/1020)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified matching of URIs where greedy labels have no matching segment.",
+      "pull_requests": [
+        "[#1013](https://github.com/awslabs/smithy/pull/1013)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Added minor optimizations.",
+      "pull_requests": [
+        "[#1028](https://github.com/awslabs/smithy/pull/1028)",
+        "[#1027](https://github.com/awslabs/smithy/pull/1027)",
+        "[#1004](https://github.com/awslabs/smithy/pull/1004)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Added Apple silicon target for smithy-cli.",
+      "pull_requests": [
+        "[#1012](https://github.com/awslabs/smithy/pull/1012)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Updated smithy-cli to use JDK 17.",
+      "pull_requests": [
+        "[#1003](https://github.com/awslabs/smithy/pull/1003)"
+      ]
+    }
+  ],
+  "date": "2022-01-03"
+}

--- a/.changes/releases/1.16.1.json
+++ b/.changes/releases/1.16.1.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.16.1",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Make `smithy.api#Unit` easier to adopt by excluding direct relationships\nbetween it and operation inputs and outputs.",
+      "pull_requests": [
+        "[#1034](https://github.com/awslabs/smithy/pull/1034)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed character escaping in a restJson1 protocol test.",
+      "pull_requests": [
+        "[#1035](https://github.com/awslabs/smithy/pull/1035)"
+      ]
+    }
+  ],
+  "date": "2022-01-06"
+}

--- a/.changes/releases/1.16.2.json
+++ b/.changes/releases/1.16.2.json
@@ -1,0 +1,41 @@
+{
+  "version": "1.16.2",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Renamed `StutteredShapeName` validator to `RepeatingShapeName` and added an\n`exactMatch` configuration to let it more precisely prevent problematic\nmodels.",
+      "pull_requests": [
+        "[#1041](https://github.com/awslabs/smithy/pull/1041)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Reduced the severity of `HttpBindingsMissing` events for services that do not\nuse protocols that support the `@http` trait.",
+      "pull_requests": [
+        "[#1044](https://github.com/awslabs/smithy/pull/1044)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `unwrite()` to `CodeWriter`.",
+      "pull_requests": [
+        "[#1038](https://github.com/awslabs/smithy/pull/1038)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed the `RestJsonInputUnionWithUnitMember` protocol test.",
+      "pull_requests": [
+        "[#1042](https://github.com/awslabs/smithy/pull/1042)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated the documentation for pagination.",
+      "pull_requests": [
+        "[#1043](https://github.com/awslabs/smithy/pull/1043)"
+      ]
+    }
+  ],
+  "date": "2022-01-10"
+}

--- a/.changes/releases/1.16.3.json
+++ b/.changes/releases/1.16.3.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.16.3",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Removed @internal from the @unitType trait.",
+      "pull_requests": [
+        "[#1054](https://github.com/awslabs/smithy/pull/1054)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed JMESPath and-expression evaluation to correctly provide the result of\nthe left expression when it is falsey.",
+      "pull_requests": [
+        "[#1053](https://github.com/awslabs/smithy/pull/1053)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed quoted string headers restJson1 response protocol test.",
+      "pull_requests": [
+        "[#1049](https://github.com/awslabs/smithy/pull/1049)"
+      ]
+    }
+  ],
+  "date": "2022-01-13"
+}

--- a/.changes/releases/1.17.0.json
+++ b/.changes/releases/1.17.0.json
@@ -1,0 +1,55 @@
+{
+  "version": "1.17.0",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Updated `@streaming` validation for protocols that support `@httpPayload`.",
+      "pull_requests": [
+        "[#1076](https://github.com/awslabs/smithy/pull/1076)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added ability to serialize the JMESPath AST.",
+      "pull_requests": [
+        "[#1059](https://github.com/awslabs/smithy/pull/1059)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Update `CodeWriter` to add getters and ability to copy settings.",
+      "pull_requests": [
+        "[#1067](https://github.com/awslabs/smithy/pull/1067)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified `outputToken`.",
+      "pull_requests": [
+        "[#1056](https://github.com/awslabs/smithy/pull/1056)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Removed repeated words.",
+      "pull_requests": [
+        "[#1063](https://github.com/awslabs/smithy/pull/1063)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified server behavior for query parameter deserialization.",
+      "pull_requests": [
+        "[#1080](https://github.com/awslabs/smithy/pull/1080)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Updated traits to preserve the original `Node` value from the model.",
+      "pull_requests": [
+        "[#1047](https://github.com/awslabs/smithy/pull/1047)"
+      ]
+    }
+  ],
+  "date": "2022-02-04"
+}

--- a/.changes/releases/1.18.0.json
+++ b/.changes/releases/1.18.0.json
@@ -1,0 +1,184 @@
+{
+  "version": "1.18.0",
+  "changes": [
+    {
+      "type": "break",
+      "description": "Sets can now only contain byte, short, integer, long, bigInteger, bigDecimal,\nand string shapes. Sets with other types of values are either difficult to\nimplement in various programming languages (for example, sets of floats in\nRust), or highly problematic for client/server use cases. Clients that are out\nof sync with a service model could receive structures or unions from a\nservice, not recognize new members and drop them, causing the hash codes of\nmembers of the set to collide, and this would result in the client discarding\nset entries. For example, a service might return a set of 3 structures, but\nwhen clients deserialize them, they drop unknown members, and the set contains\nfewer than 3 entries.\n\nExisting models that already use a set of other types will need to migrate to\nuse a list rather than a set, and they will need to implement any necessary\nuniqueness checks server-side as needed.\n\n**NOTE**: This restriction was downgraded to a WARNING in 1.18.1",
+      "pull_requests": [
+        "[#1106](https://github.com/awslabs/smithy/pull/1106)"
+      ]
+    },
+    {
+      "type": "break",
+      "description": "Removed unused `UseShapeWriterObserver` and related features.",
+      "pull_requests": [
+        "[#1117](https://github.com/awslabs/smithy/pull/1117)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added interfaces for Codegen integrations, interceptors, and contexts.",
+      "pull_requests": [
+        "[#1109](https://github.com/awslabs/smithy/pull/1109)",
+        "[#1118](https://github.com/awslabs/smithy/pull/1118)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for typed sections, prependers and appenders, and more explicit\nnewline control to `CodeWriter`.",
+      "pull_requests": [
+        "[#1110](https://github.com/awslabs/smithy/pull/1110)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added built-in `Symbol` and `Call` formatters, a typed context, and debug info\nto `CodeWriter`.",
+      "pull_requests": [
+        "[#1095](https://github.com/awslabs/smithy/pull/1095)",
+        "[#1104](https://github.com/awslabs/smithy/pull/1104)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a `DependencyTracker` for `Symbol`s.",
+      "pull_requests": [
+        "[#1107](https://github.com/awslabs/smithy/pull/1107)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Rewrote `CodeFormatter` to be easier to understand and evolve.",
+      "pull_requests": [
+        "[#1104](https://github.com/awslabs/smithy/pull/1104)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Exposed `CodegenWriter`'s `DocumentationWriter`.",
+      "pull_requests": [
+        "[#1083](https://github.com/awslabs/smithy/pull/1083)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved error messages from `SmithyBuilder`.",
+      "pull_requests": [
+        "[#1100](https://github.com/awslabs/smithy/pull/1100)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Reduced copies made in `smithy-codegen-core` and `smithy-build`.",
+      "pull_requests": [
+        "[#1103](https://github.com/awslabs/smithy/pull/1103)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added non-optional method for `@httpMalformedRequestTest` uris.",
+      "pull_requests": [
+        "[#1108](https://github.com/awslabs/smithy/pull/1108)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added multi-code-unit characters to `@length` validation tests.",
+      "pull_requests": [
+        "[#1092](https://github.com/awslabs/smithy/pull/1092)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added malformed request tests for `set` types.",
+      "pull_requests": [
+        "[#1094](https://github.com/awslabs/smithy/pull/1094)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Clarified a message for `@httpPayload` binding errors.",
+      "pull_requests": [
+        "[#1113](https://github.com/awslabs/smithy/pull/1113)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Deprecated `onSectionAppend` and `onSectionPrepend`.",
+      "pull_requests": [
+        "[#1110](https://github.com/awslabs/smithy/pull/1110)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an incorrect warning when the `errors` property was set on a `service`.",
+      "pull_requests": [
+        "[#1120](https://github.com/awslabs/smithy/pull/1120)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed various issues in protocol tests.",
+      "pull_requests": [
+        "[#1084](https://github.com/awslabs/smithy/pull/1084)",
+        "[#1040](https://github.com/awslabs/smithy/pull/1040)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a failing code path in `SmithyBuild`.",
+      "pull_requests": [
+        "[#1100](https://github.com/awslabs/smithy/pull/1100)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added note about escaping `\\` in `@pattern`.",
+      "pull_requests": [
+        "[#1091](https://github.com/awslabs/smithy/pull/1091)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified error serialization behavior for `@restJson1`.",
+      "pull_requests": [
+        "[#1099](https://github.com/awslabs/smithy/pull/1099)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified defaulting behavior of `@httpResponseCode`.",
+      "pull_requests": [
+        "[#1111](https://github.com/awslabs/smithy/pull/1111)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified behavior of the `sources` plugin.",
+      "pull_requests": [
+        "[#977](https://github.com/awslabs/smithy/pull/977)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified how `@length` interacts with UTF-8 encoding.",
+      "pull_requests": [
+        "[#1089](https://github.com/awslabs/smithy/pull/1089)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed an `@idRef` example.",
+      "pull_requests": [
+        "[#1087](https://github.com/awslabs/smithy/pull/1087)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Migrated to using Gradle 7.3.3 to build Smithy. This should have no impactful\ndownstream effects.",
+      "pull_requests": [
+        "[#1085](https://github.com/awslabs/smithy/pull/1085)"
+      ]
+    }
+  ],
+  "date": "2022-03-07"
+}

--- a/.changes/releases/1.18.1.json
+++ b/.changes/releases/1.18.1.json
@@ -1,0 +1,48 @@
+{
+  "version": "1.18.1",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Downgraded set type violations from ERROR to WARNING to give consumers more\ntime to convert these sets to lists. These will be upgraded to ERROR again in\na future release.",
+      "pull_requests": [
+        "[#1125](https://github.com/awslabs/smithy/pull/1125)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed backwards compatibility of CodeWriter and created a new basic\nimplementation of `AbstractCodeWriter` named `SimpleCodeWriter`.",
+      "pull_requests": [
+        "[#1123](https://github.com/awslabs/smithy/pull/1123)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug in `AbstractCodeWriter` where indenting the next line would not be\npreserved after popping a state.",
+      "pull_requests": [
+        "[#1129](https://github.com/awslabs/smithy/pull/1129)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug in `AbstractCodeWriter` where text could sometimes be lost due to\nlazy StringBuilder construction.",
+      "pull_requests": [
+        "[#1128](https://github.com/awslabs/smithy/pull/1128)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a null pointer exception in `ModelAssembler` after calling `reset()`.",
+      "pull_requests": [
+        "[#1124](https://github.com/awslabs/smithy/pull/1124)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Removed examples showing `@sensitive` on structure members, which is\ndeprecated in IDL 2.0.",
+      "pull_requests": [
+        "[#1127](https://github.com/awslabs/smithy/pull/1127)"
+      ]
+    }
+  ],
+  "date": "2022-03-10"
+}

--- a/.changes/releases/1.19.0.json
+++ b/.changes/releases/1.19.0.json
@@ -1,0 +1,91 @@
+{
+  "version": "1.19.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Disallowed `requiresLength` trait in output.",
+      "pull_requests": [
+        "[#1155](https://github.com/awslabs/smithy/pull/1155)",
+        "[#1152](https://github.com/awslabs/smithy/pull/1152)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation that `code` in `http` trait is between 100 and 999.",
+      "pull_requests": [
+        "[#1156](https://github.com/awslabs/smithy/pull/1156)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation that `uri` in `http` trait uses ASCII characters.",
+      "pull_requests": [
+        "[#1154](https://github.com/awslabs/smithy/pull/1154)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Allowed `jsonName` trait on union members.",
+      "pull_requests": [
+        "[#1153](https://github.com/awslabs/smithy/pull/1153)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved Dockerfile support.",
+      "pull_requests": [
+        "[#1140](https://github.com/awslabs/smithy/pull/1140)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for conditions and loops to AbstractCodeWriter.",
+      "pull_requests": [
+        "[#1144](https://github.com/awslabs/smithy/pull/1144)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a warning for missing `^` or `$` anchors in `@pattern` trait.",
+      "pull_requests": [
+        "[#1141](https://github.com/awslabs/smithy/pull/1141)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a validator to catch usage of non-inclusive words.",
+      "pull_requests": [
+        "[#931](https://github.com/awslabs/smithy/pull/931)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added new classes for code writing and delegation, which deprecates the\n`software.amazon.smithy.codegen.core.writer` package.",
+      "pull_requests": [
+        "[#1131](https://github.com/awslabs/smithy/pull/1131)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a warning for using `@sensitive` trait on members, which will be removed\nin IDL 2.0.",
+      "pull_requests": [
+        "[#1132](https://github.com/awslabs/smithy/pull/1132)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Documented the supported OpenAPI version.",
+      "pull_requests": [
+        "[#1151](https://github.com/awslabs/smithy/pull/1151)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added links to Scala generator and plugin.",
+      "pull_requests": [
+        "[#1145](https://github.com/awslabs/smithy/pull/1145)"
+      ]
+    }
+  ],
+  "date": "2022-03-21"
+}

--- a/.changes/releases/1.2.0.json
+++ b/.changes/releases/1.2.0.json
@@ -1,0 +1,85 @@
+{
+  "version": "1.2.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added information to the `ModelDiff.Result` indicating how events have changed\nbetween the diff'd models.",
+      "pull_requests": [
+        "[#574](https://github.com/awslabs/smithy/pull/574)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a media type parser and validation for the `@mediaType` trait.",
+      "pull_requests": [
+        "[#582](https://github.com/awslabs/smithy/pull/582)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added additional default CORS headers and configuration for OpenAPI\nconversions.",
+      "pull_requests": [
+        "[#583](https://github.com/awslabs/smithy/pull/583)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `flattenNamespaces` build transform to flatten the namespaces of\nshapes connected to a specified service in a model in to a target namespace.",
+      "pull_requests": [
+        "[#572](https://github.com/awslabs/smithy/pull/572)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `runCommand` functionality to `smithy-utils`.",
+      "pull_requests": [
+        "[#580](https://github.com/awslabs/smithy/pull/580)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a `TriConsumer` to `smithy-utils`.",
+      "pull_requests": [
+        "[#581](https://github.com/awslabs/smithy/pull/581)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for the `@httpResponseCode` trait in the `HttpBindingIndex`.",
+      "pull_requests": [
+        "[#571](https://github.com/awslabs/smithy/pull/571)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol tests for the `@httpResponseCode` trait.",
+      "pull_requests": [
+        "[#573](https://github.com/awslabs/smithy/pull/573)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed several issues that would cause Smithy to fail when running on Windows.",
+      "pull_requests": [
+        "[#575](https://github.com/awslabs/smithy/pull/575)",
+        "[#576](https://github.com/awslabs/smithy/pull/576)",
+        "[#577](https://github.com/awslabs/smithy/pull/577)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug where a `union` shape marked as an `@httpPayload` would throw an\nexception when trying to resolve its content-type.",
+      "pull_requests": [
+        "[#584](https://github.com/awslabs/smithy/pull/584)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug in OpenAPI conversions where tags were not passed through unless\nset in the `supportedTags` list, even when the `tags` setting was enabled.",
+      "pull_requests": [
+        "[#570](https://github.com/awslabs/smithy/pull/570)"
+      ]
+    }
+  ],
+  "date": "2020-09-30"
+}

--- a/.changes/releases/1.21.0.json
+++ b/.changes/releases/1.21.0.json
@@ -1,0 +1,42 @@
+{
+  "version": "1.21.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added `DirectedCodegen` to make codegen simpler.",
+      "pull_requests": [
+        "[#1167](https://github.com/awslabs/smithy/pull/1167)",
+        "[#1180](https://github.com/awslabs/smithy/pull/1180)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add ability to register interceptors with delegator.",
+      "pull_requests": [
+        "[#1165](https://github.com/awslabs/smithy/pull/1165)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Optimized deprecated trait validation.",
+      "pull_requests": [
+        "[#1162](https://github.com/awslabs/smithy/pull/1162)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Used ConcurrentSkipListMap in Model for knowledge instead of synchornized\nIdentityMap.",
+      "pull_requests": [
+        "[#1161](https://github.com/awslabs/smithy/pull/1161)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added http and eventStreamHttp properties to AWS protocols.",
+      "pull_requests": [
+        "[#1172](https://github.com/awslabs/smithy/pull/1172)"
+      ]
+    }
+  ],
+  "date": "2022-04-13"
+}

--- a/.changes/releases/1.22.0.json
+++ b/.changes/releases/1.22.0.json
@@ -1,0 +1,234 @@
+{
+  "version": "1.22.0",
+  "changes": [
+    {
+      "type": "break",
+      "description": "Disallowed `@sensitive` trait on members. It must be applied the shape\ntargeted by members.",
+      "pull_requests": [
+        "[#1226](https://github.com/awslabs/smithy/pull/1226)"
+      ]
+    },
+    {
+      "type": "break",
+      "description": "Deprecated `set` in favor of `@uniqueItems`. `@uniqueItems` can no longer\ntarget `float`, `double` and `document`.",
+      "pull_requests": [
+        "[#1278](https://github.com/awslabs/smithy/pull/1278)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `breakingChanges` property to `@trait` to specify more complex backward\ncompatibility rules.",
+      "pull_requests": [
+        "[#1193](https://github.com/awslabs/smithy/pull/1193)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added automatic casing detection to CamelCaseValidator.",
+      "pull_requests": [
+        "[#1217](https://github.com/awslabs/smithy/pull/1217)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `--quiet` flag to all CLI commands.",
+      "pull_requests": [
+        "[#1257](https://github.com/awslabs/smithy/pull/1257)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added CodeWriter support to pull named parameters from CodeSections.",
+      "pull_requests": [
+        "[#1256](https://github.com/awslabs/smithy/pull/1256)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added stack trace comment support to code writer.",
+      "pull_requests": [
+        "[#1198](https://github.com/awslabs/smithy/pull/1198)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added an automatic topological sorting of shape in DirectedCodegen.",
+      "pull_requests": [
+        "[#1214](https://github.com/awslabs/smithy/pull/1214)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated CodegenDirector to generate shapes before generating service.",
+      "pull_requests": [
+        "[#1289](https://github.com/awslabs/smithy/pull/1289)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated CodegenDirector to automatically use `SymbolProvider.cache`.",
+      "pull_requests": [
+        "[#1233](https://github.com/awslabs/smithy/pull/1233)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Made SmithyIntegrations available from CodegenContext.",
+      "pull_requests": [
+        "[#1237](https://github.com/awslabs/smithy/pull/1237)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added helper to convert `Symbol` to `SymbolReference`.",
+      "pull_requests": [
+        "[#1220](https://github.com/awslabs/smithy/pull/1220)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated NodeDiff to sort results to make them easier to understand.",
+      "pull_requests": [
+        "[#1238](https://github.com/awslabs/smithy/pull/1238)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Implemented `Comparable` in `SourceLocation`.",
+      "pull_requests": [
+        "[#1192](https://github.com/awslabs/smithy/pull/1192)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added missing validation to ensure that unions have at least one member.",
+      "pull_requests": [
+        "[#1229](https://github.com/awslabs/smithy/pull/1229)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation to forbid impossibly recursive shapes.",
+      "pull_requests": [
+        "[#1200](https://github.com/awslabs/smithy/pull/1200)",
+        "[#1212](https://github.com/awslabs/smithy/pull/1212)",
+        "[#1253](https://github.com/awslabs/smithy/pull/1253)",
+        "[#1269](https://github.com/awslabs/smithy/pull/1269)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation to warn when HTTP 204/205 responses have bodies.",
+      "pull_requests": [
+        "[#1254](https://github.com/awslabs/smithy/pull/1254)",
+        "[#1276](https://github.com/awslabs/smithy/pull/1276)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation to forbid sparse maps with httpPrefixHeaders.",
+      "pull_requests": [
+        "[#1268](https://github.com/awslabs/smithy/pull/1268)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added ability to serialize the prelude.",
+      "pull_requests": [
+        "[#1275](https://github.com/awslabs/smithy/pull/1275)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol tests for httpResponseCode.",
+      "pull_requests": [
+        "[#1241](https://github.com/awslabs/smithy/pull/1241)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Enabled the PostUnionWithJsonName protocol test.",
+      "pull_requests": [
+        "[#1239](https://github.com/awslabs/smithy/pull/1239)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed the MalformedAcceptWithGenericString compliance test.",
+      "pull_requests": [
+        "[#1243](https://github.com/awslabs/smithy/pull/1243)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added definition for value equality for `@uniqueItems`.",
+      "pull_requests": [
+        "[#1278](https://github.com/awslabs/smithy/pull/1278)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added documentation for Smithy Server Generator for TypeScript.",
+      "pull_requests": [
+        "[#1119](https://github.com/awslabs/smithy/pull/1119)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added link to Smithy Diff from Evolving Models guide.",
+      "pull_requests": [
+        "[#1208](https://github.com/awslabs/smithy/pull/1208)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed constraint traits doc regarding non-structure members.",
+      "pull_requests": [
+        "[#1205](https://github.com/awslabs/smithy/pull/1205)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed typo in `uniqueItems` warning.",
+      "pull_requests": [
+        "[#1201](https://github.com/awslabs/smithy/pull/1201)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified `@deprecated` javadocs in `smithy-codegen-core`.",
+      "pull_requests": [
+        "[#1197](https://github.com/awslabs/smithy/pull/1197)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified Selectors documentation.",
+      "pull_requests": [
+        "[#1196](https://github.com/awslabs/smithy/pull/1196)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified meaning of Language in implementations.",
+      "pull_requests": [
+        "[#1191](https://github.com/awslabs/smithy/pull/1191)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified that constraint traits cascade for all members.",
+      "pull_requests": [
+        "[#1205](https://github.com/awslabs/smithy/pull/1205)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Removed jsonName note from awsJson protocols.",
+      "pull_requests": [
+        "[#1279](https://github.com/awslabs/smithy/pull/1279)"
+      ]
+    }
+  ],
+  "date": "2022-06-30"
+}

--- a/.changes/releases/1.23.0.json
+++ b/.changes/releases/1.23.0.json
@@ -1,0 +1,194 @@
+{
+  "version": "1.23.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added version 2.0 of the Smithy IDL.",
+      "pull_requests": [
+        "[#1317](https://github.com/awslabs/smithy/pull/1317)",
+        "[#1312](https://github.com/awslabs/smithy/pull/1312)",
+        "[#1318](https://github.com/awslabs/smithy/pull/1318)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added mixins for all shape types.",
+      "pull_requests": [
+        "[#889](https://github.com/awslabs/smithy/pull/889)",
+        "[#1025](https://github.com/awslabs/smithy/pull/1025)",
+        "[#1139](https://github.com/awslabs/smithy/pull/1139)",
+        "[#1323](https://github.com/awslabs/smithy/pull/1323)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added resource properties to version 2.0 of Smithy IDL.",
+      "pull_requests": [
+        "[#1213](https://github.com/awslabs/smithy/pull/1213)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added target elision for mixins/resources.",
+      "pull_requests": [
+        "[#1231](https://github.com/awslabs/smithy/pull/1231)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added inline operation IO shapes.",
+      "pull_requests": [
+        "[#963](https://github.com/awslabs/smithy/pull/963)",
+        "[#962](https://github.com/awslabs/smithy/pull/962)",
+        "[#1007](https://github.com/awslabs/smithy/pull/1007)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation for multiple IDL versions.",
+      "pull_requests": [
+        "[#917](https://github.com/awslabs/smithy/pull/917)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added IDL 1.0 to 2.0 model migration tool.",
+      "pull_requests": [
+        "[#1175](https://github.com/awslabs/smithy/pull/1175)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added enum shapes.",
+      "pull_requests": [
+        "[#1088](https://github.com/awslabs/smithy/pull/1088)",
+        "[#1114](https://github.com/awslabs/smithy/pull/1114)",
+        "[#1133](https://github.com/awslabs/smithy/pull/1133)",
+        "[#1313](https://github.com/awslabs/smithy/pull/1313)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `@clientOptional` trait.",
+      "pull_requests": [
+        "[#1052](https://github.com/awslabs/smithy/pull/1052)",
+        "[#1264](https://github.com/awslabs/smithy/pull/1264)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Multiple traits can now be applied in a single `apply` statement.",
+      "pull_requests": [
+        "[#885](https://github.com/awslabs/smithy/pull/885)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Commas are now optional in the IDL.",
+      "pull_requests": [
+        "[#772](https://github.com/awslabs/smithy/pull/772)",
+        "[#776](https://github.com/awslabs/smithy/pull/776)",
+        "[#1166](https://github.com/awslabs/smithy/pull/1166)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `@default` trait.",
+      "pull_requests": [
+        "[#1019](https://github.com/awslabs/smithy/pull/1019)",
+        "[#1286](https://github.com/awslabs/smithy/pull/1286)",
+        "[#1021](https://github.com/awslabs/smithy/pull/1021)",
+        "[#1048](https://github.com/awslabs/smithy/pull/1048)",
+        "[#920](https://github.com/awslabs/smithy/pull/920)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Sets can no longer be used in 2.0 models. Use a list with the `@uniqueItems`\ntrait instead. Sets can still be used in 1.0 models, though a warning will be\nemitted. The `SetShape` in smithy-model is a subclass of `ListShape`, so new\ncode generators can simply treat any `SetShape` like a `ListShape`.",
+      "pull_requests": [
+        "[#1292](https://github.com/awslabs/smithy/pull/1292)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Migrated traits packages to use Smithy IDL definitions instead of JSON AST.",
+      "pull_requests": [
+        "[#1207](https://github.com/awslabs/smithy/pull/1207)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `@cfnDefaultValue` trait",
+      "pull_requests": [
+        "[#1285](https://github.com/awslabs/smithy/pull/1285)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Made streaming blobs required/default.",
+      "pull_requests": [
+        "[#1209](https://github.com/awslabs/smithy/pull/1209)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed TextIndex to handle synthetic traits.",
+      "pull_requests": [
+        "[#1206](https://github.com/awslabs/smithy/pull/1206)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Removed duplicate aws.protocols model file.",
+      "pull_requests": [
+        "[#1310](https://github.com/awslabs/smithy/pull/1310)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Removed empty trait block serialization.",
+      "pull_requests": [
+        "[#1240](https://github.com/awslabs/smithy/pull/1240)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed trait source locations.",
+      "pull_requests": [
+        "[#1146](https://github.com/awslabs/smithy/pull/1146)",
+        "[#1157](https://github.com/awslabs/smithy/pull/1157)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added documentation for IDL 2.0 and changed location of 1.0 docs.",
+      "pull_requests": [
+        "[#1302](https://github.com/awslabs/smithy/pull/1302)",
+        "[#1057](https://github.com/awslabs/smithy/pull/1057)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added IDL 1.0 to 2.0 migration guide.",
+      "pull_requests": [
+        "[#1065](https://github.com/awslabs/smithy/pull/1065)",
+        "[#1074](https://github.com/awslabs/smithy/pull/1074)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated the doc highlighter for IDL 2.0.",
+      "pull_requests": [
+        "[#1251](https://github.com/awslabs/smithy/pull/1251)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added documentation to IAM trait enums.",
+      "pull_requests": [
+        "[#1322](https://github.com/awslabs/smithy/pull/1322)"
+      ]
+    }
+  ],
+  "date": "2022-08-10"
+}

--- a/.changes/releases/1.23.1.json
+++ b/.changes/releases/1.23.1.json
@@ -1,0 +1,61 @@
+{
+  "version": "1.23.1",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added new methods to help deserializing object nodes",
+      "pull_requests": [
+        "[#1350](https://github.com/awslabs/smithy/pull/1350)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added several (unstable) traits for endpoint resolution in the new\n`smithy-rules-engine` package",
+      "pull_requests": [
+        "[#1248](https://github.com/awslabs/smithy/pull/1248)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where validation events were emitted twice",
+      "pull_requests": [
+        "[#1362](https://github.com/awslabs/smithy/pull/1362)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug that was causing errors loading 1.0 models with `@enum` traits",
+      "pull_requests": [
+        "[#1358](https://github.com/awslabs/smithy/pull/1358)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed `PostUnionWithJsonName` and `MalformedAcceptWithGenericString` protocol\ntest.",
+      "pull_requests": [
+        "[#1361](https://github.com/awslabs/smithy/pull/1361)",
+        "[#1360](https://github.com/awslabs/smithy/pull/1360)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Added missing readonly traits on HTTP GET tests",
+      "pull_requests": [
+        "[#1354](https://github.com/awslabs/smithy/pull/1354)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed several documentation issues",
+      "pull_requests": [
+        "[#1355](https://github.com/awslabs/smithy/pull/1355)",
+        "[#1353](https://github.com/awslabs/smithy/pull/1353)",
+        "[#1349](https://github.com/awslabs/smithy/pull/1349)",
+        "[#1347](https://github.com/awslabs/smithy/pull/1347)",
+        "[#1346](https://github.com/awslabs/smithy/pull/1346)",
+        "[#1345](https://github.com/awslabs/smithy/pull/1345)"
+      ]
+    }
+  ],
+  "date": "2022-08-18"
+}

--- a/.changes/releases/1.24.0.json
+++ b/.changes/releases/1.24.0.json
@@ -1,0 +1,48 @@
+{
+  "version": "1.24.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Made string enum to enum shape transform opt-in in CodegenDirector.",
+      "pull_requests": [
+        "[#1370](https://github.com/awslabs/smithy/pull/1370)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated `@httpResponseCode` to not be applicable to `@input` structures.",
+      "pull_requests": [
+        "[#1359](https://github.com/awslabs/smithy/pull/1359)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Made some improvements in smithy-build.",
+      "pull_requests": [
+        "[#1366](https://github.com/awslabs/smithy/pull/1366)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Filtered out synthetic traits from build info.",
+      "pull_requests": [
+        "[#1374](https://github.com/awslabs/smithy/pull/1374)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a log message when unable to convert string enum to enum shape.",
+      "pull_requests": [
+        "[#1372](https://github.com/awslabs/smithy/pull/1372)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated Smithy IDL ABNF Docs.",
+      "pull_requests": [
+        "[#1357](https://github.com/awslabs/smithy/pull/1357)"
+      ]
+    }
+  ],
+  "date": "2022-08-30"
+}

--- a/.changes/releases/1.25.0.json
+++ b/.changes/releases/1.25.0.json
@@ -1,0 +1,95 @@
+{
+  "version": "1.25.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Made many improvements for Smithy 1.0 and 2.0 interoperability.",
+      "pull_requests": [
+        "[1394](https://github.com/awslabs/smithy/pull/1394)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Default traits can now coexist with required trais. This indicates that a\nmember should be serialized, but it is a protocol-specific decision if and how\nthis is enforced. This was a pattern that occurred in Smithy 1.0 models when a\nmember was required and targeted a shape with a zero value.",
+      "pull_requests": []
+    },
+    {
+      "type": "feature",
+      "description": "Default traits can be added to root-level shapes. Any structure member that\ntargets a shape marked with the default trait must repeat the default on the\nmember. This removes the action at a distance problem observed in Smithy IDL\n1.0 where a root level shape implicitly introduced a default zero value, and\nto know if that's the case for any member, you had to look through from the\nmember to the target shape. This change allows us to know if a root level\nshape was boxed in IDL 1.0 too (root shapes with no default or a default set\nto anything other than the zero value was boxed).",
+      "pull_requests": []
+    },
+    {
+      "type": "feature",
+      "description": "Added the `@addedDefault` trait which is used to indicate that a `@default`\ntrait was added to a member after it was initially released. This can be used\nby tooling to make an appropriate determination if generating a non-nullable\ntype for the member is a backward compatible change. For example, if a\ngenerator only uses default zero values to generate non-nullable types, then\nthe removal of the required trait and addition of a default trait would be a\nbreaking change for them, so they can use addedDefault to ignore the default\ntrait.",
+      "pull_requests": []
+    },
+    {
+      "type": "feature",
+      "description": "Add new NullableIndex modes for testing if a member is nullable based on the\nsupported features of the generator. For example, some generators only make\nmembers non-optional when the member is set to the zero value of a type, so\nthere is a NullableIndex check mode for that and other use cases.",
+      "pull_requests": []
+    },
+    {
+      "type": "feature",
+      "description": "When loading IDL 2.0 models, we will now patch synthetic box traits onto\nshapes that would have been considered boxed in Smithy IDL 1.0. This improves\nfurther interop with tooling that has not yet adopted Smithy IDL 2 or that\nhasn't yet migrated to use the NullableIndex abstraction.",
+      "pull_requests": []
+    },
+    {
+      "type": "feature",
+      "description": "When loading 1.0 models, rather than dropping the default trait from a member\nwhen the range trait of a shape is invalid for its zero value, we now instead\nemit only a warning for this specific case. This prevents changing the type\nand also doesn't lose the range constraint.",
+      "pull_requests": []
+    },
+    {
+      "type": "feature",
+      "description": "The Primitive\\* shapes in the prelude are no longer deprecated, and they now\nhave a `@default` trait on them set to the zero value of the type. This makes\nthese traits function exactly as they did in Smithy 1.0 models. Any member\nthat targets one of these primitive prelude shapes must now also repeat the\nzero value of the target shape.",
+      "pull_requests": []
+    },
+    {
+      "type": "feature",
+      "description": "Added an optional nullability report to smithy-build that shows the computed\nnullability semantics of each member in a model. This can be used to better\nunderstand nullability semantics.",
+      "pull_requests": []
+    },
+    {
+      "type": "feature",
+      "description": "Added method to NumberNode to detect if it is set to zero.",
+      "pull_requests": [
+        "[#1385](https://github.com/awslabs/smithy/pull/1385)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "In ChangeShapeType transform, ignored types changes to same type.",
+      "pull_requests": [
+        "[#1397](https://github.com/awslabs/smithy/pull/1397)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Updated smithy-diff to not emit events when diffing a 1.0 model against the\n2.0 serialized version of the model. This means that changes to the box trait\nare ignored unless the change impacts the nullability of the shape. Special\nhandling was added to detect breaking changes with the default trait too (you\ncan't change a default value of a root-level shape for example, you cannot\nchange a default value of a shape to or from the zero value of a type as this\nmight break code generators, etc).",
+      "pull_requests": [
+        "[1394](https://github.com/awslabs/smithy/pull/1394)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "smithy-diff is no longer reporting expected `set` shape to `list` shape\ntransitions. Sets are deprecated and models are encouraged to migrate from\nsets to lists with the `@uniqueItems` trait.",
+      "pull_requests": [
+        "[1383](https://github.com/awslabs/smithy/pull/1383)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fix operationOutputSuffix in example code snippet",
+      "pull_requests": [
+        "[#1393](https://github.com/awslabs/smithy/pull/1393)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fix ABNF grammar of inlined structure",
+      "pull_requests": [
+        "[1377](https://github.com/awslabs/smithy/pull/1377)"
+      ]
+    }
+  ],
+  "date": "2022-09-13"
+}

--- a/.changes/releases/1.25.1.json
+++ b/.changes/releases/1.25.1.json
@@ -1,0 +1,98 @@
+{
+  "version": "1.25.1",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Warn when box trait found on union member",
+      "pull_requests": [
+        "[#1420](https://github.com/awslabs/smithy/pull/1420)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Warn when default used with union member target",
+      "pull_requests": [
+        "[#1418](https://github.com/awslabs/smithy/pull/1418)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Simplify ShapeId caching",
+      "pull_requests": [
+        "[#1411](https://github.com/awslabs/smithy/pull/1411)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Update smithy-diff for strings with the enum trait to enum shapes",
+      "pull_requests": [
+        "[#1409](https://github.com/awslabs/smithy/pull/1409)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add support for 1.0 downgrades and serialization",
+      "pull_requests": [
+        "[#1403](https://github.com/awslabs/smithy/pull/1403)",
+        "[#1410](https://github.com/awslabs/smithy/pull/1410)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add AwsQueryCompatible trait",
+      "pull_requests": [
+        "[#1314](https://github.com/awslabs/smithy/pull/1314)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Only emit deprecation of enum trait in 2.0 models",
+      "pull_requests": [
+        "[#1421](https://github.com/awslabs/smithy/pull/1421)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Enforce private on traits",
+      "pull_requests": [
+        "[#1406](https://github.com/awslabs/smithy/pull/1406)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix apply statement parsing and ABNF",
+      "pull_requests": [
+        "[#1414](https://github.com/awslabs/smithy/pull/1414)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Add test for synthetic box traits on mixins",
+      "pull_requests": [
+        "[#1404](https://github.com/awslabs/smithy/pull/1404)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Add some clarifications to revised default value design doc",
+      "pull_requests": [
+        "[#1413](https://github.com/awslabs/smithy/pull/1413)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Revise default value design doc to match recent updates",
+      "pull_requests": [
+        "[#1412](https://github.com/awslabs/smithy/pull/1412)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fix typo in migration guide",
+      "pull_requests": [
+        "[#1405](https://github.com/awslabs/smithy/pull/1405)"
+      ]
+    }
+  ],
+  "date": "2022-09-23"
+}

--- a/.changes/releases/1.25.2.json
+++ b/.changes/releases/1.25.2.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.25.2",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Revert \"Enforce private on traits (#1406)\"",
+      "pull_requests": [
+        "[#1428](https://github.com/awslabs/smithy/pull/1428)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Remove aws query compatible protocol test",
+      "pull_requests": [
+        "[#1424](https://github.com/awslabs/smithy/pull/1424)"
+      ]
+    }
+  ],
+  "date": "2022-09-28"
+}

--- a/.changes/releases/1.26.0.json
+++ b/.changes/releases/1.26.0.json
@@ -1,0 +1,41 @@
+{
+  "version": "1.26.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Add support for missing authorizer members",
+      "pull_requests": [
+        "[#1426](https://github.com/awslabs/smithy/pull/1426)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add intEnum DirectedCodegen",
+      "pull_requests": [
+        "[#1434](https://github.com/awslabs/smithy/pull/1434)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add Smithy Rules Engine (unstable)",
+      "pull_requests": [
+        "[#1356](https://github.com/awslabs/smithy/pull/1356)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fix intEnum example",
+      "pull_requests": [
+        "[#1432](https://github.com/awslabs/smithy/pull/1432)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fix javadoc for CodegenDirector.simplifyModelForServiceCodegen",
+      "pull_requests": [
+        "[#1433](https://github.com/awslabs/smithy/pull/1433)"
+      ]
+    }
+  ],
+  "date": "2022-10-10"
+}

--- a/.changes/releases/1.26.1.json
+++ b/.changes/releases/1.26.1.json
@@ -1,0 +1,128 @@
+{
+  "version": "1.26.1",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added support for hierarchical event IDs in validation events, allowing for\nmore granular suppression",
+      "pull_requests": [
+        "[#1466](https://github.com/awslabs/smithy/pull/1466)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Removed the pattern from the `@suppress` trait's entry list, allowing them to\nmatch all validator IDs",
+      "pull_requests": [
+        "[#1455](https://github.com/awslabs/smithy/pull/1455)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the ability to lint based on word boundaries for the `ReservedWords`\nvalidator",
+      "pull_requests": [
+        "[#1461](https://github.com/awslabs/smithy/pull/1461)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a `toNode` method to the `Partition` class in `smithy-rules-engine`",
+      "pull_requests": [
+        "[#1449](https://github.com/awslabs/smithy/pull/1449)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a warning when `smithy-diff` detects changes to traits that do not have\ndefinitions loaded",
+      "pull_requests": [
+        "[#1468](https://github.com/awslabs/smithy/pull/1468)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved validation for members that target nullable shapes",
+      "pull_requests": [
+        "[#1454](https://github.com/awslabs/smithy/pull/1454)",
+        "[1460](https://github.com/awslabs/smithy/pull/1460)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a hook to the `CodegenDirector` to allow for customization before shape\ngeneration",
+      "pull_requests": [
+        "[#1469](https://github.com/awslabs/smithy/pull/1469)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated model assembling to always attempt model interop transforms",
+      "pull_requests": [
+        "[#1435](https://github.com/awslabs/smithy/pull/1435)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug where transforms would not remove enum members",
+      "pull_requests": [
+        "[#1442](https://github.com/awslabs/smithy/pull/1442)",
+        "[#1447](https://github.com/awslabs/smithy/pull/1447)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug where documentation comments were dropped if they occurred after a\nmember using the default value syntactic sugar",
+      "pull_requests": [
+        "[1459](https://github.com/awslabs/smithy/pull/1459)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where resource identifier collisions would cause a model to\nfail loading",
+      "pull_requests": [
+        "[#1453](https://github.com/awslabs/smithy/pull/1453)",
+        "[#1474](https://github.com/awslabs/smithy/pull/1474)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Added `@private` to the local traits for the AWS `HttpConfiguration` shape",
+      "pull_requests": [
+        "[#1445](https://github.com/awslabs/smithy/pull/1445)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue with behavior defined in an `awsQuery` protocol test",
+      "pull_requests": [
+        "[#1444](https://github.com/awslabs/smithy/pull/1444)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed several protocol tests in the `awsJson1_1` protocol test suite",
+      "pull_requests": [
+        "[#1392](https://github.com/awslabs/smithy/pull/1392)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an incorrect application of the `@httpMalformedRequestTests` trait",
+      "pull_requests": [
+        "[#1467](https://github.com/awslabs/smithy/pull/1467)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified streaming trait values and semantics",
+      "pull_requests": [
+        "[#1458](https://github.com/awslabs/smithy/pull/1458)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated the identifier ABNF and parser",
+      "pull_requests": [
+        "[#1464](https://github.com/awslabs/smithy/pull/1464)"
+      ]
+    }
+  ],
+  "date": "2022-10-31"
+}

--- a/.changes/releases/1.26.2.json
+++ b/.changes/releases/1.26.2.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.26.2",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Add missing regions and fix typo in partitions.json",
+      "pull_requests": [
+        "[#1487](https://github.com/awslabs/smithy/pull/1487)"
+      ]
+    }
+  ],
+  "date": "2022-11-07"
+}

--- a/.changes/releases/1.26.3.json
+++ b/.changes/releases/1.26.3.json
@@ -1,0 +1,76 @@
+{
+  "version": "1.26.3",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Moved useIntegerType to jsonschema",
+      "pull_requests": [
+        "[1495](https://github.com/awslabs/smithy/pull/1495)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added intEnum protocol tests",
+      "pull_requests": [
+        "[1492](https://github.com/awslabs/smithy/pull/1492)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added timestampFormat protocol tests on target shapes",
+      "pull_requests": [
+        "[1440](https://github.com/awslabs/smithy/pull/1440)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added MissingSensitiveTraitValidator",
+      "pull_requests": [
+        "[1364](https://github.com/awslabs/smithy/pull/1364)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed applying protocol tests to correct operations",
+      "pull_requests": [
+        "[1477](https://github.com/awslabs/smithy/pull/1477)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed cfn-mutability for inherited identifiers",
+      "pull_requests": [
+        "[1465](https://github.com/awslabs/smithy/pull/1465)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed Resource shape properties Type entry",
+      "pull_requests": [
+        "[1415](https://github.com/awslabs/smithy/pull/1415)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated links to point to smithy.io",
+      "pull_requests": [
+        "[1497](https://github.com/awslabs/smithy/pull/1497)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed docs and fail on additional doc warnings",
+      "pull_requests": [
+        "[1496](https://github.com/awslabs/smithy/pull/1496)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed AbstractCodeWriter documentation",
+      "pull_requests": [
+        "[1490](https://github.com/awslabs/smithy/pull/1490)"
+      ]
+    }
+  ],
+  "date": "2022-11-17"
+}

--- a/.changes/releases/1.26.4.json
+++ b/.changes/releases/1.26.4.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.26.4",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Fixed updating mixins when replacing shapes in transforms",
+      "pull_requests": [
+        "[1509](https://github.com/awslabs/smithy/pull/1509)"
+      ]
+    }
+  ],
+  "date": "2022-11-22"
+}

--- a/.changes/releases/1.27.0.json
+++ b/.changes/releases/1.27.0.json
@@ -1,0 +1,140 @@
+{
+  "version": "1.27.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Add tests for ACCEPT *",
+      "pull_requests": [
+        "[#1365](https://github.com/awslabs/smithy/pull/1365)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Test content-type modeled inputs without body",
+      "pull_requests": [
+        "[#1399](https://github.com/awslabs/smithy/pull/1399)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improve member not targeting a property error message to better hint at fix",
+      "pull_requests": [
+        "[#1501](https://github.com/awslabs/smithy/pull/1501)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add typechecking to EndpointRuleset build",
+      "pull_requests": [
+        "[#1507](https://github.com/awslabs/smithy/pull/1507)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add warnings for private access on traits",
+      "pull_requests": [
+        "[#1508](https://github.com/awslabs/smithy/pull/1508)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Tweak class caching in node (de)serializers.",
+      "pull_requests": [
+        "[#1518](https://github.com/awslabs/smithy/pull/1518)",
+        "[#1530](https://github.com/awslabs/smithy/pull/1530)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add Maven dependency resolution to the CLI",
+      "pull_requests": [
+        "[#1526](https://github.com/awslabs/smithy/pull/1526)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add details to TraitBreakingChange EventId",
+      "pull_requests": [
+        "[#1538](https://github.com/awslabs/smithy/pull/1538)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix dedicated io transform leaving unused shapes",
+      "pull_requests": [
+        "[#1419](https://github.com/awslabs/smithy/pull/1419)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix return type of substring method",
+      "pull_requests": [
+        "[#1504](https://github.com/awslabs/smithy/pull/1504)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix quoted text grammar and parsing",
+      "pull_requests": [
+        "[#1535](https://github.com/awslabs/smithy/pull/1535)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix backwards compatibility rules for the paginated trait",
+      "pull_requests": [
+        "[#1549](https://github.com/awslabs/smithy/pull/1549)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Make it clearer that assembly-name stripping is not a MUST in `restJson1`",
+      "pull_requests": [
+        "[#1493](https://github.com/awslabs/smithy/pull/1493)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarify service-level pagination configuration",
+      "pull_requests": [
+        "[#1514](https://github.com/awslabs/smithy/pull/1514)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Document it is generally breaking to add/remove input trait",
+      "pull_requests": [
+        "[#1519](https://github.com/awslabs/smithy/pull/1519)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fix grammar for MapMembers",
+      "pull_requests": [
+        "[#1520](https://github.com/awslabs/smithy/pull/1520)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarify that metadata has no namespace",
+      "pull_requests": [
+        "[#1521](https://github.com/awslabs/smithy/pull/1521)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Update trailing line break, list member grammar",
+      "pull_requests": [
+        "[#1533](https://github.com/awslabs/smithy/pull/1533)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fix MapMembers grammar and update test",
+      "pull_requests": [
+        "[#1536](https://github.com/awslabs/smithy/pull/1536)"
+      ]
+    }
+  ],
+  "date": "2022-12-15"
+}

--- a/.changes/releases/1.27.1.json
+++ b/.changes/releases/1.27.1.json
@@ -1,0 +1,104 @@
+{
+  "version": "1.27.1",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Update protocol tests with datetime offset coverage",
+      "pull_requests": [
+        "[#1502](https://github.com/awslabs/smithy/pull/1502)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add protocol tests to cover @range for short, long and integer shapes",
+      "pull_requests": [
+        "[#1515](https://github.com/awslabs/smithy/pull/1515)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add exclude/include tranforms using selectors",
+      "pull_requests": [
+        "[#1534](https://github.com/awslabs/smithy/pull/1534)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add a parseArn test case for resources with `:` and `/`",
+      "pull_requests": [
+        "[#1537](https://github.com/awslabs/smithy/pull/1537)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Move CDS warmup to the CLI directly",
+      "pull_requests": [
+        "[#1553](https://github.com/awslabs/smithy/pull/1553)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Allow error rename and disallow error rename for all AWS protocols",
+      "pull_requests": [
+        "[#1554](https://github.com/awslabs/smithy/pull/1554)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add details to ModifiedTrait event id",
+      "pull_requests": [
+        "[#1560](https://github.com/awslabs/smithy/pull/1560)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix deterministic order of properties",
+      "pull_requests": [
+        "[#1555](https://github.com/awslabs/smithy/pull/1555)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix datetime offset restXml payload",
+      "pull_requests": [
+        "[#1559](https://github.com/awslabs/smithy/pull/1559)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix `RestJsonQueryStringEscaping` protocol test",
+      "pull_requests": [
+        "[#1562](https://github.com/awslabs/smithy/pull/1562)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix `RestJsonAllQueryStringTypes` protocol test",
+      "pull_requests": [
+        "[#1564](https://github.com/awslabs/smithy/pull/1564)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix Upgrade1to2Command for Set shape",
+      "pull_requests": [
+        "[#1569](https://github.com/awslabs/smithy/pull/1569)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix parameters to builder",
+      "pull_requests": [
+        "[#1571](https://github.com/awslabs/smithy/pull/1571)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fix typo for NOTE under breaking change rules",
+      "pull_requests": [
+        "[#1552](https://github.com/awslabs/smithy/pull/1552)"
+      ]
+    }
+  ],
+  "date": "2023-01-11"
+}

--- a/.changes/releases/1.27.2.json
+++ b/.changes/releases/1.27.2.json
@@ -1,0 +1,48 @@
+{
+  "version": "1.27.2",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Implement Comparable interface for TagObject and ExternalDocumentation",
+      "pull_requests": [
+        "[#1589](https://github.com/awslabs/smithy/pull/1589)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Relax rule engine validation to support test auth schemes",
+      "pull_requests": [
+        "[#1590](https://github.com/awslabs/smithy/pull/1590)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Ensure that AuthSchemes added to Endpoint builder retain parameter ordering",
+      "pull_requests": [
+        "[#1591](https://github.com/awslabs/smithy/pull/1591)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add intEnum coverage on map of string list",
+      "pull_requests": [
+        "[#1596](https://github.com/awslabs/smithy/pull/1596)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Add source location to synthetic Enum trait",
+      "pull_requests": [
+        "[#1580](https://github.com/awslabs/smithy/pull/1580)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Minor fix to restJson1 docs",
+      "pull_requests": [
+        "[#1587](https://github.com/awslabs/smithy/pull/1587)"
+      ]
+    }
+  ],
+  "date": "2023-01-30"
+}

--- a/.changes/releases/1.28.0.json
+++ b/.changes/releases/1.28.0.json
@@ -1,0 +1,127 @@
+{
+  "version": "1.28.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Add client-only protocol tests for fractional second parsing",
+      "pull_requests": [
+        "[#1627](https://github.com/awslabs/smithy/pull/1627)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add protocol test for omitting empty http-query lists",
+      "pull_requests": [
+        "[#1629](https://github.com/awslabs/smithy/pull/1629)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add support for JSON Schema draft2020-12",
+      "pull_requests": [
+        "[#1617](https://github.com/awslabs/smithy/pull/1617)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add hierarchical eventIds",
+      "pull_requests": [
+        "[#1527](https://github.com/awslabs/smithy/pull/1527)",
+        "[#1631](https://github.com/awslabs/smithy/pull/1631)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Preserve tag order in generated OpenAPI specification",
+      "pull_requests": [
+        "[#1604](https://github.com/awslabs/smithy/pull/1604)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add shapes generation order in CodegenDirector",
+      "pull_requests": [
+        "[#1615](https://github.com/awslabs/smithy/pull/1615)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Remove reflected input values from validation protocol tests",
+      "pull_requests": [
+        "[#1622](https://github.com/awslabs/smithy/pull/1622)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fail ExamplesTraitValidator when both output and error are defined",
+      "pull_requests": [
+        "[#1599](https://github.com/awslabs/smithy/pull/1599)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix mixin cycles being incorrectly detected",
+      "pull_requests": [
+        "[#1628](https://github.com/awslabs/smithy/pull/1628)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix warnings in AST Loader for Resource and Operation Shapes with mixins",
+      "pull_requests": [
+        "[#1626](https://github.com/awslabs/smithy/pull/1626)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix referenced components removed in openapi schema",
+      "pull_requests": [
+        "[#1595](https://github.com/awslabs/smithy/pull/1595)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix OR condition in scoped attribute selector",
+      "pull_requests": [
+        "[#1618](https://github.com/awslabs/smithy/pull/1618)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fix passthroughBehavior casing on x-amzn-apigateway-integration",
+      "pull_requests": [
+        "[#1619](https://github.com/awslabs/smithy/pull/1619)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarify rules for escaping shapes bound to URIs",
+      "pull_requests": [
+        "[#1630](https://github.com/awslabs/smithy/pull/1630)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Document Tree Sitter implementation",
+      "pull_requests": [
+        "[#1621](https://github.com/awslabs/smithy/pull/1621)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarify handling of date-time offsets",
+      "pull_requests": [
+        "[#1597](https://github.com/awslabs/smithy/pull/1597)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Add Smithy code generation guide",
+      "pull_requests": [
+        "[#1586](https://github.com/awslabs/smithy/pull/1586)",
+        "[#1592](https://github.com/awslabs/smithy/pull/1592)"
+      ]
+    }
+  ],
+  "date": "2023-02-24"
+}

--- a/.changes/releases/1.28.1.json
+++ b/.changes/releases/1.28.1.json
@@ -1,0 +1,85 @@
+{
+  "version": "1.28.1",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added a suite of compliance tests for selectors",
+      "pull_requests": [
+        "[#1643](https://github.com/awslabs/smithy/pull/1643)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue with generating CloudFormation Resource Schemas when using the\n`@nestedProperties` trait",
+      "pull_requests": [
+        "[#1641](https://github.com/awslabs/smithy/pull/1641)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where `enum` shapes could not be used as `resource` identifiers",
+      "pull_requests": [
+        "[#1644](https://github.com/awslabs/smithy/pull/1644)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue when comparing event ids for deprecated shapes",
+      "pull_requests": [
+        "[#1640](https://github.com/awslabs/smithy/pull/1640)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where \"core\" validation events were not suppressible",
+      "pull_requests": [
+        "[#1646](https://github.com/awslabs/smithy/pull/1646)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue with `NodeMapper`'s handling of lists of generic types",
+      "pull_requests": [
+        "[#1635](https://github.com/awslabs/smithy/pull/1635)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed various typos of the word \"ignore\", including for the\n`NodeMapper.WhenMissing` enum",
+      "pull_requests": [
+        "[#1652](https://github.com/awslabs/smithy/pull/1652)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where `enum` members were flagged by the\n`MissingSensitiveTrait` validator",
+      "pull_requests": [
+        "[#1661](https://github.com/awslabs/smithy/pull/1661)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Updated the validation messages for `uniqueItems` malformed request tests",
+      "pull_requests": [
+        "[#1639](https://github.com/awslabs/smithy/pull/1639)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Updated the validation messages for `enum` malformed request tests to not\nreturn internal values",
+      "pull_requests": [
+        "[#1658](https://github.com/awslabs/smithy/pull/1658)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed various issues with protocol tests",
+      "pull_requests": [
+        "[#1642](https://github.com/awslabs/smithy/pull/1642)",
+        "[#1648](https://github.com/awslabs/smithy/pull/1648)",
+        "[#1645](https://github.com/awslabs/smithy/pull/1645)"
+      ]
+    }
+  ],
+  "date": "2023-03-09"
+}

--- a/.changes/releases/1.29.0.json
+++ b/.changes/releases/1.29.0.json
@@ -1,0 +1,174 @@
+{
+  "version": "1.29.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added EnumTrait validation protocol test",
+      "pull_requests": [
+        "[#1679](https://github.com/awslabs/smithy/pull/1679)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added process based plugins to Smithy build",
+      "pull_requests": [
+        "[#1672](https://github.com/awslabs/smithy/pull/1672)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added GenerateOperationDirective to generate operation shapes separate from\nresources and services",
+      "pull_requests": [
+        "[#1676](https://github.com/awslabs/smithy/pull/1679)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added :root and :in selectors",
+      "pull_requests": [
+        "[#1690](https://github.com/awslabs/smithy/pull/1690)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added --show-traits to select command",
+      "pull_requests": [
+        "[#1692](https://github.com/awslabs/smithy/pull/1692)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added includePreludeShapes in model plugin",
+      "pull_requests": [
+        "[#1693](https://github.com/awslabs/smithy/pull/1693)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added aws.iam#actionName trait to override using the API operation name",
+      "pull_requests": [
+        "[#1679](https://github.com/awslabs/smithy/pull/1665)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved resource property validation and error messages",
+      "pull_requests": [
+        "[#1694](https://github.com/awslabs/smithy/pull/1694)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved CLI outputs for validation commands",
+      "pull_requests": [
+        "[#1695](https://github.com/awslabs/smithy/pull/1695)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Optimized identity and neighbor selectors",
+      "pull_requests": [
+        "[#1691](https://github.com/awslabs/smithy/pull/1691)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Refactored CLI to remove --severity from some commands",
+      "pull_requests": [
+        "[#1700](https://github.com/awslabs/smithy/pull/1700)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Removed unused positional \\[<MODEL>\\] from diff command",
+      "pull_requests": [
+        "[#1703](https://github.com/awslabs/smithy/pull/1703)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Ensured that the ValidationEvent listener gets all events when batch\ninclusions are used",
+      "pull_requests": [
+        "[#1698](https://github.com/awslabs/smithy/pull/1698)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed cp-R for linux, xcopy for windows in smithy-cli installers",
+      "pull_requests": [
+        "[#1686](https://github.com/awslabs/smithy/pull/1686)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed allowUnknownTraits for projection with import",
+      "pull_requests": [
+        "[#1685](https://github.com/awslabs/smithy/pull/1685)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed reversed parameters in diff message for RemovedOperationError",
+      "pull_requests": [
+        "[#1689](https://github.com/awslabs/smithy/pull/1689)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed hierarchical event ids lost when specifying a custom linter validator id\nor severity level",
+      "pull_requests": [
+        "[#1705](https://github.com/awslabs/smithy/pull/1705)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Improved handling additionalSchema targeting an invalid shape",
+      "pull_requests": [
+        "[#1708](https://github.com/awslabs/smithy/pull/1708)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Reduced IDL ambiguity by replacing \\*WS with [WS]",
+      "pull_requests": [
+        "[#1699](https://github.com/awslabs/smithy/pull/1699)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added compatibility note to evolving models",
+      "pull_requests": [
+        "[#1669](https://github.com/awslabs/smithy/pull/1669)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed mixins usage examples in style guide",
+      "pull_requests": [
+        "[#1670](https://github.com/awslabs/smithy/pull/1670)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed type in primitive root-level example",
+      "pull_requests": [
+        "[#1687](https://github.com/awslabs/smithy/pull/1687)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Removed recommendation to implement presence tracking when handling default\nvalues",
+      "pull_requests": [
+        "[#1682](https://github.com/awslabs/smithy/pull/1682)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Removed OperationBody indefinite repetition in IDL",
+      "pull_requests": [
+        "[#1707](https://github.com/awslabs/smithy/pull/1707)"
+      ]
+    }
+  ],
+  "date": "2023-04-03"
+}

--- a/.changes/releases/1.3.0.json
+++ b/.changes/releases/1.3.0.json
@@ -1,0 +1,128 @@
+{
+  "version": "1.3.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added several `CodegenWriter` and related abstractions to simplify creating\ncode generators.",
+      "pull_requests": [
+        "[#587](https://github.com/awslabs/smithy/pull/587)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `@sparse` trait to the Prelude.",
+      "pull_requests": [
+        "[#599](https://github.com/awslabs/smithy/pull/599)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `NullableIndex` to help check if a shape can be set to null.",
+      "pull_requests": [
+        "[#599](https://github.com/awslabs/smithy/pull/599)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for API Gateway API key usage plans.",
+      "pull_requests": [
+        "[#603](https://github.com/awslabs/smithy/pull/603)",
+        "[#605](https://github.com/awslabs/smithy/pull/605)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `sortMembers` model transform to reorder the members of structures\nand unions.",
+      "pull_requests": [
+        "[#588](https://github.com/awslabs/smithy/pull/588)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add `description` property to operations when converting to OpenAPI.",
+      "pull_requests": [
+        "[#589](https://github.com/awslabs/smithy/pull/589)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where the `flattenNamespaces` build transform was not\nregistered with the SPI.",
+      "pull_requests": [
+        "[#593](https://github.com/awslabs/smithy/pull/593)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified that `map` keys, `set` values, and `union` members cannot be null.",
+      "pull_requests": [
+        "[#596](https://github.com/awslabs/smithy/pull/596/)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified `enum` names and their usage.",
+      "pull_requests": [
+        "[#601](https://github.com/awslabs/smithy/pull/601)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added an example dependency to OpenAPI conversion.",
+      "pull_requests": [
+        "[#594](https://github.com/awslabs/smithy/pull/594)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Improve and clean up formatting.",
+      "pull_requests": [
+        "[#585](https://github.com/awslabs/smithy/pull/585)",
+        "[#597](https://github.com/awslabs/smithy/pull/597)",
+        "[#598](https://github.com/awslabs/smithy/pull/598)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Optimized the reverse `NeighborProvider` for memory usage.",
+      "pull_requests": [
+        "[#590](https://github.com/awslabs/smithy/pull/590)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Optimized model validation event aggregation for memory usage.",
+      "pull_requests": [
+        "[#595](https://github.com/awslabs/smithy/pull/595)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Updated `service`, `resource`, and `operation` shapes to maintain the order of\nbound `resource` and `operation` shapes.",
+      "pull_requests": [
+        "[#602](https://github.com/awslabs/smithy/pull/602)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Updated the `sources` build plugin to create an empty manifest if there are no\nsource models.",
+      "pull_requests": [
+        "[#607](https://github.com/awslabs/smithy/pull/607)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Deprecated the `BoxIndex`.",
+      "pull_requests": [
+        "[#599](https://github.com/awslabs/smithy/pull/599)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Added `enum` names for `httpApiKeyLocation` in the Prelude.",
+      "pull_requests": [
+        "[#606](https://github.com/awslabs/smithy/pull/606)"
+      ]
+    }
+  ],
+  "date": "2020-10-20"
+}

--- a/.changes/releases/1.30.0.json
+++ b/.changes/releases/1.30.0.json
@@ -1,0 +1,99 @@
+{
+  "version": "1.30.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Updated smithy-diff and smithy-build to use pretty validation output and color\ntheming options",
+      "pull_requests": [
+        "[#1712](https://github.com/awslabs/smithy/pull/1712)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added --mode flag to smithy diff command with support for `aribtrary`,\n`project`, and `git` modes",
+      "pull_requests": [
+        "[#1724](https://github.com/awslabs/smithy/pull/1724)",
+        "[#1721](https://github.com/awslabs/smithy/pull/1721)",
+        "[#1718](https://github.com/awslabs/smithy/pull/1718)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added --flatten flag to AST command which flattens and removes mixins from the\nmodel",
+      "pull_requests": [
+        "[#1723](https://github.com/awslabs/smithy/pull/1723)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Expose functions to make ruleEvaluator more flexible to support coverage\nchecking",
+      "pull_requests": [
+        "[#1681](https://github.com/awslabs/smithy/pull/1681)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Updated mixins to allow multiple mixins to override the same member if they\nall target the same shape",
+      "pull_requests": [
+        "[#1715](https://github.com/awslabs/smithy/pull/1715)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where source file names impacted the ordering of metadata",
+      "pull_requests": [
+        "[#1716](https://github.com/awslabs/smithy/pull/1716)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed error messages for invalid operation input/output bindings",
+      "pull_requests": [
+        "[#1728](https://github.com/awslabs/smithy/pull/1728)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed bugs in smithy-rules-engine boolEquals and stringEquals which could\ncause unexpected results when visitors are invoked",
+      "pull_requests": [
+        "[#1681](https://github.com/awslabs/smithy/pull/1681)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Remove unnecessary member from `aws.iam#actionName`",
+      "pull_requests": [
+        "[#1726](https://github.com/awslabs/smithy/pull/1726)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added guide on how to install the Smithy CLI",
+      "pull_requests": [
+        "[#1697](https://github.com/awslabs/smithy/pull/1697)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added examples of how smithy validators can be used to prevent common bugs and\nenforce common style",
+      "pull_requests": [
+        "[#1702](https://github.com/awslabs/smithy/pull/1702)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added clarification on meaning and use of `@httpApiKeyAuth` `scheme` property",
+      "pull_requests": [
+        "[#1714](https://github.com/awslabs/smithy/pull/1714)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Reduced IDL ambiguity by replacing \\*SP with [SP]",
+      "pull_requests": [
+        "[#1711](https://github.com/awslabs/smithy/pull/1711)"
+      ]
+    }
+  ],
+  "date": "2023-04-10"
+}

--- a/.changes/releases/1.31.0.json
+++ b/.changes/releases/1.31.0.json
@@ -1,0 +1,48 @@
+{
+  "version": "1.31.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added `@requestCompression` trait which indicates whether an operation\nsupports compressed requests",
+      "pull_requests": [
+        "[#1748](https://github.com/awslabs/smithy/pull/1748)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved IDL parser and added basic error recovery",
+      "pull_requests": [
+        "[#1733](https://github.com/awslabs/smithy/pull/1733)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added restJson1 protocol test for a list of structures missing a required key",
+      "pull_requests": [
+        "[#1735](https://github.com/awslabs/smithy/pull/1735)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added ability to order the output of the IDL serializer",
+      "pull_requests": [
+        "[#1727](https://github.com/awslabs/smithy/pull/1727)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Updated conversion from string shape with `@enum` trait to enum shape to\nconvert `internal` tag to `@internal` trait",
+      "pull_requests": [
+        "[#1739](https://github.com/awslabs/smithy/pull/1739)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added documentation for changeStringEnumsToEnumShapes transformation",
+      "pull_requests": [
+        "[#1740](https://github.com/awslabs/smithy/pull/1740)"
+      ]
+    }
+  ],
+  "date": "2023-04-25"
+}

--- a/.changes/releases/1.32.0.json
+++ b/.changes/releases/1.32.0.json
@@ -1,0 +1,144 @@
+{
+  "version": "1.32.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Refactor parsing and validation of `list` and `map` shapes. This improved\nvalidation output when unexpected members were present in these shapes",
+      "pull_requests": [
+        "[#1782](https://github.com/awslabs/smithy/pull/1782)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated smithy-build to output projection failures only after all plugins\nfinish running (failed or otherwise)",
+      "pull_requests": [
+        "[#1762](https://github.com/awslabs/smithy/pull/1762)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added new pluggable validation-event decorator capability. This allows for\ncustomizing of validation events through a service provider interface",
+      "pull_requests": [
+        "[#1774](https://github.com/awslabs/smithy/pull/1774)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added new diff-evaluator to emit events for when the `@required` trait is\nadded to existing structures without a default",
+      "pull_requests": [
+        "[##1781](https://github.com/awslabs/smithy/pull/1781)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved validation output for `@default` collisions",
+      "pull_requests": [
+        "[#1780](https://github.com/awslabs/smithy/pull/1780)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated `@httpQuery` trait validation to prevent query-literal and query-param\nconflicts",
+      "pull_requests": [
+        "[#1786](https://github.com/awslabs/smithy/pull/1786)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated default pagination flags to improve missing-pagination validation",
+      "pull_requests": [
+        "[#1764](https://github.com/awslabs/smithy/pull/1764)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated `SdkServiceIdValidator` to emit `DANGER` events instead of `ERROR`\nevents",
+      "pull_requests": [
+        "[#1772](https://github.com/awslabs/smithy/pull/1772)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated `ChangedEnumTrait` evaluator to include specific ids, in order to\ndifferentiate specific events",
+      "pull_requests": [
+        "[#1787](https://github.com/awslabs/smithy/pull/1787)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol tests to validate http-label escaping in the `restXml` protocol",
+      "pull_requests": [
+        "[#1759](https://github.com/awslabs/smithy/pull/1759)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for `@externalDocs` trait when converting operations in the\nOpenAPI converter",
+      "pull_requests": [
+        "[#1767](https://github.com/awslabs/smithy/pull/1767)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated a handful of specifications in the smithy-grammar to improve\nparsability",
+      "pull_requests": [
+        "[#1788](https://github.com/awslabs/smithy/pull/1788)",
+        "[#1790](https://github.com/awslabs/smithy/pull/1790)",
+        "[#1792](https://github.com/awslabs/smithy/pull/1792)",
+        "[#1793](https://github.com/awslabs/smithy/pull/1793)",
+        "[#1800](https://github.com/awslabs/smithy/pull/1800)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed `migrate` CLI command to properly upgrade 1/1.0 models to 2/2.0",
+      "pull_requests": [
+        "[#1579](https://github.com/awslabs/smithy/pull/1579)",
+        "[#1769](https://github.com/awslabs/smithy/pull/1769)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed application of enum-mixins on empty enums",
+      "pull_requests": [
+        "[#1794](https://github.com/awslabs/smithy/pull/1794)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed handling of dangling doc-comments in structures",
+      "pull_requests": [
+        "[#1776](https://github.com/awslabs/smithy/pull/1776)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed several smithy-grammar typos and consistency issues",
+      "pull_requests": [
+        "[#1783](https://github.com/awslabs/smithy/pull/1783)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added a warning about the limitations of request-validation in API-Gateway",
+      "pull_requests": [
+        "[#1765](https://github.com/awslabs/smithy/pull/1765)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated CLI installation guide for Windows to be more idiomatic",
+      "pull_requests": [
+        "[#1757](https://github.com/awslabs/smithy/pull/1757)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated protocol documentation pages to indicate support for the\n`@requestCompression` trait",
+      "pull_requests": [
+        "[#1763](https://github.com/awslabs/smithy/pull/1763)"
+      ]
+    }
+  ],
+  "date": "2023-06-06"
+}

--- a/.changes/releases/1.33.0.json
+++ b/.changes/releases/1.33.0.json
@@ -1,0 +1,100 @@
+{
+  "version": "1.33.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Extended event ids for `AddedOperationError`, `RemovedOperationError`,\n`AddedEntityBinding` and `RemovedEntityBinding` diff events",
+      "pull_requests": [
+        "[#1797](https://github.com/awslabs/smithy/pull/1797)",
+        "[#1803](https://github.com/awslabs/smithy/pull/1803)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added enum values to ids for `ChangedEnumTrait` diff events",
+      "pull_requests": [
+        "[#1807](https://github.com/awslabs/smithy/pull/1807)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `init` command to Smithy CLI",
+      "pull_requests": [
+        "[#1802](https://github.com/awslabs/smithy/pull/1802)",
+        "[#1825](https://github.com/awslabs/smithy/pull/1825)",
+        "[#1832](https://github.com/awslabs/smithy/pull/1832)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `smithy-syntax` package and `smithy format` command to Smithy CLI",
+      "pull_requests": [
+        "[#1830](https://github.com/awslabs/smithy/pull/1830)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed duplicated events for `ChangedNullability` alongside the\n`AddedInputTrait / RemovedInputTrait`",
+      "pull_requests": [
+        "[#1806](https://github.com/awslabs/smithy/pull/1806)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Updated request compression trait protocol tests with regard to HTTP bindings\nand respective specification",
+      "pull_requests": [
+        "[#1831](https://github.com/awslabs/smithy/pull/1831)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added `smithy-dafny` to code generators table",
+      "pull_requests": [
+        "[#1813](https://github.com/awslabs/smithy/pull/1813)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated stale docs around `MissingPaginatedTrait`",
+      "pull_requests": [
+        "[#1814](https://github.com/awslabs/smithy/pull/1814)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed grammar rendering",
+      "pull_requests": [
+        "[#1815](https://github.com/awslabs/smithy/pull/1815)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated recommendation for HTTP status code",
+      "pull_requests": [
+        "[#1818](https://github.com/awslabs/smithy/pull/1818)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed selector example",
+      "pull_requests": [
+        "[#1824](https://github.com/awslabs/smithy/pull/1824)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added note about how constraint traits affect backward compatibility",
+      "pull_requests": [
+        "[#1826](https://github.com/awslabs/smithy/pull/1826)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added guide on disabling authentication",
+      "pull_requests": [
+        "[#1791](https://github.com/awslabs/smithy/pull/1791)"
+      ]
+    }
+  ],
+  "date": "2023-06-21"
+}

--- a/.changes/releases/1.34.0.json
+++ b/.changes/releases/1.34.0.json
@@ -1,0 +1,55 @@
+{
+  "version": "1.34.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added a default template for the `smithy init` command, making specifying\ntemplates optional",
+      "pull_requests": [
+        "[#1843](https://github.com/awslabs/smithy/pull/1843)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated the model loader to skip unrecognized non-Smithy JSON files",
+      "pull_requests": [
+        "[#1846](https://github.com/awslabs/smithy/pull/1846)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed basic HTTP authentication when resolving dependencies in the Smithy CLI",
+      "pull_requests": [
+        "[#1838](https://github.com/awslabs/smithy/pull/1838)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug when deduping `ChangedNullability` events",
+      "pull_requests": [
+        "[#1839](https://github.com/awslabs/smithy/pull/1839)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Replaced implementation docs with the awesome-smithy repository",
+      "pull_requests": [
+        "[#1845](https://github.com/awslabs/smithy/pull/1845)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Removed support for fractional seconds from the `http-date` timestamp format",
+      "pull_requests": [
+        "[#1847](https://github.com/awslabs/smithy/pull/1847)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Rephrased optional fractional precision and no UTC offset support for the\n`date-time` timestamp format",
+      "pull_requests": [
+        "[#1835](https://github.com/awslabs/smithy/pull/1835)"
+      ]
+    }
+  ],
+  "date": "2023-07-10"
+}

--- a/.changes/releases/1.35.0.json
+++ b/.changes/releases/1.35.0.json
@@ -1,0 +1,133 @@
+{
+  "version": "1.35.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Enabled support for SNAPSHOT dependencies",
+      "pull_requests": [
+        "[#1853](https://github.com/smithy-lang/smithy/pull/1853)",
+        "[#1857](https://github.com/smithy-lang/smithy/pull/1857)",
+        "[#1884](https://github.com/smithy-lang/smithy/pull/1884)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Enabled default mode for `smithy diff` rather than failing when not set",
+      "pull_requests": [
+        "[#1856](https://github.com/smithy-lang/smithy/pull/1856)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added warning to mis-cased standard HTTP verbs",
+      "pull_requests": [
+        "[#1862](https://github.com/smithy-lang/smithy/pull/1862)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Relaxed type constraints for `pageSize` property of the `@paginated` trait",
+      "pull_requests": [
+        "[#1866](https://github.com/smithy-lang/smithy/pull/1866)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved message for invalid `.errors` entries",
+      "pull_requests": [
+        "[#1867](https://github.com/smithy-lang/smithy/pull/1867)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `docId` property to `aws.api#service` trait",
+      "pull_requests": [
+        "[#1863](https://github.com/smithy-lang/smithy/pull/1863)",
+        "[#1872](https://github.com/smithy-lang/smithy/pull/1872)",
+        "[#1881](https://github.com/smithy-lang/smithy/pull/1881)",
+        "[#1882](https://github.com/smithy-lang/smithy/pull/1882)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved validation for http binding protocols",
+      "pull_requests": [
+        "[#1873](https://github.com/smithy-lang/smithy/pull/1873)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Expanded valid targets of `@httpPayload`",
+      "pull_requests": [
+        "[#1876](https://github.com/smithy-lang/smithy/pull/1876)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated documentation around `timestamp` and added more specificity to the\ndefinition",
+      "pull_requests": [
+        "[#1858](https://github.com/smithy-lang/smithy/pull/1858)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Removed unrecognized models from sources",
+      "pull_requests": [
+        "[#1851](https://github.com/smithy-lang/smithy/pull/1851)",
+        "[#1860](https://github.com/smithy-lang/smithy/pull/1860)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Updated the content type of list & map shapes with the `@httpPayload` trait to\ndocument content type",
+      "pull_requests": [
+        "[#1840](https://github.com/smithy-lang/smithy/pull/1840)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed IDL serializer which would write emtpy `apply` statements to mixed in\nmembers of `enums`",
+      "pull_requests": [
+        "[#1865](https://github.com/smithy-lang/smithy/pull/1865)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed indentation when formatting text blocks",
+      "pull_requests": [
+        "[#1875](https://github.com/smithy-lang/smithy/pull/1875)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Added resource files to source jars",
+      "pull_requests": [
+        "[#1877](https://github.com/smithy-lang/smithy/pull/1877)",
+        "[#1880](https://github.com/smithy-lang/smithy/pull/1880)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a potential resource leak by using a try with resources",
+      "pull_requests": [
+        "[#1878](https://github.com/smithy-lang/smithy/pull/1878)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Migrated to using Gradle 8.2.1 to build Smithy. This should have no impactful\ndownstream effects",
+      "pull_requests": [
+        "[#1849](https://github.com/smithy-lang/smithy/pull/1849)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Moved repository into `smithy-lang` organization and updated resources\naccordingly",
+      "pull_requests": [
+        "[#1852](https://github.com/smithy-lang/smithy/pull/1852)",
+        "[#1854](https://github.com/smithy-lang/smithy/pull/1854)"
+      ]
+    }
+  ],
+  "date": "2023-07-27"
+}

--- a/.changes/releases/1.36.0.json
+++ b/.changes/releases/1.36.0.json
@@ -1,0 +1,139 @@
+{
+  "version": "1.36.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Allowed disabling format on integers when converting to OpenAPI",
+      "pull_requests": [
+        "[#1904](https://github.com/smithy-lang/smithy/pull/1904)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added intEnum support when converting to OpenAPI",
+      "pull_requests": [
+        "[#1898](https://github.com/smithy-lang/smithy/pull/1898)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for overriding validation severity",
+      "pull_requests": [
+        "[#1890](https://github.com/smithy-lang/smithy/pull/1890)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `disableDefaultValues` option when converting to OpenAPI",
+      "pull_requests": [
+        "[#1887](https://github.com/smithy-lang/smithy/pull/1887)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated brew workflow to use new smithy tap",
+      "pull_requests": [
+        "[#1897](https://github.com/smithy-lang/smithy/pull/1897)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added progress tracker and message for CLI while cloning a template",
+      "pull_requests": [
+        "[#1888](https://github.com/smithy-lang/smithy/pull/1888)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated init command to honor quiet setting",
+      "pull_requests": [
+        "[#1889](https://github.com/smithy-lang/smithy/pull/1889)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated appearance of smithy init list output",
+      "pull_requests": [
+        "[#1901](https://github.com/smithy-lang/smithy/pull/1901)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added exceptions for invalid paths in template definition",
+      "pull_requests": [
+        "[#1907](https://github.com/smithy-lang/smithy/pull/1907)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added Cache template directory in init command",
+      "pull_requests": [
+        "[#1896](https://github.com/smithy-lang/smithy/pull/1896)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Check for existing directory when creating template with init",
+      "pull_requests": [
+        "[#1885](https://github.com/smithy-lang/smithy/pull/1885)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified constraint trait enforcement",
+      "pull_requests": [
+        "[#1902](https://github.com/smithy-lang/smithy/pull/1902)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Better document trait merging",
+      "pull_requests": [
+        "[#1895](https://github.com/smithy-lang/smithy/pull/1895)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated docs to use new smithy-lang tap",
+      "pull_requests": [
+        "[#1893](https://github.com/smithy-lang/smithy/pull/1893)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added naming recommendations",
+      "pull_requests": [
+        "[#1892](https://github.com/smithy-lang/smithy/pull/1892)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed NPE when docId is null when ServiceTrait.equals is called",
+      "pull_requests": [
+        "[#1903](https://github.com/smithy-lang/smithy/pull/1903)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed off-by-one issues in TokenTree and TreeCursor",
+      "pull_requests": [
+        "[#1891](https://github.com/smithy-lang/smithy/pull/1891)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed snapshot dependency resolution",
+      "pull_requests": [
+        "[#1884](https://github.com/smithy-lang/smithy/pull/1884)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Use standard output for regular messages",
+      "pull_requests": [
+        "[#1894](https://github.com/smithy-lang/smithy/pull/1894)"
+      ]
+    }
+  ],
+  "date": "2023-08-03"
+}

--- a/.changes/releases/1.37.0.json
+++ b/.changes/releases/1.37.0.json
@@ -1,0 +1,118 @@
+{
+  "version": "1.37.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Formatted operation errors onto multiple lines",
+      "pull_requests": [
+        "[#1933](https://github.com/smithy-lang/smithy/pull/1933)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for creating specific `TreeType` to smithy-syntax",
+      "pull_requests": [
+        "[#1925](https://github.com/smithy-lang/smithy/pull/1925)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validator for services with noAuth trait",
+      "pull_requests": [
+        "[#1929](https://github.com/smithy-lang/smithy/pull/1929)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added ServiceIndex method for noAuth scheme",
+      "pull_requests": [
+        "[#1924](https://github.com/smithy-lang/smithy/pull/1924)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added warning on addition of required trait",
+      "pull_requests": [
+        "[#1923](https://github.com/smithy-lang/smithy/pull/1923)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added versioning for API Gateway defaults",
+      "pull_requests": [
+        "[#1916](https://github.com/smithy-lang/smithy/pull/1916)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for enum map keys with OpenApi 3.1.0",
+      "pull_requests": [
+        "[#1905](https://github.com/smithy-lang/smithy/pull/1905)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for suppressions to smithy-diff",
+      "pull_requests": [
+        "[#1861](https://github.com/smithy-lang/smithy/pull/1861)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `specificationExtension` trait for OpenAPI extensions",
+      "pull_requests": [
+        "[#1609](https://github.com/smithy-lang/smithy/pull/1609)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `conditionKeyValue` and `conditionKeysResolvedByService` traits",
+      "pull_requests": [
+        "[#1677](https://github.com/smithy-lang/smithy/pull/1677)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated `getAuthSchemes` javadoc",
+      "pull_requests": [
+        "[#1930](https://github.com/smithy-lang/smithy/pull/1930)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified `default` and `clientOptional` traits",
+      "pull_requests": [
+        "[#1920](https://github.com/smithy-lang/smithy/pull/1920)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed version numbers in smithy-build.json examples",
+      "pull_requests": [
+        "[#1918](https://github.com/smithy-lang/smithy/pull/1918)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified ordering of auth schemes in ServiceIndex",
+      "pull_requests": [
+        "[#1915](https://github.com/smithy-lang/smithy/pull/1915)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Included prelude in spec",
+      "pull_requests": [
+        "[#1913](https://github.com/smithy-lang/smithy/pull/1913)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed assembler addTraits for some resource models",
+      "pull_requests": [
+        "[#1927](https://github.com/smithy-lang/smithy/pull/1927)"
+      ]
+    }
+  ],
+  "date": "2023-08-22"
+}

--- a/.changes/releases/1.38.0.json
+++ b/.changes/releases/1.38.0.json
@@ -1,0 +1,173 @@
+{
+  "version": "1.38.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Updated auto-formatting to use line breaks for some properties",
+      "pull_requests": [
+        "[#1939](https://github.com/smithy-lang/smithy/pull/1939)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated JSON-based AWS protocols to ignore the `__type` field when\ndeserializing `union`s",
+      "pull_requests": [
+        "[#1945](https://github.com/smithy-lang/smithy/pull/1945)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added metadata key to `RemovedMetadata` diff events",
+      "pull_requests": [
+        "[#1940](https://github.com/smithy-lang/smithy/pull/1940)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved equality comparison for `NumberNode` instances",
+      "pull_requests": [
+        "[#1955](https://github.com/smithy-lang/smithy/pull/1955)",
+        "[#1965](https://github.com/smithy-lang/smithy/pull/1965)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `--aut` as a shortcut for `--allow-unknown-traits` in the Smithy CLI",
+      "pull_requests": [
+        "[#1950](https://github.com/smithy-lang/smithy/pull/1950)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a `--show` option to the Smithy CLI to include extra information like\ntype, source location, and captured variables. This deprecates the\n`--show-vars` option",
+      "pull_requests": [
+        "[#1953](https://github.com/smithy-lang/smithy/pull/1953)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation to emit warnings when a member has an HTTP trait applied in a\ncontext where it is ignored",
+      "pull_requests": [
+        "[#1962](https://github.com/smithy-lang/smithy/pull/1962)",
+        "[#1969](https://github.com/smithy-lang/smithy/pull/1969)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation to check the consistency of IAM resource names and ARN\nresource names",
+      "pull_requests": [
+        "[#1954](https://github.com/smithy-lang/smithy/pull/1954)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a `RemoveInvalidDefaults` transform to remove `@default` traits when\ntheir values conflict with applied `@range` traits",
+      "pull_requests": [
+        "[#1964](https://github.com/smithy-lang/smithy/pull/1964)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added an `allowConstraintErrors` property to the `@examples` trait for\nrelaxing content validation requirements",
+      "pull_requests": [
+        "[#1949](https://github.com/smithy-lang/smithy/pull/1949)",
+        "[#1968](https://github.com/smithy-lang/smithy/pull/1968)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added several protocol tests for `@restXml`",
+      "pull_requests": [
+        "[#1909](https://github.com/smithy-lang/smithy/pull/1909)",
+        "[#1908](https://github.com/smithy-lang/smithy/pull/1908)",
+        "[#1574](https://github.com/smithy-lang/smithy/pull/1574)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added several protocol tests for `@restJson1`",
+      "pull_requests": [
+        "[#1908](https://github.com/smithy-lang/smithy/pull/1908)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified how trait values are provided in the IDL",
+      "pull_requests": [
+        "[#1944](https://github.com/smithy-lang/smithy/pull/1944)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added the `@length` trait to the specification's trait index",
+      "pull_requests": [
+        "[#1952](https://github.com/smithy-lang/smithy/pull/1952)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Improved the ability to link to certain sections of the specification",
+      "pull_requests": [
+        "[#1958](https://github.com/smithy-lang/smithy/pull/1958)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified behavior of `@sigv4` and `@optionalAuth`",
+      "pull_requests": [
+        "[#1963](https://github.com/smithy-lang/smithy/pull/1963)",
+        "[#1971](https://github.com/smithy-lang/smithy/pull/1971)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed diff event messages for `ChangedNullability` events",
+      "pull_requests": [
+        "[#1972](https://github.com/smithy-lang/smithy/pull/1972)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an NPE when auto-formatting certain types of trait values",
+      "pull_requests": [
+        "[#1942](https://github.com/smithy-lang/smithy/pull/1942)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where exceptions thrown when creating traits were not emitted\nas validation events",
+      "pull_requests": [
+        "[#1947](https://github.com/smithy-lang/smithy/pull/1947)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue validating timestamp members in nodes where a\n`@timestampFormat` trait was involved",
+      "pull_requests": [
+        "[#1948](https://github.com/smithy-lang/smithy/pull/1948)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where the `FlattenAndRemoveMixins` transform would not remove\nunused mixins",
+      "pull_requests": [
+        "[#1951](https://github.com/smithy-lang/smithy/pull/1951)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a malformed request test for the `@restJson1` protocol",
+      "pull_requests": [
+        "[#1959](https://github.com/smithy-lang/smithy/pull/1959)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where `NonInclusiveTerms` validation events would be identical\nfor different text paths.",
+      "pull_requests": [
+        "[#1975](https://github.com/smithy-lang/smithy/pull/1975)"
+      ]
+    }
+  ],
+  "date": "2023-09-14"
+}

--- a/.changes/releases/1.39.0.json
+++ b/.changes/releases/1.39.0.json
@@ -1,0 +1,34 @@
+{
+  "version": "1.39.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Refactored `smithy-rules-engine` significantly in an effort to improve\nvalidation, separate AWS and non-AWS concerns, add a specification, and more.\nGeneral notes are provided in individual commit messages. The format of the\nrules documents have not changed, meaning a successful migration to the\nrefactored codebase will involve no changes to code generated for an SDK\nclient",
+      "pull_requests": [
+        "[#1855](https://github.com/smithy-lang/smithy/pull/1855)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `Sha1` checksum to `ResolvedArtifacts`",
+      "pull_requests": [
+        "[#1979](https://github.com/smithy-lang/smithy/pull/1979)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Relaxed `Content-Length` in unset union payloads protocol tests",
+      "pull_requests": [
+        "[#1984](https://github.com/smithy-lang/smithy/pull/1984)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated example by keeping operation list from previous examples",
+      "pull_requests": [
+        "[#1981](https://github.com/smithy-lang/smithy/pull/1981)"
+      ]
+    }
+  ],
+  "date": "2023-09-25"
+}

--- a/.changes/releases/1.39.1.json
+++ b/.changes/releases/1.39.1.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.39.1",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Fix several issues with validating `authSchemes` configurations for endpoints\nin the `smithy-rules-engine` package for both AWS and non-AWS issues.",
+      "pull_requests": [
+        "[#1990](https://github.com/smithy-lang/smithy/pull/1990)"
+      ]
+    }
+  ],
+  "date": "2023-09-26"
+}

--- a/.changes/releases/1.4.0.json
+++ b/.changes/releases/1.4.0.json
@@ -1,0 +1,154 @@
+{
+  "version": "1.4.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added `smithy-jmespath`, a dependency-less, JMESPath parser with a rich AST\nthat can be used in code generation, and performs static analysis of\nexpressions.",
+      "pull_requests": [
+        "[#621](https://github.com/awslabs/smithy/pull/621)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `smithy-waiters`, containing the `@waitable` trait. This provides\ninformation that clients can use to poll until a desired state is reached, or\nit is determined that state cannot be reached.",
+      "pull_requests": [
+        "[#623](https://github.com/awslabs/smithy/pull/623)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `smithy-aws-cloudformation-traits`, containing several (unstable) traits\nthat indicate CloudFormation resources and the additional metadata about their\nproperties.",
+      "pull_requests": [
+        "[#579](https://github.com/awslabs/smithy/pull/579)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `smithy-aws-cloudformation`, containing the (unstable) \"cloudformation\"\nbuild tool that, given a model decorated with traits from\n`aws.cloudformation`, will generate CloudFormation Resource Schemas.",
+      "pull_requests": [
+        "[#622](https://github.com/awslabs/smithy/pull/622)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for `patternProperties` when generating JSON Schema.",
+      "pull_requests": [
+        "[#611](https://github.com/awslabs/smithy/pull/611)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added more utility methods to the `CodeWriter`.",
+      "pull_requests": [
+        "[#624](https://github.com/awslabs/smithy/pull/624)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation for `@sensitive` trait when applied to members.",
+      "pull_requests": [
+        "[#609](https://github.com/awslabs/smithy/pull/609)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for retrieving full paths to the `outputToken` and `items`\npagination members.",
+      "pull_requests": [
+        "[#628](https://github.com/awslabs/smithy/pull/628)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a warning for `@enum` entries without names.",
+      "pull_requests": [
+        "[#610](https://github.com/awslabs/smithy/pull/610)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for generating an `integer` OpenAPI type.",
+      "pull_requests": [
+        "[#632](https://github.com/awslabs/smithy/pull/632)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved `smithy-diff` evaluation of changing member targets.",
+      "pull_requests": [
+        "[#630](https://github.com/awslabs/smithy/pull/630)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated pagination tokens to support being `map` shapes.",
+      "pull_requests": [
+        "[#629](https://github.com/awslabs/smithy/pull/629)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug where URIs would be declared conflicting if the differed through\nthe `@endpoint` trait.",
+      "pull_requests": [
+        "[#626](https://github.com/awslabs/smithy/pull/626)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug that would allow the `@aws.auth#sigv4` trait's `name` property to\nbe empty.",
+      "pull_requests": [
+        "[#635](https://github.com/awslabs/smithy/pull/635)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Updated protocol tests for `@sparse` trait.",
+      "pull_requests": [
+        "[#620](https://github.com/awslabs/smithy/pull/620)",
+        "[#631](https://github.com/awslabs/smithy/pull/631)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug with the interaction of `CodeWriter.writeInline` with sections.",
+      "pull_requests": [
+        "[#617](https://github.com/awslabs/smithy/pull/617)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed links for protocol test suites.",
+      "pull_requests": [
+        "[#615](https://github.com/awslabs/smithy/pull/615)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added example and test for composing with `CodeWriter`.",
+      "pull_requests": [
+        "[#619](https://github.com/awslabs/smithy/pull/619)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified that `@enum` values cannot be empty.",
+      "pull_requests": [
+        "[#633](https://github.com/awslabs/smithy/pull/633)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified binary data in protocol tests.",
+      "pull_requests": [
+        "[#634](https://github.com/awslabs/smithy/pull/634)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Lowered severity of validation that a `pageSize` member is marked `@required`.",
+      "pull_requests": [
+        "[#612](https://github.com/awslabs/smithy/pull/612)"
+      ]
+    }
+  ],
+  "date": "2020-11-20"
+}

--- a/.changes/releases/1.40.0.json
+++ b/.changes/releases/1.40.0.json
@@ -1,0 +1,83 @@
+{
+  "version": "1.40.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added new protocol tests for the `restXml` protocol, which assert\nrequest/response behaviors for string payloads.",
+      "pull_requests": [
+        "[#2007](https://github.com/smithy-lang/smithy/pull/2007)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added new package, `smithy-smoke-test-traits`, which defines the traits for\nsmoke tests. This package contains the smithy model definitions of said\ntraits, their java implementations, and unit tests.",
+      "pull_requests": [
+        "[#2005](https://github.com/smithy-lang/smithy/pull/2005)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added auth-scheme validator that runs for SigV4 sub-schemes as part of the AWS\nrule-set in `smithy-rules-engine`.",
+      "pull_requests": [
+        "[#2000](https://github.com/smithy-lang/smithy/pull/2000)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `AccountId` and `CredentialScope` parameters for AWS-specific endpoint\nrules in `smithy-rules-engine`.",
+      "pull_requests": [
+        "[#1993](https://github.com/smithy-lang/smithy/pull/1993)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added traits anchors for a few traits that were previously missing.",
+      "pull_requests": [
+        "[#2008](https://github.com/smithy-lang/smithy/pull/2008)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added `Smithy Examples` embedding to the [smithy.io](https://smithy.io)\nsidebar under `Project`.",
+      "pull_requests": [
+        "[#2006](https://github.com/smithy-lang/smithy/pull/2006)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added important notice for the `@contextParam` trait to clarify expected\nbehavior of clients when `@required` is used on the same\nmember.",
+      "pull_requests": [
+        "[#1999](https://github.com/smithy-lang/smithy/pull/1999)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed missing source-locations in emitted events by `smithy-diff`. Previously,\n`N/A` would be displayed instead of the real location.",
+      "pull_requests": [
+        "[#2001](https://github.com/smithy-lang/smithy/pull/2001)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Added missing method override in `smithy-rules-engine`.",
+      "pull_requests": [
+        "[#1998](https://github.com/smithy-lang/smithy/pull/1998)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed bug where properties of resource shapes were not being serialized in the\nIDL serializer.",
+      "pull_requests": [
+        "[#1996](https://github.com/smithy-lang/smithy/pull/1996)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue with OpenAPI conversion not allowing multiple errors for a\nsingle status code with an opt-in that uses `oneOf` to de-conflict the errors.",
+      "pull_requests": [
+        "[#1995](https://github.com/smithy-lang/smithy/pull/1995)"
+      ]
+    }
+  ],
+  "date": "2023-10-16"
+}

--- a/.changes/releases/1.41.0.json
+++ b/.changes/releases/1.41.0.json
@@ -1,0 +1,153 @@
+{
+  "version": "1.41.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added new member to `@aws.iam#iamResource` for disabling condition key\ninheritance.",
+      "pull_requests": [
+        "[#2036](https://github.com/smithy-lang/smithy/pull/2036)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added new trait for defining IAM actions, which consolidates and deprecates\nseveral older IAM traits.",
+      "pull_requests": [
+        "[#2034](https://github.com/smithy-lang/smithy/pull/2034)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added convenience method, `expectIntEnumShape`, to `GenerateIntEnumDirective`\nto get an `IntEnumShape`",
+      "pull_requests": [
+        "[#2033](https://github.com/smithy-lang/smithy/pull/2033)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added plugin to `NodeValidationVisitor` to ensure collections with\n`@uniqueItems` trait have unique-ness enforced.",
+      "pull_requests": [
+        "[#2031](https://github.com/smithy-lang/smithy/pull/2031)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added new member to `@aws.iam#iamResource` and `@aws.iam#defineConditionKeys`\ntraits for defining a relative URL path of documentation.",
+      "pull_requests": [
+        "[#2027](https://github.com/smithy-lang/smithy/pull/2027)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Migrated IAM traits JSON file to IDL file in `smithy-aws-iam-traits`.",
+      "pull_requests": [
+        "[#2026](https://github.com/smithy-lang/smithy/pull/2026)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol test for verifying behavior when handling unknown union members\nin the `restJson1` protocol.",
+      "pull_requests": [
+        "[#2022](https://github.com/smithy-lang/smithy/pull/2022)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Enabled `aws.iam#disableConditionKeyInference` trait to be applicable to\nservice shapes.",
+      "pull_requests": [
+        "[#2019](https://github.com/smithy-lang/smithy/pull/2019)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated `partitions.json` with two new entries, `aws-iso-e` and `aws-iso-f` to\nbe consistent with SDKs.",
+      "pull_requests": [
+        "[#2018](https://github.com/smithy-lang/smithy/pull/2018)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added event-id subparts to `ClientEndpointDiscoveryValidator` to clarify\nvalidation events.",
+      "pull_requests": [
+        "[#2017](https://github.com/smithy-lang/smithy/pull/2017)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added configuration for plugin integrations in `smithy-build.json`.",
+      "pull_requests": [
+        "[#2014](https://github.com/smithy-lang/smithy/pull/2014)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol tests for verifying behavior of default values in the\n`awsJson1_1` protocol.",
+      "pull_requests": [
+        "[#2002](https://github.com/smithy-lang/smithy/pull/2002)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added several new traits for modelling declarative endpoints.",
+      "pull_requests": [
+        "[#1987](https://github.com/smithy-lang/smithy/pull/1987)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added basic website analytics so that engagement can be measured.",
+      "pull_requests": [
+        "[#2025](https://github.com/smithy-lang/smithy/pull/2025)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added documentation for new traits added for declarative endpoints.",
+      "pull_requests": [
+        "[#2013](https://github.com/smithy-lang/smithy/pull/2013)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed handling and deconflicting of duplicate apply statements targetting\nmixed-in members",
+      "pull_requests": [
+        "[#2030](https://github.com/smithy-lang/smithy/pull/2030)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an NPE in the `PluginContext.toBuilder` method in `PluginContext`.",
+      "pull_requests": [
+        "[#2028](https://github.com/smithy-lang/smithy/pull/2028)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a trait parse error for shape IDs.",
+      "pull_requests": [
+        "[#2023](https://github.com/smithy-lang/smithy/pull/2023)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed several major issues with how neighbors and model graph traversal was\nimplemented.",
+      "pull_requests": [
+        "[#2020](https://github.com/smithy-lang/smithy/pull/2020)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Added expect-check to mitigate NSE exception in `PrivateAccessValidator`.",
+      "pull_requests": [
+        "[#2015](https://github.com/smithy-lang/smithy/pull/2015)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed equality of `@examples` traits by overriding the `equals` method in\n`ExampleTrait`.",
+      "pull_requests": [
+        "[#2009](https://github.com/smithy-lang/smithy/pull/2009)"
+      ]
+    }
+  ],
+  "date": "2023-11-08"
+}

--- a/.changes/releases/1.41.1.json
+++ b/.changes/releases/1.41.1.json
@@ -1,0 +1,41 @@
+{
+  "version": "1.41.1",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added support for `sdkId`s with a single character",
+      "pull_requests": [
+        "[#2043](https://github.com/smithy-lang/smithy/pull/2043)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed `toShapeId` call in `EndpointModifierIndex`",
+      "pull_requests": [
+        "[#2044](https://github.com/smithy-lang/smithy/pull/2044)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed removal of applied non-prelude meta traits",
+      "pull_requests": [
+        "[#2042](https://github.com/smithy-lang/smithy/pull/2042)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed `recommended` trait provider to avoid discarding `reason`",
+      "pull_requests": [
+        "[#2041](https://github.com/smithy-lang/smithy/pull/2041)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated the javadoc of `ValidatedResult.unwrap` to note that `DANGER` events\nalso throw a validation event",
+      "pull_requests": [
+        "[#2040](https://github.com/smithy-lang/smithy/pull/2040)"
+      ]
+    }
+  ],
+  "date": "2023-11-16"
+}

--- a/.changes/releases/1.42.0.json
+++ b/.changes/releases/1.42.0.json
@@ -1,0 +1,49 @@
+{
+  "version": "1.42.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added the `@aws.auth#sigv4a` auth trait.",
+      "pull_requests": [
+        "[#2032](https://github.com/smithy-lang/smithy/pull/2032)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `timestampFormat` and `httpChecksumRequired` traits to protocols.",
+      "pull_requests": [
+        "[#2054](https://github.com/smithy-lang/smithy/pull/2054)",
+        "[#2061](https://github.com/smithy-lang/smithy/pull/2061)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed conversion of root `intEnum` shape to IDL 1.0 when the shape doesn't\nhave a default value of 0.",
+      "pull_requests": [
+        "[#2053](https://github.com/smithy-lang/smithy/pull/2053)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed equality of `@examples` traits by overriding the `equals` method in\n`ExampleTrait.ErrorExample`.",
+      "pull_requests": [
+        "[#2052](https://github.com/smithy-lang/smithy/pull/2052)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated documentation for auth traits.",
+      "pull_requests": [
+        "[#2051](https://github.com/smithy-lang/smithy/pull/2051)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added documentation for smoke tests.",
+      "pull_requests": [
+        "[#2057](https://github.com/smithy-lang/smithy/pull/2057)"
+      ]
+    }
+  ],
+  "date": "2023-12-07"
+}

--- a/.changes/releases/1.43.0.json
+++ b/.changes/releases/1.43.0.json
@@ -1,0 +1,132 @@
+{
+  "version": "1.43.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Updated `RemovedShape` diff event severity from `ERROR` to `WARNING` for\nscalar shapes.",
+      "pull_requests": [
+        "[#2037](https://github.com/smithy-lang/smithy/pull/2037)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Made `parameterizedTestSource` public, allowing users to use a customized\nsuite as a source for JUnit parameterized tests.",
+      "pull_requests": [
+        "[#2087](https://github.com/smithy-lang/smithy/pull/2087)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Refactored `ReplaceShapes` transform to improve efficiency.",
+      "pull_requests": [
+        "[#2082](https://github.com/smithy-lang/smithy/pull/2082)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation for endpoint patterns used by `standardRegionalEndpoints` and\n`standardPartitionalEndpoints`.",
+      "pull_requests": [
+        "[#2069](https://github.com/smithy-lang/smithy/pull/2069)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for CLI dependency resolution via proxy.",
+      "pull_requests": [
+        "[#2076](https://github.com/smithy-lang/smithy/pull/2076)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved efficiency of `ReplaceShapes` transform by only building container\nshapes once when multiple members are changed.",
+      "pull_requests": [
+        "[#2081](https://github.com/smithy-lang/smithy/pull/2081)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Moved `allowOptionalNull` to `NodeValidationVisitor.Feature`.",
+      "pull_requests": [
+        "[#2080](https://github.com/smithy-lang/smithy/pull/2080)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added rules engine built-in for `AccountIdEndpointMode`.",
+      "pull_requests": [
+        "[#2065](https://github.com/smithy-lang/smithy/pull/2065)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added [JReleaser](https://jreleaser.org/) config.",
+      "pull_requests": [
+        "[#2059](https://github.com/smithy-lang/smithy/pull/2059)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added ability to find all operations for which a shape is used as an input,\noutput, or error.",
+      "pull_requests": [
+        "[#2064](https://github.com/smithy-lang/smithy/pull/2064)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Split InputOutput shapes into separate request and response shapes for\n`restXml` protocol tests.",
+      "pull_requests": [
+        "[#2063](https://github.com/smithy-lang/smithy/pull/2063)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where `@iamAction` wasn't reflected in CFN resource schema\ncreation.",
+      "pull_requests": [
+        "[#2091](https://github.com/smithy-lang/smithy/pull/2091)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed tree node start and end locations.",
+      "pull_requests": [
+        "[#2084](https://github.com/smithy-lang/smithy/pull/2084)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed several minor build warnings.",
+      "pull_requests": [
+        "[2089](https://github.com/smithy-lang/smithy/pull/2089)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed protocol test service signing name for `awsJson1_1` protocol.",
+      "pull_requests": [
+        "[#2089](https://github.com/smithy-lang/smithy/pull/2089)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Updated member removal for `ReplaceShapes` transform to ensure enum and\nintEnum members are correctly removed.",
+      "pull_requests": [
+        "[#2082](https://github.com/smithy-lang/smithy/pull/2082)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Corrected erroneous outer tags in `restXml` protocol tests",
+      "pull_requests": [
+        "[#2071](https://github.com/smithy-lang/smithy/pull/2071)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added documentation for configuring CLI dependency resolution via proxy.",
+      "pull_requests": [
+        "[#2083](https://github.com/smithy-lang/smithy/pull/2083)"
+      ]
+    }
+  ],
+  "date": "2024-01-05"
+}

--- a/.changes/releases/1.44.0.json
+++ b/.changes/releases/1.44.0.json
@@ -1,0 +1,132 @@
+{
+  "version": "1.44.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Add AWS smoke test model package.",
+      "pull_requests": [
+        "[#2113](https://github.com/smithy-lang/smithy/pull/2113)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add more traits to protocol test services",
+      "pull_requests": [
+        "[#2117](https://github.com/smithy-lang/smithy/pull/2117)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Enable custom inline suffixes in IDL serializer",
+      "pull_requests": [
+        "[#2121](https://github.com/smithy-lang/smithy/pull/2121)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Keep trailing doc comment spaces in IDL serializer",
+      "pull_requests": [
+        "[#2116](https://github.com/smithy-lang/smithy/pull/2116)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Expand protocol tests for default values.",
+      "pull_requests": [
+        "[#2049](https://github.com/smithy-lang/smithy/pull/2049)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add protocol tests for 0/false in query params.",
+      "pull_requests": [
+        "[#2070](https://github.com/smithy-lang/smithy/pull/2070)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Change line break formatting in brackets.",
+      "pull_requests": [
+        "[#2072](https://github.com/smithy-lang/smithy/pull/2072)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add backticks to diff messages for trait changes.",
+      "pull_requests": [
+        "[#2075](https://github.com/smithy-lang/smithy/pull/2075)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Support internal trait when building synthetic enum trait.",
+      "pull_requests": [
+        "[#2106](https://github.com/smithy-lang/smithy/pull/2106)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add \"critical\" validation phase to validation.",
+      "pull_requests": [
+        "[#2098](https://github.com/smithy-lang/smithy/pull/2098)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Deprecated IAM Action traits that are now formally superseded by `@iamAction`.",
+      "pull_requests": [
+        "[#2095](https://github.com/smithy-lang/smithy/pull/2095)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added ability to override AWS endpoints partitions when needed.",
+      "pull_requests": [
+        "[#2092](https://github.com/smithy-lang/smithy/pull/2092)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fail when duplicate members are found in enum/intEnum shapes.",
+      "pull_requests": [
+        "[#2112](https://github.com/smithy-lang/smithy/pull/2112)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Check references via idRef when looking for unreferenced shapes.",
+      "pull_requests": [
+        "[#2105](https://github.com/smithy-lang/smithy/pull/2105)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Remove service renames after flattening namespaces.",
+      "pull_requests": [
+        "[#2109](https://github.com/smithy-lang/smithy/pull/2109)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed issue where endpoint modifier traits without a valid shape definition\nwere being indexed.",
+      "pull_requests": [
+        "[#2096](https://github.com/smithy-lang/smithy/pull/2096)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Upgrade sphinx for docs.",
+      "pull_requests": [
+        "[#2100](https://github.com/smithy-lang/smithy/pull/2100)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated several of the guide sections and tidied up the layout.",
+      "pull_requests": [
+        "[#2097](https://github.com/smithy-lang/smithy/pull/2097)"
+      ]
+    }
+  ],
+  "date": "2024-01-25"
+}

--- a/.changes/releases/1.45.0.json
+++ b/.changes/releases/1.45.0.json
@@ -1,0 +1,62 @@
+{
+  "version": "1.45.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added new option to CLI to configure the format (`text` or `csv`) of\nvalidation output.",
+      "pull_requests": [
+        "[#2133](https://github.com/smithy-lang/smithy/pull/2133)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added options to CLI to hide or show validation events for specified\nvalidators.",
+      "pull_requests": [
+        "[#2127](https://github.com/smithy-lang/smithy/pull/2127)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol tests for verifying serialization/deserialization behavior for\nmaps with document values.",
+      "pull_requests": [
+        "[#2125](https://github.com/smithy-lang/smithy/pull/2125)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Changed `UnreferencedShape` to be an opt-in linter instead of on-by-default to\nreduce friction when defining common shapes that are not connected to a\nservice shape. Added a validator that allows you to configure what shape to\ncheck connectedness (defaults to service shape).",
+      "pull_requests": [
+        "[#2119](https://github.com/smithy-lang/smithy/pull/2119)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed headers when printing validation event output in csv format.",
+      "pull_requests": [
+        "[#2136](https://github.com/smithy-lang/smithy/pull/2136)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed `RestJsonZeroAndFalseQueryValues` protocol test to correctly include a\nparams value for servers.",
+      "pull_requests": [
+        "[#2132](https://github.com/smithy-lang/smithy/pull/2132)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed regression in model validation that incorrectly allowed suppression of\nERROR events.",
+      "pull_requests": [
+        "[#2130](https://github.com/smithy-lang/smithy/pull/2130)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed typo in @pattern validation example.",
+      "pull_requests": [
+        "[#2126](https://github.com/smithy-lang/smithy/pull/2126)"
+      ]
+    }
+  ],
+  "date": "2024-02-14"
+}

--- a/.changes/releases/1.46.0.json
+++ b/.changes/releases/1.46.0.json
@@ -1,0 +1,156 @@
+{
+  "version": "1.46.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added protocol tests for `null` values in unions.",
+      "pull_requests": [
+        "[#2180](https://github.com/smithy-lang/smithy/pull/2180)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated `ec2QueryName` tests to reflect usage.",
+      "pull_requests": [
+        "[#2186](https://github.com/smithy-lang/smithy/pull/2186)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated model validation and protocol tests to use the new Gradle plugins.",
+      "pull_requests": [
+        "[#2176](https://github.com/smithy-lang/smithy/pull/2176)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added data-shape-only visitor class.",
+      "pull_requests": [
+        "[#2168](https://github.com/smithy-lang/smithy/pull/2168)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol tests for S3 when dots are part of a key segment.",
+      "pull_requests": [
+        "[#2166](https://github.com/smithy-lang/smithy/pull/2166)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `@traitValidators` trait that can constrain shape closures.",
+      "pull_requests": [
+        "[#2156](https://github.com/smithy-lang/smithy/pull/2156)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added logic to infer default inline I/O suffixes in the IDL serializer.",
+      "pull_requests": [
+        "[#2122](https://github.com/smithy-lang/smithy/pull/2122)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added annotation processor base class for executing Smithy-Build plugins.",
+      "pull_requests": [
+        "[#2073](https://github.com/smithy-lang/smithy/pull/2073)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug when creating `@standardRegionalEndpoints` nodes.",
+      "pull_requests": [
+        "[#2179](https://github.com/smithy-lang/smithy/pull/2179)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed Windows CI errors by removing no-cone on git add command.",
+      "pull_requests": [
+        "[#2168](https://github.com/smithy-lang/smithy/pull/2168)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed the `RestJsonZeroAndFalseQueryValues` protocol test.",
+      "pull_requests": [
+        "[#2167](https://github.com/smithy-lang/smithy/pull/2167)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Properly fix multi-mixin members in shape build.",
+      "pull_requests": [
+        "[#2157](https://github.com/smithy-lang/smithy/pull/2157)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed text block incidental whitespace handling.",
+      "pull_requests": [
+        "[#2147](https://github.com/smithy-lang/smithy/pull/2147)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed issues with `AbstractCodeWriter` state stacks.",
+      "pull_requests": [
+        "[#2142](https://github.com/smithy-lang/smithy/pull/2142)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Remove incorrect `jsonName` protocol info.",
+      "pull_requests": [
+        "[#2187](https://github.com/smithy-lang/smithy/pull/2187)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed minor formattting.",
+      "pull_requests": [
+        "[#2175](https://github.com/smithy-lang/smithy/pull/2175)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added CLI and Groovy examples to guides.",
+      "pull_requests": [
+        "[#2165](https://github.com/smithy-lang/smithy/pull/2165)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated quickstart example to use terse input/output syntax.",
+      "pull_requests": [
+        "[#2163](https://github.com/smithy-lang/smithy/pull/2163)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated OpenApi guide to use new gradle plugin and cli.",
+      "pull_requests": [
+        "[#2161](https://github.com/smithy-lang/smithy/pull/2161)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated Gradle quickstart example to include empty `smithy-build.json`.",
+      "pull_requests": [
+        "[#2149](https://github.com/smithy-lang/smithy/pull/2149)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Multiple updates of the Gradle plugin after the 0.8.0 release.",
+      "pull_requests": [
+        "[#2140](https://github.com/smithy-lang/smithy/pull/2140)",
+        "[#2146](https://github.com/smithy-lang/smithy/pull/2146)",
+        "[#2139](https://github.com/smithy-lang/smithy/pull/2139)",
+        "[#2148](https://github.com/smithy-lang/smithy/pull/2148)"
+      ]
+    }
+  ],
+  "date": "2024-03-19"
+}

--- a/.changes/releases/1.47.0.json
+++ b/.changes/releases/1.47.0.json
@@ -1,0 +1,48 @@
+{
+  "version": "1.47.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added the `smithy-trait-codegen` package. This package provides a new\n`trait-codegen` plugin that can be used to generate Java implementations of\nSmithy traits, removing the need to hand-write most trait implementations.",
+      "pull_requests": [
+        "[#2074](https://github.com/smithy-lang/smithy/pull/2074)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `@smithy.protocols#rpcv2Cbor` protocol trait. Smithy RPC v2 CBOR is\nan RPC-based protocol over HTTP that sends requests and responses with\n[CBOR](https://www.rfc-editor.org/rfc/rfc8949.html) payloads. This trait is\navailable in the new `smithy-protocol-traits` package, with protocol tests\navailable in the new `smithy-protocol-tests` package.",
+      "pull_requests": [
+        "[#2212](https://github.com/smithy-lang/smithy/pull/2212)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated several protocol tests around the `@sparse` trait to ease\nimplementation.",
+      "pull_requests": [
+        "[#2206](https://github.com/smithy-lang/smithy/pull/2206)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Remove content-type from no XML body protocol test.",
+      "pull_requests": [
+        "[#2218](https://github.com/smithy-lang/smithy/pull/2218)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug where all shapes would fail to load in a file if a mixin was\nmissing.",
+      "pull_requests": [
+        "[#2214](https://github.com/smithy-lang/smithy/pull/2214)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified HTTP protocol compliance test `params` field docs.",
+      "pull_requests": [
+        "[#2202](https://github.com/smithy-lang/smithy/pull/2202)"
+      ]
+    }
+  ],
+  "date": "2024-03-28"
+}

--- a/.changes/releases/1.48.0.json
+++ b/.changes/releases/1.48.0.json
@@ -1,0 +1,126 @@
+{
+  "version": "1.48.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Updated HTTP binding validation to allow for specificity routing.",
+      "pull_requests": [
+        "[#2220](https://github.com/smithy-lang/smithy/pull/2220)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for the `deprecated` trait in OpenAPI conversion.",
+      "pull_requests": [
+        "[#2221](https://github.com/smithy-lang/smithy/pull/2221)",
+        "[#2222](https://github.com/smithy-lang/smithy/pull/2222)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol tests for nested XML maps with XML names.",
+      "pull_requests": [
+        "[#2236](https://github.com/smithy-lang/smithy/pull/2236)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added diff validation for services that migrate from sigv4 to sigv4a.",
+      "pull_requests": [
+        "[#2245](https://github.com/smithy-lang/smithy/pull/2245)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Emit a `NOTE` validation event on ignored duplicate shapes.",
+      "pull_requests": [
+        "[#2247](https://github.com/smithy-lang/smithy/pull/2247)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added strongly typed properties for `TypedPropertiesBag`.",
+      "pull_requests": [
+        "[#2248](https://github.com/smithy-lang/smithy/pull/2248)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated trait code generation to use strongly typed property bags.",
+      "pull_requests": [
+        "[#2254](https://github.com/smithy-lang/smithy/pull/2254)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a Smithy Diff test runner.",
+      "pull_requests": [
+        "[#2250](https://github.com/smithy-lang/smithy/pull/2250)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added captializing formatter for use in trait code generation and normalized\nsymbol references to reduce false positive duplicates.",
+      "pull_requests": [
+        "[#2255](https://github.com/smithy-lang/smithy/pull/2255)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Removed incorrect `Content-Type` from no-body XML payload protocol test.",
+      "pull_requests": [
+        "[#2218](https://github.com/smithy-lang/smithy/pull/2218)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed header expectations in RPCv2 protocol tests.",
+      "pull_requests": [
+        "[#2246](https://github.com/smithy-lang/smithy/pull/2246)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed `ModifiedTrait` validation for traits with breaking change rules.",
+      "pull_requests": [
+        "[#2249](https://github.com/smithy-lang/smithy/pull/2249)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed Gradle plugin version in documentation.",
+      "pull_requests": [
+        "[#2226](https://github.com/smithy-lang/smithy/pull/2226)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated the Gradle migration guide caption.",
+      "pull_requests": [
+        "[#2227](https://github.com/smithy-lang/smithy/pull/2227)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated installation instructions for the Smithy CLI.",
+      "pull_requests": [
+        "[#2229](https://github.com/smithy-lang/smithy/pull/2229)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added missing commas in JSON AST docs.",
+      "pull_requests": [
+        "[#2230](https://github.com/smithy-lang/smithy/pull/2230)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed incorrect reference to the `traitValidators` trait in the protocol\ndefinition trait.",
+      "pull_requests": [
+        "[#2241](https://github.com/smithy-lang/smithy/pull/2241/)"
+      ]
+    }
+  ],
+  "date": "2024-04-24"
+}

--- a/.changes/releases/1.49.0.json
+++ b/.changes/releases/1.49.0.json
@@ -1,0 +1,90 @@
+{
+  "version": "1.49.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added list and map shapes to directed codegen.",
+      "pull_requests": [
+        "[#2273](https://github.com/smithy-lang/smithy/pull/2273)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for defaults on trait member values in trait-codegen.",
+      "pull_requests": [
+        "[#2267](https://github.com/smithy-lang/smithy/pull/2267)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for string-arrays for as parameters in rules-engine.",
+      "pull_requests": [
+        "[#2266](https://github.com/smithy-lang/smithy/pull/2266)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added new trait (`@operationContextParams`) for binding array parameters to\nnested operation inputs in the rules-engine.",
+      "pull_requests": [
+        "[#2264](https://github.com/smithy-lang/smithy/pull/2264)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed bug in the formatter where comments in operation errors were not being\nhandled correctly.",
+      "pull_requests": [
+        "[#2283](https://github.com/smithy-lang/smithy/pull/2283)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed bug in the formatter where certain documentation comments were being\nconverted to line-comments.",
+      "pull_requests": [
+        "[#2277](https://github.com/smithy-lang/smithy/pull/2277)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed incorrect status code in restXml response protocol test.",
+      "pull_requests": [
+        "[#2272](https://github.com/smithy-lang/smithy/pull/2272)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed ec2query protocol test for empty list serialization.",
+      "pull_requests": [
+        "[#2269](https://github.com/smithy-lang/smithy/pull/2269)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed Javadoc integration for documentation in members and enum variants in\ntrait-codegen.",
+      "pull_requests": [
+        "[#2265](https://github.com/smithy-lang/smithy/pull/2265)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed timing issue in the delay calculation for waiter retries.",
+      "pull_requests": [
+        "[#2259](https://github.com/smithy-lang/smithy/pull/2259)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Corrected a typo in RPCv2 CBOR specificaiton.",
+      "pull_requests": [
+        "[#2278](https://github.com/smithy-lang/smithy/pull/2278)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated casing of aggregate shape names in shape type table.",
+      "pull_requests": [
+        "[#2271](https://github.com/smithy-lang/smithy/pull/2271)"
+      ]
+    }
+  ],
+  "date": "2024-05-08"
+}

--- a/.changes/releases/1.5.0.json
+++ b/.changes/releases/1.5.0.json
@@ -1,0 +1,175 @@
+{
+  "version": "1.5.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added the `endpointPrefix` property to the `@aws.api#service` trait.",
+      "pull_requests": [
+        "[#663](https://github.com/awslabs/smithy/pull/663)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for `tags` and `deprecated` members to `@waitable` definitions.",
+      "pull_requests": [
+        "[#652](https://github.com/awslabs/smithy/pull/652)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation for `@httpHeader` trait values.",
+      "pull_requests": [
+        "[#650](https://github.com/awslabs/smithy/pull/650)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Add `required` property for `requestBody` when converting to OpenAPI.",
+      "pull_requests": [
+        "[#655](https://github.com/awslabs/smithy/pull/655)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added more helper methods to `OperationIndex`.",
+      "pull_requests": [
+        "[#657](https://github.com/awslabs/smithy/pull/657)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Ensure that names in the `@waitable` trait are unique in the closure of the\nservice.",
+      "pull_requests": [
+        "[#645](https://github.com/awslabs/smithy/pull/645)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a regression with `@aws.apigateway#authorizors` behavior when setting\nthe `customAuthType` property without having set its `type` property.",
+      "pull_requests": [
+        "[#613](https://github.com/awslabs/smithy/pull/613)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where modeled headers were not populated in to\n`Access-Control-Expose-Headers` in CORS responses.",
+      "pull_requests": [
+        "[#659](https://github.com/awslabs/smithy/pull/659)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Added missing `deprecated` member to `@enum` definitions in the prelude model.",
+      "pull_requests": [
+        "[#651](https://github.com/awslabs/smithy/pull/651)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue with the conversion of greedy label parameter names in to\nOpenAPI.",
+      "pull_requests": [
+        "[#641](https://github.com/awslabs/smithy/pull/641)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue in `CodeWriter.popState` where it would not honor custom\nexpression start characters.",
+      "pull_requests": [
+        "[#648](https://github.com/awslabs/smithy/pull/648)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a potential `NullPointerException` when validating the `@examples`\ntrait.",
+      "pull_requests": [
+        "[#642](https://github.com/awslabs/smithy/pull/642)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed issues with some `@awsQuery` and `@ec2Query` protocol test responses.",
+      "pull_requests": [
+        "[#653](https://github.com/awslabs/smithy/pull/653)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where the `removeTraitDefinitions` build transform was not\nregistered with the SPI.",
+      "pull_requests": [
+        "[#660](https://github.com/awslabs/smithy/pull/660)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where using an environment variable in `smithy-build.json`\nwould consume an extra preceding character when performing a replacement.",
+      "pull_requests": [
+        "[#662](https://github.com/awslabs/smithy/pull/662)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Update `@waitable` documentation to specify using jitter and account for\noverflows.",
+      "pull_requests": [
+        "[#656](https://github.com/awslabs/smithy/pull/656)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added examples and clarified documentation for several HTTP traits, most\nimportantly `@httpLabel` and `@httpQuery`.",
+      "pull_requests": [
+        "[#654](https://github.com/awslabs/smithy/pull/654)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified various aspects of the `@xmlNamespace` trait documentation.",
+      "pull_requests": [
+        "[#643](https://github.com/awslabs/smithy/pull/643)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified `@waitable` documentation.",
+      "pull_requests": [
+        "[#646](https://github.com/awslabs/smithy/pull/646)",
+        "[#664](https://github.com/awslabs/smithy/pull/664)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified that the `@pattern` trait does not implicitly match an entire\nstring.",
+      "pull_requests": [
+        "[#649](https://github.com/awslabs/smithy/pull/649)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed various examples in the specification.",
+      "pull_requests": [
+        "[#639](https://github.com/awslabs/smithy/pull/639)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Sort `TopDownIndex` contents to provide deterministic results.",
+      "pull_requests": [
+        "[#667](https://github.com/awslabs/smithy/pull/667)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Improved error messages when an unknown annotation trait is encountered.",
+      "pull_requests": [
+        "[#644](https://github.com/awslabs/smithy/pull/644)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Added `smithy-diff` error when the `@idempotencyTrait` token is removed from a\nshape.",
+      "pull_requests": [
+        "[#640](https://github.com/awslabs/smithy/pull/640)"
+      ]
+    }
+  ],
+  "date": "2020-12-10"
+}

--- a/.changes/releases/1.5.1.json
+++ b/.changes/releases/1.5.1.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.5.1",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Fixed several issues related to building and running on Windows.",
+      "pull_requests": [
+        "[#671](https://github.com/awslabs/smithy/pull/671)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue loading the `jsonAdd` map from configuration for the\n`cloudformation` plugin.",
+      "pull_requests": [
+        "[#673](https://github.com/awslabs/smithy/pull/673)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where API Gateway REST APIs would have greedy label parameter\nnames rendered into OpenAPI with a `+` suffix.",
+      "pull_requests": [
+        "[#674](https://github.com/awslabs/smithy/pull/674)"
+      ]
+    }
+  ],
+  "date": "2020-12-21"
+}

--- a/.changes/releases/1.50.0.json
+++ b/.changes/releases/1.50.0.json
@@ -1,0 +1,192 @@
+{
+  "version": "1.50.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added a `required` property to IAM trait condition key definitions.",
+      "pull_requests": [
+        "[#2288](https://github.com/smithy-lang/smithy/pull/2288)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `syncCorsPreflightIntegration` configuration option to APIGateway\nconversion, which updates CORS preflight templates with all possible content\ntypes.",
+      "pull_requests": [
+        "[#2290](https://github.com/smithy-lang/smithy/pull/2290)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validator for duplicate names in the `iamResource` trait.",
+      "pull_requests": [
+        "[#2293](https://github.com/smithy-lang/smithy/pull/2293)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `operationContextParams` support to `RulesetParameterValidator`.",
+      "pull_requests": [
+        "[#2295](https://github.com/smithy-lang/smithy/pull/2295)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Enabled the application of example traits to service-level errors.",
+      "pull_requests": [
+        "[#2307](https://github.com/smithy-lang/smithy/pull/2307)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added IDL serializer option to coerce inline IO.",
+      "pull_requests": [
+        "[#2316](https://github.com/smithy-lang/smithy/pull/2316)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a function to writer delegators to check out writers with a symbol.",
+      "pull_requests": [
+        "[#2328](https://github.com/smithy-lang/smithy/pull/2328)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added defaults tests for restJson1.",
+      "pull_requests": [
+        "[#2280](https://github.com/smithy-lang/smithy/pull/2280)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added float16 upcast tests for RPCv2 CBOR.",
+      "pull_requests": [
+        "[#2291](https://github.com/smithy-lang/smithy/pull/2291)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol tests for content-type parameters.",
+      "pull_requests": [
+        "[#2296](https://github.com/smithy-lang/smithy/pull/2296)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol tests asserting servers reject empty unions.",
+      "pull_requests": [
+        "[#2300](https://github.com/smithy-lang/smithy/pull/2300)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol tests for malformed media types.",
+      "pull_requests": [
+        "[#2309](https://github.com/smithy-lang/smithy/pull/2309)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol tests for missing content types.",
+      "pull_requests": [
+        "[#2310](https://github.com/smithy-lang/smithy/pull/2310)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added several content-type and HTTP payload protocol tests.",
+      "pull_requests": [
+        "[#2314](https://github.com/smithy-lang/smithy/pull/2314)",
+        "[#2315](https://github.com/smithy-lang/smithy/pull/2315)",
+        "[#2322](https://github.com/smithy-lang/smithy/pull/2322)",
+        "[#2331](https://github.com/smithy-lang/smithy/pull/2331)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed formatter to correctly convert invalid doc comments.",
+      "pull_requests": [
+        "[#2277](https://github.com/smithy-lang/smithy/pull/2277)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Added missing node mapper for document types.",
+      "pull_requests": [
+        "[#2313](https://github.com/smithy-lang/smithy/pull/2313)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed issues with S3 dot segment tests.",
+      "pull_requests": [
+        "[#2304](https://github.com/smithy-lang/smithy/pull/2304)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed several issues in RPCv2 CBOR protocol tests.",
+      "pull_requests": [
+        "[#2319](https://github.com/smithy-lang/smithy/pull/2319)",
+        "[#2320](https://github.com/smithy-lang/smithy/pull/2320)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Updated protocol tests to use floating point values representable exactly in\nIEEE representation.",
+      "pull_requests": [
+        "[#2321](https://github.com/smithy-lang/smithy/pull/2321)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed EC2 request ID casing.",
+      "pull_requests": [
+        "[#2329](https://github.com/smithy-lang/smithy/pull/2329)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed typos in RPCv2 CBOR spec.",
+      "pull_requests": [
+        "[#2278](https://github.com/smithy-lang/smithy/pull/2278)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed typo in AddDefaultConfigSettings.",
+      "pull_requests": [
+        "[#2285](https://github.com/smithy-lang/smithy/pull/2285)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed errors in IAM trait docs.",
+      "pull_requests": [
+        "[#2287](https://github.com/smithy-lang/smithy/pull/2287)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified RPCv2 response event stream behavior.",
+      "pull_requests": [
+        "[#2297](https://github.com/smithy-lang/smithy/pull/2297)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Replaced references to outdated RFCs with references to their replacements.",
+      "pull_requests": [
+        "[#2298](https://github.com/smithy-lang/smithy/pull/2298)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified `httpResponseCode` value range.",
+      "pull_requests": [
+        "[#2308](https://github.com/smithy-lang/smithy/pull/2308)"
+      ]
+    }
+  ],
+  "date": "2024-06-18"
+}

--- a/.changes/releases/1.51.0.json
+++ b/.changes/releases/1.51.0.json
@@ -1,0 +1,143 @@
+{
+  "version": "1.51.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added the `:recursive` selector function to enable recursively traversing\nrelationships.",
+      "pull_requests": [
+        "[#2353](https://github.com/smithy-lang/smithy/pull/2353)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation of `intEnum` shapes to the `NodeValidationVisitor`.",
+      "pull_requests": [
+        "[#2357](https://github.com/smithy-lang/smithy/pull/2357)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added various protocol tests.",
+      "pull_requests": [
+        "[#2333](https://github.com/smithy-lang/smithy/pull/2333)",
+        "[#2342](https://github.com/smithy-lang/smithy/pull/2342)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added elliptic curve cryptography module to the Smithy CLI for communicating\nwith certain package managers.",
+      "pull_requests": [
+        "[#2379](https://github.com/smithy-lang/smithy/pull/2379)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a warning when the `@idempotencyToken` trait is applied where it would\nbe ignored.",
+      "pull_requests": [
+        "[#2358](https://github.com/smithy-lang/smithy/pull/2358)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation for the `@httpChecksum` trait's `responseAlgorithms`\nproperty.",
+      "pull_requests": [
+        "[#2371](https://github.com/smithy-lang/smithy/pull/2371)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated list of supported `@httpCheckum` algorithms.",
+      "pull_requests": [
+        "[#2386](https://github.com/smithy-lang/smithy/pull/2386)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved the performance of the `BottomUpIndex`.",
+      "pull_requests": [
+        "[#2367](https://github.com/smithy-lang/smithy/pull/2367)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed formatting of `resource` shape `identifiers` and `properties` fields.",
+      "pull_requests": [
+        "[#2377](https://github.com/smithy-lang/smithy/pull/2377)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed issue with parsing different types of documentation comments.",
+      "pull_requests": [
+        "[#2390](https://github.com/smithy-lang/smithy/pull/2390)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed issue that would cause shape conflicts when loading the same model twice\nthat uses `apply` on a member from a mixin.",
+      "pull_requests": [
+        "[#2378](https://github.com/smithy-lang/smithy/pull/2378)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed issue with generating CFN resource schema handler permissions for\n`@noReplace` resources.",
+      "pull_requests": [
+        "[#2383](https://github.com/smithy-lang/smithy/pull/2383)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed several classes of bugs in the `AwsTagIndex`.",
+      "pull_requests": [
+        "[#2384](https://github.com/smithy-lang/smithy/pull/2384)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed various issues with protocol tests.",
+      "pull_requests": [
+        "[#2336](https://github.com/smithy-lang/smithy/pull/2336)",
+        "[#2340](https://github.com/smithy-lang/smithy/pull/2340)",
+        "[#2341](https://github.com/smithy-lang/smithy/pull/2341)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added full-stack application tutorial.",
+      "pull_requests": [
+        "[#2362](https://github.com/smithy-lang/smithy/pull/2362)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added documentation to several places in the `smithy-aws-endpoints` trait\ndefinitions.",
+      "pull_requests": [
+        "[#2374](https://github.com/smithy-lang/smithy/pull/2374)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added note on `smithy-build.json` supporting `//` based comments.",
+      "pull_requests": [
+        "[#2375](https://github.com/smithy-lang/smithy/pull/2375)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified documentation for resolving auth schemes from endpoint rule sets.",
+      "pull_requests": [
+        "[#2382](https://github.com/smithy-lang/smithy/pull/2382)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed various documentation issues.",
+      "pull_requests": [
+        "[#2346](https://github.com/smithy-lang/smithy/pull/2346)",
+        "[#2363](https://github.com/smithy-lang/smithy/pull/2363)"
+      ]
+    }
+  ],
+  "date": "2024-09-03"
+}

--- a/.changes/releases/1.52.0.json
+++ b/.changes/releases/1.52.0.json
@@ -1,0 +1,125 @@
+{
+  "version": "1.52.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added validator for identifiers missing references",
+      "pull_requests": [
+        "[#2418](https://github.com/smithy-lang/smithy/pull/2418)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added checksum algorithm to model enum",
+      "pull_requests": [
+        "[#2419](https://github.com/smithy-lang/smithy/pull/2419)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated the `httpChecksum` trait spec",
+      "pull_requests": [
+        "[#2413](https://github.com/smithy-lang/smithy/pull/2413)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `breakingChanges` to the `httpChecksum` trait",
+      "pull_requests": [
+        "[#2398](https://github.com/smithy-lang/smithy/pull/2398)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Use the most common suffix for IDL inline IO",
+      "pull_requests": [
+        "[#2397](https://github.com/smithy-lang/smithy/pull/2397)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed the name of XML root nodes in the protocol tests",
+      "pull_requests": [
+        "[#2423](https://github.com/smithy-lang/smithy/pull/2423)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed trait codegen to properly support lists of enums",
+      "pull_requests": [
+        "[#2420](https://github.com/smithy-lang/smithy/pull/2420)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Update RPC v2 CBOR spec to require an Accept header for requests",
+      "pull_requests": [
+        "[#2417](https://github.com/smithy-lang/smithy/pull/2417)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Changed prefix header tests to allow for empty headers",
+      "pull_requests": [
+        "[#2415](https://github.com/smithy-lang/smithy/pull/2415)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed OpenAPI plugin to properly support effective documentation precedence",
+      "pull_requests": [
+        "[#2402](https://github.com/smithy-lang/smithy/pull/2402)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug in the `SigV4` diff logic that assumed that the a service exists\nin the old operation",
+      "pull_requests": [
+        "[#2405](https://github.com/smithy-lang/smithy/pull/2405)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Added `NodeValidationVisitor` checks for invalid nulls",
+      "pull_requests": [
+        "[#2393](https://github.com/smithy-lang/smithy/pull/2393)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated the `httpChecksum` trait spec to clarify the expected behavior and\nadded the supported algorithms",
+      "pull_requests": [
+        "[#2413](https://github.com/smithy-lang/smithy/pull/2413)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed the `httpChecksum` algorithm list in spec",
+      "pull_requests": [
+        "[#2394](https://github.com/smithy-lang/smithy/pull/2394)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed a broken link to smithy-rs design document in Code Gen documentation.",
+      "pull_requests": [
+        "[#2416](https://github.com/smithy-lang/smithy/pull/2416)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed resource type typo in AST docs",
+      "pull_requests": [
+        "[#2410](https://github.com/smithy-lang/smithy/pull/2410)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed small typos in full stack tutorial",
+      "pull_requests": [
+        "[#2389](https://github.com/smithy-lang/smithy/pull/2389)"
+      ]
+    }
+  ],
+  "date": "2024-10-16"
+}

--- a/.changes/releases/1.52.1.json
+++ b/.changes/releases/1.52.1.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.52.1",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Fixed several minor issues with IAM trait class implementations",
+      "pull_requests": [
+        "[#2427](https://github.com/smithy-lang/smithy/pull/2427)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where several protocol test operations were not bound to\nservices",
+      "pull_requests": [
+        "[#2426](https://github.com/smithy-lang/smithy/pull/2426)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed the name of XML root nodes in the protocol tests",
+      "pull_requests": [
+        "[#2423](https://github.com/smithy-lang/smithy/pull/2423)"
+      ]
+    }
+  ],
+  "date": "2024-10-22"
+}

--- a/.changes/releases/1.53.0.json
+++ b/.changes/releases/1.53.0.json
@@ -1,0 +1,160 @@
+{
+  "version": "1.53.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added a transform to mark required idempotency tokens client optional",
+      "pull_requests": [
+        "[#2466](https://github.com/smithy-lang/smithy/pull/2466)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated the IDL serializer to write metadata to a separate file",
+      "pull_requests": [
+        "[#2464](https://github.com/smithy-lang/smithy/pull/2464)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Expanded the `title` trait to be applicable to any non-member shape",
+      "pull_requests": [
+        "[#2461](https://github.com/smithy-lang/smithy/pull/2461)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a pagination flattening transform",
+      "pull_requests": [
+        "[#2454](https://github.com/smithy-lang/smithy/pull/2454)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added transforms to remove deprecated shapes",
+      "pull_requests": [
+        "[#2452](https://github.com/smithy-lang/smithy/pull/2452)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Relaxed the pattern on the `@defineConditionKeys` trait's keys to enable\ninferring the `service` to be the service's `arnNamespace`",
+      "pull_requests": [
+        "[#2450](https://github.com/smithy-lang/smithy/pull/2450)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `useInlineMaps` JSONSchema setting to allow users to configure JSON\nSchema conversion to inline converted map shapes instead of creating\nreferences",
+      "pull_requests": [
+        "[#2449](https://github.com/smithy-lang/smithy/pull/2449)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated the CFN resource schema generation to fill in the permissions field of\nthe tagging configuration for resources",
+      "pull_requests": [
+        "[#2446](https://github.com/smithy-lang/smithy/pull/2446)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `resourceDelimiter` and `reusable` properties to the `arn` trait",
+      "pull_requests": [
+        "[#2440](https://github.com/smithy-lang/smithy/pull/2440)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a validator for the xmlFlattened trait that checks if the member's\ntarget is a list that has a member with xmlName, and that xmlName doesn't\nmatch the name of the xmlFlattened member",
+      "pull_requests": [
+        "[#2439](https://github.com/smithy-lang/smithy/pull/2439)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Updated CloudFormation resource schema conversion to be round-trippable",
+      "pull_requests": [
+        "[#2445](https://github.com/smithy-lang/smithy/pull/2445/)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed for tagsProperty in CFN schema creation",
+      "pull_requests": [
+        "[#2444](https://github.com/smithy-lang/smithy/pull/2444)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Deferred the `scrubTraitDefinitions` call inside JSON Schema deconflicting to\nhappen only when the model is in a state that would have an avoidable conflict",
+      "pull_requests": [
+        "[#2435](https://github.com/smithy-lang/smithy/pull/2435)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Updated the `ChangedMemberTarget` diff evaluator to properly check changes to\nmap keys and values the same way it checks changes to list members",
+      "pull_requests": [
+        "[#2434](https://github.com/smithy-lang/smithy/pull/2434)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed a typo in event stream content-type documentation",
+      "pull_requests": [
+        "[#2458](https://github.com/smithy-lang/smithy/pull/2458)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed a broken README link",
+      "pull_requests": [
+        "[#2457](https://github.com/smithy-lang/smithy/pull/2457)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Updated blob defaults for protocol tests",
+      "pull_requests": [
+        "[#2467](https://github.com/smithy-lang/smithy/pull/2467)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Downgraded a noisy log statement",
+      "pull_requests": [
+        "[#2451](https://github.com/smithy-lang/smithy/pull/2451)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Fixed the CBOR type for blobs in RPCv2 CBOR protocol tests",
+      "pull_requests": [
+        "[#2447](https://github.com/smithy-lang/smithy/pull/2447)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Updated protocol tests to use lower-cased headers",
+      "pull_requests": [
+        "[#2437](https://github.com/smithy-lang/smithy/pull/2437)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Updated server protocol tests to assert serialization of empty headers",
+      "pull_requests": [
+        "[#2433](https://github.com/smithy-lang/smithy/pull/2433)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Lowered the severity of `UnboundTestOperation` to `WARNING`",
+      "pull_requests": [
+        "[#2432](https://github.com/smithy-lang/smithy/pull/2432)"
+      ]
+    }
+  ],
+  "date": "2024-11-18"
+}

--- a/.changes/releases/1.54.0.json
+++ b/.changes/releases/1.54.0.json
@@ -1,0 +1,98 @@
+{
+  "version": "1.54.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added multiselect and filter to supported `operationContextParams` paths",
+      "pull_requests": [
+        "[#2442](https://github.com/smithy-lang/smithy/pull/2442)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Integrated Spotless formatter into build logic to automatically format Java\nand Kotlin code",
+      "pull_requests": [
+        "[#2485](https://github.com/smithy-lang/smithy/pull/2485)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added help text to `ResourceOperationInputOutput` event",
+      "pull_requests": [
+        "[#2489](https://github.com/smithy-lang/smithy/pull/2489)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `smithy-docgen` package that enables the generation of a service\ndocumentation site from a smithy model",
+      "pull_requests": [
+        "[#2488](https://github.com/smithy-lang/smithy/pull/2488)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated `ShouldHaveUsedTimestampValidator` to reduce false positives",
+      "pull_requests": [
+        "[#2480](https://github.com/smithy-lang/smithy/pull/2480)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added service ID to tagging validator error messages to aid debugging",
+      "pull_requests": [
+        "[#2483](https://github.com/smithy-lang/smithy/pull/2483)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Corrected variable expansion logic in CLI to support multiple variables",
+      "pull_requests": [
+        "[#2495](https://github.com/smithy-lang/smithy/pull/2495)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Added missing getters to CloudFormation `ResourceSchema`",
+      "pull_requests": [
+        "[#2486](https://github.com/smithy-lang/smithy/pull/2486)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Converted blob default values to Base64 for protocol tests",
+      "pull_requests": [
+        "[#2474](https://github.com/smithy-lang/smithy/pull/2474)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed smoke test validator to correctly enforce unique test case ids",
+      "pull_requests": [
+        "[#2482](https://github.com/smithy-lang/smithy/pull/2482)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated Smithy logo in documentation",
+      "pull_requests": [
+        "[#2478](https://github.com/smithy-lang/smithy/pull/2478)",
+        "[#2479](https://github.com/smithy-lang/smithy/pull/2479)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Updated build logic to now require JDK17+ for development",
+      "pull_requests": [
+        "[#2487](https://github.com/smithy-lang/smithy/pull/2487)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Migrated Gradle build logic to use conventions plugins",
+      "pull_requests": [
+        "[#2484](https://github.com/smithy-lang/smithy/pull/2484)"
+      ]
+    }
+  ],
+  "date": "2025-01-08"
+}

--- a/.changes/releases/1.55.0.json
+++ b/.changes/releases/1.55.0.json
@@ -1,0 +1,143 @@
+{
+  "version": "1.55.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added support for `oneOf` enumStrategy in `smithy-jsonschema`",
+      "pull_requests": [
+        "[#2504](https://github.com/smithy-lang/smithy/pull/2504)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated `TaggableApiConfig` builder methods visibility to public",
+      "pull_requests": [
+        "[#2506](https://github.com/smithy-lang/smithy/pull/2506)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `flattenAndRemoveMixins` build transform",
+      "pull_requests": [
+        "[#2516](https://github.com/smithy-lang/smithy/pull/2516)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added ability to model more complex ARN templates in the `@arn` trait",
+      "pull_requests": [
+        "[#2527](https://github.com/smithy-lang/smithy/pull/2527)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Expanded the list of allowed member names in tag shapes",
+      "pull_requests": [
+        "[#2528](https://github.com/smithy-lang/smithy/pull/2528)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `primaryIdentifier` field to the `cfnResource` trait to indicate an\nunconventional primary identifier",
+      "pull_requests": [
+        "[#2539](https://github.com/smithy-lang/smithy/pull/2539)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed malformed CBOR body in `rpcv2Cbor` test",
+      "pull_requests": [
+        "[#2502](https://github.com/smithy-lang/smithy/pull/2502)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed serialization order of resource properties in the IDL",
+      "pull_requests": [
+        "[#2513](https://github.com/smithy-lang/smithy/pull/2513)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed `restXml` protocol test to be consistent with other tests and be less\nconfusing",
+      "pull_requests": [
+        "[#2520](https://github.com/smithy-lang/smithy/pull/2520)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed validation of shape ids for resource identifier bindings",
+      "pull_requests": [
+        "[#2526](https://github.com/smithy-lang/smithy/pull/2526)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed bug where null was being returned instead of empty collection in\ntrait-codegen",
+      "pull_requests": [
+        "[#2530](https://github.com/smithy-lang/smithy/pull/2530)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed conversion of `oneOf` errors so that they are treated as untagged unions",
+      "pull_requests": [
+        "[#2532](https://github.com/smithy-lang/smithy/pull/2532)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed bug where documentation was being applied twice with dynamic\ndocumentation trait in the idl-serializer",
+      "pull_requests": [
+        "[#2544](https://github.com/smithy-lang/smithy/pull/2544)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added links to SigV4a spec",
+      "pull_requests": [
+        "[#2503](https://github.com/smithy-lang/smithy/pull/2503)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed `cfnDefaultValue` trait selector documentation to match what is defined\nin code",
+      "pull_requests": [
+        "[#2509](https://github.com/smithy-lang/smithy/pull/2509)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added a Smithy Java quickstart guide",
+      "pull_requests": [
+        "[#2517](https://github.com/smithy-lang/smithy/pull/2517)",
+        "[#2521](https://github.com/smithy-lang/smithy/pull/2521)",
+        "[#2525](https://github.com/smithy-lang/smithy/pull/2525)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed incorrect examples and typos in mixin specification",
+      "pull_requests": [
+        "[#2518](https://github.com/smithy-lang/smithy/pull/2518)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added a Smithy Java client user-guide",
+      "pull_requests": [
+        "[#2522](https://github.com/smithy-lang/smithy/pull/2522)",
+        "[#2531](https://github.com/smithy-lang/smithy/pull/2531)",
+        "[#2533](https://github.com/smithy-lang/smithy/pull/2533)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added documentation placeholders for other languages",
+      "pull_requests": [
+        "[#2534](https://github.com/smithy-lang/smithy/pull/2534)"
+      ]
+    }
+  ],
+  "date": "2025-02-27"
+}

--- a/.changes/releases/1.56.0.json
+++ b/.changes/releases/1.56.0.json
@@ -1,0 +1,97 @@
+{
+  "version": "1.56.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added `FlattenAndRemoveMixins` transform to list of provided build transforms",
+      "pull_requests": [
+        "[#2552](https://github.com/smithy-lang/smithy/pull/2552)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `Since` suffix to timestamp linter for better timestamp validation",
+      "pull_requests": [
+        "[#2554](https://github.com/smithy-lang/smithy/pull/2554)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved performance by preferring `ShapeId` for `hasTrait` lookups instead of\nclass-based lookups",
+      "pull_requests": [
+        "[#2562](https://github.com/smithy-lang/smithy/pull/2562)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved `CleanClientDiscoveryTraitTransformer` implementation by adding short\nciruit if ClientDiscovery traits are not applied",
+      "pull_requests": [
+        "[#2559](https://github.com/smithy-lang/smithy/pull/2559)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Make IDL serialization clearer by skipping to serialize default boolean values",
+      "pull_requests": [
+        "[#2553](https://github.com/smithy-lang/smithy/pull/2553)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Optimized `ModelTransformPlugin` and `ResourceIdentifierBindingValidator` to\nuse fewer intermediate objects and\nstreams.",
+      "pull_requests": [
+        "[#2561](https://github.com/smithy-lang/smithy/pull/2561)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `breakingChanges` property to the removal of sigv4 and sigv4a traits",
+      "pull_requests": [
+        "[#2567](https://github.com/smithy-lang/smithy/pull/2567)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Relaxed constraints on `httpPrefixHeaders` trait to have `NOTE` severity\nduring validation when the prefix is set to empty string",
+      "pull_requests": [
+        "[#2565](https://github.com/smithy-lang/smithy/pull/2565)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Relaxed on `TaggableResource` instance validation by lowering the severity\nfrom `ERROR` to `DANGER` when a resource does not have instance operations for\nmanipulating tags and service level tagging operations are not present",
+      "pull_requests": [
+        "[#2566](https://github.com/smithy-lang/smithy/pull/2566)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed OpenAPI conversion by using `ShapeId` instead of name, reducing\nunnecessary object creation",
+      "pull_requests": [
+        "[#2560](https://github.com/smithy-lang/smithy/pull/2560)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added TypeScript quickstart pages to provide tutorial for users to generate\nclients and SDKs with Smithy TypeScript",
+      "pull_requests": [
+        "[#2536](https://github.com/smithy-lang/smithy/pull/2536)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added documentation for OpenAPI `enumStrategy` setting to clarify\nconfiguration options",
+      "pull_requests": [
+        "[#2551](https://github.com/smithy-lang/smithy/pull/2551)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added new Smithy landing page for improved user experience",
+      "pull_requests": [
+        "[#2543](https://github.com/smithy-lang/smithy/pull/2543)"
+      ]
+    }
+  ],
+  "date": "2025-03-27"
+}

--- a/.changes/releases/1.57.0.json
+++ b/.changes/releases/1.57.0.json
@@ -1,0 +1,48 @@
+{
+  "version": "1.57.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added `aws_recommended` as a partitional endpoint pattern type",
+      "pull_requests": [
+        "[#2575](https://github.com/smithy-lang/smithy/pull/2575)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Increased validation event severity for input name-value validation for the\nendpoint tests trait",
+      "pull_requests": [
+        "[#2593](https://github.com/smithy-lang/smithy/pull/2593)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added nascent document type support for RPC v2 CBOR",
+      "pull_requests": [
+        "[#2595](https://github.com/smithy-lang/smithy/pull/2595)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Enabled AWS query compatibility for RPC v2 CBOR",
+      "pull_requests": [
+        "[#2579](https://github.com/smithy-lang/smithy/pull/2579)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Updated `restXml` protocol tests to align with other XML tests",
+      "pull_requests": [
+        "[#2583](https://github.com/smithy-lang/smithy/pull/2583)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed waiter examples that included wrong members",
+      "pull_requests": [
+        "[2594](https://github.com/smithy-lang/smithy/pull/2594)"
+      ]
+    }
+  ],
+  "date": "2025-04-21"
+}

--- a/.changes/releases/1.57.1.json
+++ b/.changes/releases/1.57.1.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.57.1",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where `FileManifest::writeJson` would return a relative path\ninstead of an absolute one",
+      "pull_requests": [
+        "[#2602](https://github.com/smithy-lang/smithy/pull/2602)"
+      ]
+    }
+  ],
+  "date": "2025-04-21"
+}

--- a/.changes/releases/1.58.0.json
+++ b/.changes/releases/1.58.0.json
@@ -1,0 +1,129 @@
+{
+  "version": "1.58.0",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Fixed `Node` serialization and deserialization of rules engine endpoint\nvalues.",
+      "pull_requests": [
+        "[#2616](https://github.com/smithy-lang/smithy/pull/2616)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed null pointer exceptions when serializing endpoints traits to nodes.",
+      "pull_requests": [
+        "[#2629](https://github.com/smithy-lang/smithy/pull/2629)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Made `smithy.rules#endpointTests` have an explicit dependency on\n`smithy.rules#endpointRuleSet`.",
+      "pull_requests": [
+        "[#2637](https://github.com/smithy-lang/smithy/pull/2637)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added hierarchical IDs for `ChangedOperation` diff events.",
+      "pull_requests": [
+        "[#2607](https://github.com/smithy-lang/smithy/pull/2607)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Removed `@unstable` from the following traits: `@standardRegionalEndpoints`,\n`@standardPartitonalEndpoints`, and `@dualStackOnlyEndpoints`.",
+      "pull_requests": [
+        "[#2608](https://github.com/smithy-lang/smithy/pull/2608)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Made `Dynamic` `Part`s of the rules engine public.",
+      "pull_requests": [
+        "[#2614](https://github.com/smithy-lang/smithy/pull/2614)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Made validation of IAM resource names case-insensitive.",
+      "pull_requests": [
+        "[#2615](https://github.com/smithy-lang/smithy/pull/2615)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added several static utility methods to the rules engine.",
+      "pull_requests": [
+        "[#2617](https://github.com/smithy-lang/smithy/pull/2617)",
+        "[#2618](https://github.com/smithy-lang/smithy/pull/2618)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Made `arnNamespace` optional in IAM traits that support specifying condition\nkeys.",
+      "pull_requests": [
+        "[#2619](https://github.com/smithy-lang/smithy/pull/2619)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation to ensure that the value for any condition key may only be\nsupplied by one member in operation input.",
+      "pull_requests": [
+        "[#2620](https://github.com/smithy-lang/smithy/pull/2620)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added additional validation for the `endpointsTests` trait.",
+      "pull_requests": [
+        "[#2622](https://github.com/smithy-lang/smithy/pull/2622)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `UnknownMember` to the event ID for node validation.",
+      "pull_requests": [
+        "[#2630](https://github.com/smithy-lang/smithy/pull/2630)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added more links to OpenAPI APIGateway config.",
+      "pull_requests": [
+        "[#2605](https://github.com/smithy-lang/smithy/pull/2605)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed bad links in javadocs.",
+      "pull_requests": [
+        "[#2612](https://github.com/smithy-lang/smithy/pull/2612)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Documented `SUPPRESSED` as a valid value for `--severity` in validate command.",
+      "pull_requests": [
+        "[#2638](https://github.com/smithy-lang/smithy/pull/2638)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Improved performance of `CleanOperationStructures`.",
+      "pull_requests": [
+        "[#2609](https://github.com/smithy-lang/smithy/pull/2609)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Improved performance of several rules engine functions.",
+      "pull_requests": [
+        "[#2633](https://github.com/smithy-lang/smithy/pull/2633)",
+        "[#2634](https://github.com/smithy-lang/smithy/pull/2634)",
+        "[#2635](https://github.com/smithy-lang/smithy/pull/2635)",
+        "[#2636](https://github.com/smithy-lang/smithy/pull/2636)"
+      ]
+    }
+  ],
+  "date": "2025-05-13"
+}

--- a/.changes/releases/1.59.0.json
+++ b/.changes/releases/1.59.0.json
@@ -1,0 +1,69 @@
+{
+  "version": "1.59.0",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Fixed generation of nested lists/maps in trait code generation.",
+      "pull_requests": [
+        "[#2647](https://github.com/smithy-lang/smithy/pull/2647)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed generation of boolean collections in trait code generation.",
+      "pull_requests": [
+        "[#2652](https://github.com/smithy-lang/smithy/pull/2652)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed enum generation in docgen.",
+      "pull_requests": [
+        "[#2653](https://github.com/smithy-lang/smithy/pull/2653)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a warning when mixin members are removed.",
+      "pull_requests": [
+        "[#2644](https://github.com/smithy-lang/smithy/pull/2644)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a tag to identify service-specific protocol tests.",
+      "pull_requests": [
+        "[#2655](https://github.com/smithy-lang/smithy/pull/2655)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Made several improvements to the landing pages.",
+      "pull_requests": [
+        "[#2656](https://github.com/smithy-lang/smithy/pull/2656)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added guidance about generating unknown members for unions.",
+      "pull_requests": [
+        "[#2657](https://github.com/smithy-lang/smithy/pull/2657)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Updated references to `awslabs` to `smithy-lang` where relevant.",
+      "pull_requests": [
+        "[#2662](https://github.com/smithy-lang/smithy/pull/2662)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Added additional protocol tests for `restJson1`.",
+      "pull_requests": [
+        "[#2641](https://github.com/smithy-lang/smithy/pull/2641)"
+      ]
+    }
+  ],
+  "date": "2025-06-16"
+}

--- a/.changes/releases/1.6.0.json
+++ b/.changes/releases/1.6.0.json
@@ -1,0 +1,211 @@
+{
+  "version": "1.6.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added support for checking backwards compatibility for diffs of trait\ncontents.",
+      "pull_requests": [
+        "[#716](https://github.com/awslabs/smithy/pull/716)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for adding CORS configurations to API Gateway HTTP APIs.",
+      "pull_requests": [
+        "[#670](https://github.com/awslabs/smithy/pull/670)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Relaxed constraints on the `@httpPayload` trait, allowing it to target `list`,\n`set`, and `map` shapes except in AWS protocols.",
+      "pull_requests": [
+        "[#679](https://github.com/awslabs/smithy/pull/679)",
+        "[#683](https://github.com/awslabs/smithy/pull/683)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation to ensure a `payloadFormatVersion` is set when generating an\nAPI Gateway HTTP API.",
+      "pull_requests": [
+        "[#688](https://github.com/awslabs/smithy/pull/688)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `vendorParamsShape` to protocol test cases to support validating a test\ncase's `vendorParams` values are configured properly.",
+      "pull_requests": [
+        "[#702](https://github.com/awslabs/smithy/pull/702)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the ability to validate resolved hosts to protocol tests.",
+      "pull_requests": [
+        "[#707](https://github.com/awslabs/smithy/pull/707)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added backwards compatibility checking to `smithy-diff` for the `@paginated`\ntrait.",
+      "pull_requests": [
+        "[#716](https://github.com/awslabs/smithy/pull/716)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `tags` and `appliesTo` to protocol test definitions for better\ncategorization and grouping.",
+      "pull_requests": [
+        "[#696](https://github.com/awslabs/smithy/pull/696)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added several protocol tests for the `endpoint` and `hostLabel` traits.",
+      "pull_requests": [
+        "[#708](https://github.com/awslabs/smithy/pull/708)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added several `@restXml` protocol tests.",
+      "pull_requests": [
+        "[#689](https://github.com/awslabs/smithy/pull/689)",
+        "[#690](https://github.com/awslabs/smithy/pull/690)",
+        "[#678](https://github.com/awslabs/smithy/pull/678)",
+        "[#694](https://github.com/awslabs/smithy/pull/694)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a configuration definition for use validating `vendorParams` in AWS\nprotocol tests.",
+      "pull_requests": [
+        "[#705](https://github.com/awslabs/smithy/pull/705)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added tests and documentation for some required Amazon S3 customizations.",
+      "pull_requests": [
+        "[#709](https://github.com/awslabs/smithy/pull/709)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added tests and documentation for required Amazon Glacier customizations.",
+      "pull_requests": [
+        "[#704](https://github.com/awslabs/smithy/pull/704)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a test and documentation for the required Amazon API Gateway\ncustomization.",
+      "pull_requests": [
+        "[#706](https://github.com/awslabs/smithy/pull/706)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added a test and documentation for the required Amazon Machine Learning\ncustomization.",
+      "pull_requests": [
+        "[#707](https://github.com/awslabs/smithy/pull/707)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue that produced duplicate entries in the `security` list of a\nconverted OpenAPI document.",
+      "pull_requests": [
+        "[#687](https://github.com/awslabs/smithy/pull/687)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where `alphanumericOnlyRefs` was not fully satisfied when\ngenerating synthesized shapes.",
+      "pull_requests": [
+        "[#695](https://github.com/awslabs/smithy/pull/695)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed several issues in IDL parsing where duplicate bindings were allowed\nincorrectly.",
+      "pull_requests": [
+        "[#714](https://github.com/awslabs/smithy/pull/714)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed several issues in protocol tests around serialization of empty contents.",
+      "pull_requests": [
+        "[#692](https://github.com/awslabs/smithy/pull/692)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue where parameters in a diff error message were swapped.",
+      "pull_requests": [
+        "[#713](https://github.com/awslabs/smithy/pull/713)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an issue in a `restXml` protocol test.",
+      "pull_requests": [
+        "[#715](https://github.com/awslabs/smithy/pull/715)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Improved the documentation for the `awsJson1_0` and `awsJson1_1` protocols.",
+      "pull_requests": [
+        "[#698](https://github.com/awslabs/smithy/pull/698)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Improved the documentation for the `awsQuery` and `ec2Query` protocols.",
+      "pull_requests": [
+        "[#700](https://github.com/awslabs/smithy/pull/700)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Clarified that Smithy requires support for fractional seconds for the\n`http-date` value of `@timestampFormat`.",
+      "pull_requests": [
+        "[#672](https://github.com/awslabs/smithy/pull/672)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added missing shape documentation for some waiters related shapes.",
+      "pull_requests": [
+        "[#711](https://github.com/awslabs/smithy/pull/711)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed several minor documentation issues.",
+      "pull_requests": [
+        "[#681](https://github.com/awslabs/smithy/pull/681)",
+        "[#693](https://github.com/awslabs/smithy/pull/693)",
+        "[#697](https://github.com/awslabs/smithy/pull/697)",
+        "[#701](https://github.com/awslabs/smithy/pull/701)",
+        "[#708](https://github.com/awslabs/smithy/pull/708)",
+        "[#717](https://github.com/awslabs/smithy/pull/717)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Migrated to using Gradle 6 to build Smithy. This should have no impactful\ndownstream effects.",
+      "pull_requests": [
+        "[#194](https://github.com/awslabs/smithy/pull/194)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Migrated to using `main` from `master` for the default branch. This should\nhave no impactful downstream effects.",
+      "pull_requests": [
+        "[#685](https://github.com/awslabs/smithy/pull/685)"
+      ]
+    }
+  ],
+  "date": "2021-02-22"
+}

--- a/.changes/releases/1.6.1.json
+++ b/.changes/releases/1.6.1.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.6.1",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added the `renameShapes` build transform to rename shapes within a model.",
+      "pull_requests": [
+        "[#721](https://github.com/awslabs/smithy/pull/721)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed several issues in protocol tests around `@endpoint`.",
+      "pull_requests": [
+        "[#720](https://github.com/awslabs/smithy/pull/720)"
+      ]
+    }
+  ],
+  "date": "2021-02-23"
+}

--- a/.changes/releases/1.60.0.json
+++ b/.changes/releases/1.60.0.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.60.0",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Added ASM to the relocated dependencies.",
+      "pull_requests": [
+        "[#2676](https://github.com/smithy-lang/smithy/pull/2676)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added protocol tests for `@awsQueryCompatible`.",
+      "pull_requests": [
+        "[#2672](https://github.com/smithy-lang/smithy/pull/2672)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation to ensure query errors are unique.",
+      "pull_requests": [
+        "[#2674](https://github.com/smithy-lang/smithy/pull/2674)"
+      ]
+    }
+  ],
+  "date": "2025-06-23"
+}

--- a/.changes/releases/1.60.1.json
+++ b/.changes/releases/1.60.1.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.60.1",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Fixed body of awsQueryCompatible test.",
+      "pull_requests": [
+        "[#2677](https://github.com/smithy-lang/smithy/pull/2677)"
+      ]
+    }
+  ],
+  "date": "2025-06-25"
+}

--- a/.changes/releases/1.60.2.json
+++ b/.changes/releases/1.60.2.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.60.2",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Added model discovery args to smithy select.",
+      "pull_requests": [
+        "[#2680](https://github.com/smithy-lang/smithy/pull/2680)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed `NonQueryCompatible` to remove the bogus empty JSON body and media-type.",
+      "pull_requests": [
+        "[#2681](https://github.com/smithy-lang/smithy/pull/2681)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Reduced query error uniqueness validation severity.",
+      "pull_requests": [
+        "[#2682](https://github.com/smithy-lang/smithy/pull/2682)"
+      ]
+    }
+  ],
+  "date": "2025-06-26"
+}

--- a/.changes/releases/1.60.3.json
+++ b/.changes/releases/1.60.3.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.60.3",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Fixed incorrect operation name in URI for `NonQueryCompatibleOperation`.",
+      "pull_requests": [
+        "[#2684](https://github.com/smithy-lang/smithy/pull/2684/)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed incorrect property name in protocol test bodies.",
+      "pull_requests": [
+        "[#2686](https://github.com/smithy-lang/smithy/pull/2686)"
+      ]
+    }
+  ],
+  "date": "2025-06-27"
+}

--- a/.changes/releases/1.7.0.json
+++ b/.changes/releases/1.7.0.json
@@ -1,0 +1,48 @@
+{
+  "version": "1.7.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added the `rename` property to the `service` shape to disambiguate shape name\nconflicts in the service closure.",
+      "pull_requests": [
+        "[#734](https://github.com/awslabs/smithy/pull/734)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added the `httpQueryParams` trait that binds a map of key-value pairs to query\nstring parameters.",
+      "pull_requests": [
+        "[#735](https://github.com/awslabs/smithy/pull/735)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved the usability of code for building and running Selectors.",
+      "pull_requests": [
+        "[#726](https://github.com/awslabs/smithy/pull/726)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added several protocol tests for behavior around `null` serialization.",
+      "pull_requests": [
+        "[#728](https://github.com/awslabs/smithy/pull/728)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added missing documentation for some trait models.",
+      "pull_requests": [
+        "[#737](https://github.com/awslabs/smithy/pull/737)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed `awsQuery` and `ec2Query` list serialization examples.",
+      "pull_requests": [
+        "[#732](https://github.com/awslabs/smithy/pull/732)"
+      ]
+    }
+  ],
+  "date": "2021-03-12"
+}

--- a/.changes/releases/1.7.1.json
+++ b/.changes/releases/1.7.1.json
@@ -1,0 +1,127 @@
+{
+  "version": "1.7.1",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added the `recommended` structure member trait, which indicates that a\nstructure member SHOULD be set.",
+      "pull_requests": [
+        "[#745](https://github.com/awslabs/smithy/pull/745)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for service renames when using the `flattenNamespaces`\ntransformer.",
+      "pull_requests": [
+        "[#760](https://github.com/awslabs/smithy/pull/760)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Set `additionalProperties` to `false` for CloudFormation objects.",
+      "pull_requests": [
+        "[#764](https://github.com/awslabs/smithy/pull/764)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved model validation debugging by stopping validation when an `ERROR`\noccurs while loading models.",
+      "pull_requests": [
+        "[#775](https://github.com/awslabs/smithy/pull/775)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added validation warning when a `hostPrefix` contains a label that does not\nend in a period.",
+      "pull_requests": [
+        "[#779](https://github.com/awslabs/smithy/pull/779)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added and updated several `@restXml` protocol test.",
+      "pull_requests": [
+        "[#744](https://github.com/awslabs/smithy/pull/744)",
+        "[#755](https://github.com/awslabs/smithy/pull/755)",
+        "[#757](https://github.com/awslabs/smithy/pull/757)",
+        "[#777](https://github.com/awslabs/smithy/pull/777)",
+        "[#766](https://github.com/awslabs/smithy/pull/781)",
+        "[#789](https://github.com/awslabs/smithy/pull/789)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added and updated several `@restJson1` protocol test.",
+      "pull_requests": [
+        "[#747](https://github.com/awslabs/smithy/pull/747)",
+        "[#755](https://github.com/awslabs/smithy/pull/755)",
+        "[#765](https://github.com/awslabs/smithy/pull/765)",
+        "[#790](https://github.com/awslabs/smithy/pull/790)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added missing `name` properties to `aws.iam#ConditionKeyType` enum.",
+      "pull_requests": [
+        "[#759](https://github.com/awslabs/smithy/pull/759)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed number parsing in the IDL, using BigDecimal or BigInteger where needed.",
+      "pull_requests": [
+        "[#766](https://github.com/awslabs/smithy/pull/766)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed Gradle 7 builds.",
+      "pull_requests": [
+        "[#758](https://github.com/awslabs/smithy/pull/758)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Added `Document` type to list of inherently boxed shapes.",
+      "pull_requests": [
+        "[#749](https://github.com/awslabs/smithy/pull/749)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Reordered `TraitService` SPI entries for readability.",
+      "pull_requests": [
+        "[#742](https://github.com/awslabs/smithy/pull/742)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed `selector_expression` and `comment` in ABNF for Smithy IDL.",
+      "pull_requests": [
+        "[#771](https://github.com/awslabs/smithy/pull/771)",
+        "[#771](https://github.com/awslabs/smithy/pull/773)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Documented conflict resolution of HTTP query params.",
+      "pull_requests": [
+        "[#783](https://github.com/awslabs/smithy/pull/783)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Documented precedence of constraint traits.",
+      "pull_requests": [
+        "[#784](https://github.com/awslabs/smithy/pull/784)"
+      ]
+    },
+    {
+      "type": "other",
+      "description": "Upgraded to use version `0.5.3` of the\n[Smithy Gradle Plugin](https://github.com/awslabs/smithy-gradle-plugin).",
+      "pull_requests": [
+        "[#791](https://github.com/awslabs/smithy/pull/791)"
+      ]
+    }
+  ],
+  "date": "2021-05-07"
+}

--- a/.changes/releases/1.7.2.json
+++ b/.changes/releases/1.7.2.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.7.2",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Fixed a bug where unions would cause CloudFormation schema conversion to fail.",
+      "pull_requests": [
+        "[#794](https://github.com/awslabs/smithy/pull/794)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed an incorrect restXml protocol test.",
+      "pull_requests": [
+        "[#795](https://github.com/awslabs/smithy/pull/795)"
+      ]
+    }
+  ],
+  "date": "2021-05-11"
+}

--- a/.changes/releases/1.8.0.json
+++ b/.changes/releases/1.8.0.json
@@ -1,0 +1,56 @@
+{
+  "version": "1.8.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added `awsQueryError` trait, which defines the value in the `Code`\ndistinguishing field.",
+      "pull_requests": [
+        "[#807](https://github.com/awslabs/smithy/pull/807)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added methods to get shapes by type and trait.",
+      "pull_requests": [
+        "[#806](https://github.com/awslabs/smithy/pull/806)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved performance.",
+      "pull_requests": [
+        "[#805](https://github.com/awslabs/smithy/pull/805)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved percent-encoding tests and doumentation.",
+      "pull_requests": [
+        "[#803](https://github.com/awslabs/smithy/pull/803)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `double` format to epoch-seconds timestamps when converting to OpenAPI.",
+      "pull_requests": [
+        "[#802](https://github.com/awslabs/smithy/pull/802)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Improved CLI output.",
+      "pull_requests": [
+        "[#800](https://github.com/awslabs/smithy/pull/800)",
+        "[#801](https://github.com/awslabs/smithy/pull/801)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed awsQuery protocol test to show distinction from ignored `@xmlNamespace`\ntrait.",
+      "pull_requests": [
+        "[#799](https://github.com/awslabs/smithy/pull/799)"
+      ]
+    }
+  ],
+  "date": "2021-05-20"
+}

--- a/.changes/releases/1.9.0.json
+++ b/.changes/releases/1.9.0.json
@@ -1,0 +1,126 @@
+{
+  "version": "1.9.0",
+  "changes": [
+    {
+      "type": "feature",
+      "description": "Added a common validation model for use in server SDKs.",
+      "pull_requests": [
+        "[#813](https://github.com/awslabs/smithy/pull/813)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added support for cross platform builds of the CLI.",
+      "pull_requests": [
+        "[#832](https://github.com/awslabs/smithy/pull/832)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Validate the contents of protocol test bodies for known media types.",
+      "pull_requests": [
+        "[#822](https://github.com/awslabs/smithy/pull/822)",
+        "[#835](https://github.com/awslabs/smithy/pull/835)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Updated support for non-numeric floating-point values in several places.",
+      "pull_requests": [
+        "[#828](https://github.com/awslabs/smithy/pull/828)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added several `restJson` protocol tests.",
+      "pull_requests": [
+        "[#684](https://github.com/awslabs/smithy/pull/684)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added several `restXml` protocol tests.",
+      "pull_requests": [
+        "[#804](https://github.com/awslabs/smithy/pull/804)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added and updated several `awsQuery` and `ec2Query` protocol tests.",
+      "pull_requests": [
+        "[#815](https://github.com/awslabs/smithy/pull/815)",
+        "[#833](https://github.com/awslabs/smithy/pull/833)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added several `document` type protocol tests.",
+      "pull_requests": [
+        "[#810](https://github.com/awslabs/smithy/pull/810)"
+      ]
+    },
+    {
+      "type": "feature",
+      "description": "Added `s3UnwrappedXmlOutput` trait, which defines when an S3 operation does\nnot use the protocol standard XML wrapper.",
+      "pull_requests": [
+        "[#839](https://github.com/awslabs/smithy/pull/839)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Fixed a `NullPointerException` when loading a config and no parent path is\npresent.",
+      "pull_requests": [
+        "[#814](https://github.com/awslabs/smithy/pull/814)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added an overview of known Smithy implementations and projects.",
+      "pull_requests": [
+        "[#830](https://github.com/awslabs/smithy/pull/830)",
+        "[#831](https://github.com/awslabs/smithy/pull/831)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Improved the documentation for the `restXml`.",
+      "pull_requests": [
+        "[#827](https://github.com/awslabs/smithy/pull/827)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Improved the documentation for the `awsQuery`.",
+      "pull_requests": [
+        "[#827](https://github.com/awslabs/smithy/pull/827)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Improved the documentation for the `ec2Query` protocol.",
+      "pull_requests": [
+        "[#823](https://github.com/awslabs/smithy/pull/823)",
+        "[#827](https://github.com/awslabs/smithy/pull/827)",
+        "[#836](https://github.com/awslabs/smithy/pull/836)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Added more context for documentation types.",
+      "pull_requests": [
+        "[#818](https://github.com/awslabs/smithy/pull/818)"
+      ]
+    },
+    {
+      "type": "documentation",
+      "description": "Fixed several minor documentation issues.",
+      "pull_requests": [
+        "[#816](https://github.com/awslabs/smithy/pull/816)",
+        "[#818](https://github.com/awslabs/smithy/pull/818)",
+        "[#837](https://github.com/awslabs/smithy/pull/837)",
+        "[#840](https://github.com/awslabs/smithy/pull/840)"
+      ]
+    }
+  ],
+  "date": "2021-06-23"
+}

--- a/.changes/releases/1.9.1.json
+++ b/.changes/releases/1.9.1.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.9.1",
+  "changes": [
+    {
+      "type": "bugfix",
+      "description": "Fixed a number of protocol tests related to non-numeric floats.",
+      "pull_requests": [
+        "[#844](https://github.com/awslabs/smithy/pull/844)"
+      ]
+    },
+    {
+      "type": "bugfix",
+      "description": "Tightened substitution pattern for Fn::Sub to match CloudFormation.",
+      "pull_requests": [
+        "[#842](https://github.com/awslabs/smithy/pull/842)"
+      ]
+    }
+  ],
+  "date": "2021-06-28"
+}


### PR DESCRIPTION
This backports all the previous releases into the changelog tool format. Version 1.0.0 is notable for needing to remain in markdown as it is a special case.

See #2715 for how these render after the changes from #2713.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
