### PR TITLE
Relocate com.google in cli jar

### DIFF
--- a/smithy-cli/build.gradle.kts
+++ b/smithy-cli/build.gradle.kts
@@ -192,6 +192,7 @@ tasks {
         relocate("org.sonatype", "software.amazon.smithy.cli.shaded.sonatype")
         relocate("org.codehaus", "software.amazon.smithy.cli.shaded.codehaus")
         relocate("org.objectweb", "software.amazon.smithy.cli.shaded.objectweb")
+        relocate("com.google", "software.amazon.smithy.cli.shaded.google")
 
         // If other javax packages are ever pulled in, we'll need to update this list. This is more deliberate about
         // what's shaded to ensure that things like javax.net.ssl.SSLSocketFactory are not inadvertently shaded.


### PR DESCRIPTION
One of the maven resolver dependencies in the CLI added new dependencies, which weren't being relocated.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
