### PR TITLE
Add changelog release script

### DIFF
--- a/.changes/README.md
+++ b/.changes/README.md
@@ -30,23 +30,18 @@ You may optionally edit or combine the entries as is necessary. If you combine
 entries, ensure that the combined entry contains all of the relevant pr links.
 
 Once the entries have been verified, use the `render` tool to combine the
-staged entries and generate the changelog file. From the root of the Smithy
-repository, run the following with the version being released:
+staged entries and generate the changelog file. From the `.changes` directory,
+run the following:
 
 ```sh
-> ./.changes/render --release-version RELEASE_VERSION > CHANGELOG.md
+> uv run release
 ```
 
-If the `VERSION` file has already been updated, this can be simplified:
+Then commit the changelog, version file, and the `.changes` directory:
 
 ```sh
-> ./.changes/render --release-version "$(cat VERSION)" > CHANGELOG.md
-```
-
-Then commit the changelog and the `.changes` directory:
-
-```sh
-> git add CHANGELOG.md .changes
+> cd ..
+> git add VERSION CHANGELOG.md .changes
 ```
 
 ## Development
@@ -57,7 +52,7 @@ due to a lack of dependencies, developers must make use of `uv` to lint and
 format code before committing.
 
 ```sh
-> uv sync
+> uv sync --all-groups
 > uv run ruff check --fix
 > uv run ruff format
 > uv run pyright
@@ -69,7 +64,7 @@ right versions of these tools is used.
 uv can also be used to run scripts:
 
 ```sh
-> uv sync
+> uv sync --all-groups
 > uv run render
 ```
 

--- a/.changes/pyproject.toml
+++ b/.changes/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 amend = "smithy_changelog.amend:main"
 render = "smithy_changelog.render:main"
 new-change = "smithy_changelog.new:main"
+release = "smithy_changelog.release:main"
 
 [dependency-groups]
 lint = [

--- a/.changes/smithy_changelog/__init__.py
+++ b/.changes/smithy_changelog/__init__.py
@@ -5,7 +5,7 @@ import json
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any, Self
+from typing import Any, Literal, Self
 
 CHANGES_DIR = Path(__file__).absolute().parent.parent
 NEXT_RELEASE_DIR = CHANGES_DIR / "next-release"
@@ -14,6 +14,12 @@ REPO_ROOT = CHANGES_DIR.parent
 
 
 class ChangeType(Enum):
+    """The type of a change.
+
+    This enum also embeds the name of the sections for each change type as well
+    as the order which those sections should be written in.
+    """
+
     FEATURE = "Features", 1
     BUGFIX = "Bug Fixes", 2
     DOCUMENTATION = "Documentation", 3
@@ -21,6 +27,15 @@ class ChangeType(Enum):
     OTHER = "Other", 4
 
     def __init__(self, section_title: str, order: int) -> None:
+        """Constructs a ChangeType.
+
+        This should not be called manually, it should only be called by the Enum
+        metaclass.
+
+        :param section_title: The title of the change type's changelog section.
+        :param order: The order that this change type's section appears in the
+            changelog.
+        """
         self.section_title = section_title
         self.order = order
 
@@ -33,12 +48,26 @@ class ChangeType(Enum):
 
 @dataclass
 class Change:
+    """A representation of an individual change."""
+
     type: ChangeType
+    """The type of change."""
+
     description: str
+    """A description of the change."""
+
     pull_requests: list[str] = field(default_factory=list[str])
+    """A list of pull requests associated with the change as markdown links.
+
+    For example, `[#9999](https://github.com/smithy-lang/smithy/pulls/9999)`
+    """
 
     @classmethod
     def from_json(cls, data: dict[str, Any]) -> Self:
+        """Loads a JSON representation of a change.
+
+        :param data: A JSON representation of a change.
+        """
         return cls(
             type=ChangeType[data["type"].upper()],
             description=data["description"],
@@ -47,26 +76,120 @@ class Change:
 
     @classmethod
     def read(cls, file: Path) -> Self:
+        """Loads a JSON representation of a change from a file.
+
+        :param file: A path to a JSON file containing a JSON representation
+            of a change.
+        """
         return cls.from_json(json.loads(file.read_text()))
 
     def write(self, file: Path | None = None) -> str:
+        """Writes change to a JSON string, and optionally to a file.
+
+        :param file: A file to write to.
+
+        :returns: The JSON representation of the change.
+        """
         contents = json.dumps(asdict(self), indent=2, default=str) + "\n"
         if file is not None:
             file.write_text(contents)
         return contents
 
 
-def _today() -> str:
-    return datetime.date.today().isoformat()
+type Bump = Literal["minor", "patch"]
+"""The types of version bumps that may be used."""
 
 
 @dataclass
+class Version:
+    """A representation of a three-part numeric version.
+
+    This is primarily used for sorting, but also used for handling incrementation
+    logic.
+    """
+
+    major: int
+    minor: int
+    patch: int
+
+    def bump(self, bump: Bump) -> "Version":
+        """Bump the version accoring to the specified bump type.
+
+        :returns: An incremented :py:class:`Version`
+        """
+        match bump:
+            case "minor":
+                return Version(major=self.major, minor=self.minor + 1, patch=0)
+            case "patch":
+                return Version(major=self.major, minor=self.minor, patch=self.patch + 1)
+
+    @classmethod
+    def from_str(cls, version: str) -> Self:
+        """Creates a Version from a string representation."""
+        parts = version.split(".", 2)
+        if len(parts) != 3:
+            raise Exception(
+                f"Invalid version. Expected `major.minor.patch` "
+                f"(e.g. `1.2.3`), but found: {version}"
+            )
+        return cls(major=int(parts[0]), minor=int(parts[1]), patch=int(parts[2]))
+
+    @classmethod
+    def from_path(cls, path: Path) -> Self:
+        """Creates a version from a file representation.
+
+        The file name is expected to be in the form `major.minor.patch.extention`.
+        """
+        parts = path.name.split(".", 3)
+        if len(parts) != 3:
+            raise Exception(
+                f"Invalid version. Expected `major.minor.patch.extension` "
+                f"(e.g. `1.2.3.json`), but found: {path.name}"
+            )
+        return cls(major=int(parts[0]), minor=int(parts[1]), patch=int(parts[2]))
+
+    def __lt__(self, other: Self) -> bool:
+        if self.major != other.major:
+            return self.major < other.major
+        if self.minor != other.minor:
+            return self.minor < other.minor
+        return self.patch < other.patch
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+
+@dataclass(init=False)
 class Release:
-    version: str
+    """A representation of all the changes in a release."""
+
+    version: Version
+    """The release version."""
+
     changes: list[Change]
-    date: str = field(default_factory=_today)
+    """The list of changes in the release."""
+
+    date: str
+    """The date of the release in ISO format (e.g. 2025-07-29)"""
+
+    def __init__(
+        self, version: str | Version, changes: list[Change], date: str | None
+    ) -> None:
+        """Initializes a Release.
+
+        :param version: The version of the release, optionally as a string.
+        :param changes: The list of changes included in the release.
+        :param date: The date of the release in ISO format (e.g. 2025-07-29) or
+            today's date in ISO format if not set.
+        """
+        self.version = (
+            version if isinstance(version, Version) else Version.from_str(version)
+        )
+        self.changes = changes
+        self.date = date or datetime.date.today().isoformat()
 
     def change_map(self) -> dict[ChangeType, list[Change]]:
+        """Returns a map of change type to change for changes in the release."""
         result: dict[ChangeType, list[Change]] = {}
         for change in self.changes:
             if change.type not in result:
@@ -76,6 +199,10 @@ class Release:
 
     @classmethod
     def from_json(cls, data: dict[str, Any]) -> Self:
+        """Loads a release from a JSON representation.
+
+        :param data: The JSON representation of the release.
+        """
         return cls(
             version=data["version"],
             changes=[Change.from_json(c) for c in data["changes"]],
@@ -84,13 +211,33 @@ class Release:
 
     @classmethod
     def read(cls, file: Path) -> Self:
+        """Reads a release from a JSON file.
+
+        :param file: The file containing the release JSON.
+        """
         return cls.from_json(json.loads(file.read_text()))
 
     def write(self, file: Path | None = None) -> str:
+        """Writes a release to a JSON string, and optionally to a file.
+
+        :param file: A file to write the release JSON to.
+
+        :returns: The JSON representation of the release as a string.
+        """
         contents = json.dumps(asdict(self), indent=2, default=str) + "\n"
         if file is not None:
             file.write_text(contents)
         return contents
 
+    @staticmethod
+    def get_release_files(release_dir: Path = RELEASES_DIR) -> list[Path]:
+        """Gets a sorted list of files in the release directory.
+
+        :param release_dir: The directory to search for releases.
+        """
+        release_files = list(release_dir.glob("*.json"))
+        release_files.extend(release_dir.glob("*.md"))
+        return sorted(release_files, key=lambda p: Version.from_path(p), reverse=True)
+
     def __lt__(self, other: Self) -> bool:
-        return self.date < other.date
+        return self.version < other.version

--- a/.changes/smithy_changelog/release.py
+++ b/.changes/smithy_changelog/release.py
@@ -1,20 +1,97 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import os
-from datetime import date
+from argparse import ArgumentParser
+from pathlib import Path
 
-from . import NEXT_RELEASE_DIR, RELEASES_DIR, Change, Release
+from . import (
+    NEXT_RELEASE_DIR,
+    RELEASES_DIR,
+    REPO_ROOT,
+    Bump,
+    Change,
+    ChangeType,
+    Release,
+    Version,
+)
+from .render import render
 
 
-def release(version: str, release_date: str | None) -> None:
-    version = version.strip()
+def main() -> None:
+    parser = ArgumentParser(
+        description=("Perform a release, updating the changelog and version number.")
+    )
+    version_group = parser.add_mutually_exclusive_group()
+    version_group.add_argument(
+        "-v", "--version", type=Version.from_str, help="The version to release."
+    )
+    version_group.add_argument(
+        "-b",
+        "--bump",
+        type=str,
+        choices=["minor", "patch"],
+        help=(
+            "Whether to bump the minor version or patch version. If not set, the "
+            "default value will depend on the staged changes. If there are any "
+            "feature or breaking changes, minor will be used as default. Otherwise, "
+            "patch is the default. The most recent release in the releases directory "
+            "will be used as the base."
+        ),
+    )
+    parser.add_argument(
+        "--version-file",
+        type=lambda p: Path(p).absolute(),
+        help="A file to write the new version to.",
+        default=REPO_ROOT / "VERSION",
+    )
+    parser.add_argument(
+        "-d",
+        "--release-date",
+        type=str,
+        help="""\
+            The date of the release in ISO format (e.g. 2024-11-13). If not set, \
+            today's date, according to your local time zone, will be used.""",
+    )
+    parser.add_argument(
+        "-t",
+        "--changelog-title",
+        help="The top-level title to use for the changelog file.",
+    )
+    parser.add_argument(
+        "--changelog-file",
+        help="The file to write the changelog to.",
+        type=lambda p: Path(p).absolute(),
+        default=REPO_ROOT / "CHANGELOG.md",
+    )
+    args = parser.parse_args()
+    release(
+        version=args.version,
+        bump=args.bump,
+        version_file=args.version_file,
+        release_date=args.release_date,
+        changelog_title=args.changelog_title,
+        changelog_file=args.changelog_file,
+    )
+
+
+def release(
+    version: Version | None,
+    bump: Bump | None,
+    version_file: Path | None,
+    release_date: str | None,
+    changelog_title: str | None,
+    changelog_file: Path,
+) -> None:
     print("Gathering staged changes for release")
-    release_date = release_date or date.today().isoformat()
     changes: list[Change] = []
 
+    default_bump: Bump = "patch"
     for entry in NEXT_RELEASE_DIR.glob("*.json"):
         print(f"Found staged changelog entry: {entry}")
-        changes.append(Change.read(entry))
+        change = Change.read(entry)
+        if change.type in (ChangeType.FEATURE, ChangeType.BREAK):
+            default_bump = "minor"
+        changes.append(change)
         entry.unlink()
 
     if not changes:
@@ -24,11 +101,38 @@ def release(version: str, release_date: str | None) -> None:
             in the next-release folder."""
         )
 
-    result = Release(version=version, date=release_date.strip(), changes=changes)
-
     if not RELEASES_DIR.is_dir():
         os.makedirs(RELEASES_DIR)
+
+    bump = bump or default_bump
+    version = version or _compute_version(bump, version_file)
+    result = Release(version=version, date=release_date, changes=changes)
 
     release_file = RELEASES_DIR / f"{version}.json"
     print(f"Writing combined release to {release_file}")
     result.write(release_file)
+
+    print(f"Rendering new changelog and writing it to: {changelog_file}")
+    rendered = render(title=changelog_title)
+    changelog_file.write_text(rendered)
+
+    if version_file:
+        print(f"Writing version to file: {version_file}")
+        version_file.write_text(str(version))
+
+
+def _compute_version(bump: Bump, version_file: Path | None) -> Version:
+    base: Version
+    if version_file is not None:
+        base = Version.from_str(version_file.read_text().strip())
+    else:
+        release_files = Release.get_release_files(RELEASES_DIR)
+        if not release_files:
+            raise Exception(
+                "Unable to compute new release version because there are no existing "
+                "release files to base the version on."
+            )
+
+        base = Version.from_path(release_files[0])
+
+    return base.bump(bump)

--- a/.changes/smithy_changelog/render.py
+++ b/.changes/smithy_changelog/render.py
@@ -1,12 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 from argparse import ArgumentParser
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Self
 
-from . import RELEASES_DIR, Change, Release
-from .release import release as _release
+from . import Change, Release
 
 try:
     import mdformat
@@ -23,51 +19,19 @@ _DEFAULT_TITLE = "Smithy Changelog"
 
 def main() -> None:
     parser = ArgumentParser(
-        description="""\
-            Render the changelog as markdown, optionally including pending features \
-            as a new release.""",
+        description="Render the changelog as markdown",
     )
     parser.add_argument(
-        "-t",
-        "--title",
-        help="The top-level title to use for the changelog file.",
-        default=_DEFAULT_TITLE,
+        "-t", "--title", help="The top-level title to use for the changelog file."
     )
-    release_group = parser.add_argument_group(
-        "release",
-        description="""\
-            These arguments allow for releasing all pending features in the \
-            next-release folder as a new release. If not set, the exisiting releases \
-            will be re-rendered.""",
-    )
-    release_group.add_argument(
-        "-v",
-        "--release-version",
-        type=str,
-        help="""\
-            The version to use for the staged changelog release. If set, all pending \
-            features will be compiled into a release.""",
-    )
-    release_group.add_argument(
-        "-d",
-        "--release-date",
-        type=str,
-        help="""\
-            The date of the release in ISO format (e.g. 2024-11-13). If not set, \
-            today's date, according to your local time zone, will be used.""",
-    )
-
     args = parser.parse_args()
-
-    if args.release_version:
-        _release(args.release_version, args.release_date)
-
-    render(title=args.title)
+    print(render(title=args.title))
 
 
-def render(title: str = _DEFAULT_TITLE) -> None:
+def render(title: str | None) -> str:
+    title = title or _DEFAULT_TITLE
     rendered = f"# {title}\n\n"
-    for release in get_releases():
+    for release in _get_releases():
         if isinstance(release, str):
             rendered += release + "\n"
             continue
@@ -78,18 +42,17 @@ def render(title: str = _DEFAULT_TITLE) -> None:
             rendered += f"### {change_type.section_title}\n\n"
 
             for change in changes:
-                rendered += render_change(change)
+                rendered += _render_change(change)
 
             rendered += "\n"
 
     rendered = mdformat.text(  # pyright: ignore [reportUnknownMemberType]
         rendered, options={"wrap": 80}
     )
-    rendered = rendered.strip() + "\n"
-    print(rendered)
+    return rendered.strip() + "\n"
 
 
-def render_change(change: Change) -> str:
+def _render_change(change: Change) -> str:
     lines = change.description.strip().splitlines()
     rendered = f"- {lines[0]}"
 
@@ -108,42 +71,11 @@ def render_change(change: Change) -> str:
     return rendered + "\n"
 
 
-def get_releases() -> list[Release | str]:
+def _get_releases() -> list[Release | str]:
     releases: list[Release | str] = []
-    release_files = list(RELEASES_DIR.glob("*.json"))
-    release_files.extend(RELEASES_DIR.glob("*.md"))
-    release_files = sorted(
-        release_files, key=lambda p: Version.from_path(p), reverse=True
-    )
-    for release_file in release_files:
+    for release_file in Release.get_release_files():
         if release_file.name.endswith("md"):
             releases.append(release_file.read_text().strip())
         else:
             releases.append(Release.read(release_file))
     return releases
-
-
-# This exists to allow for sorting the release files based on the version in
-# the file name.
-@dataclass
-class Version:
-    major: int
-    minor: int
-    patch: int
-
-    def __lt__(self, other: Self) -> bool:
-        if self.major != other.major:
-            return self.major < other.major
-        if self.minor != other.minor:
-            return self.minor < other.minor
-        return self.patch < other.patch
-
-    @classmethod
-    def from_path(cls, path: Path) -> Self:
-        parts = path.name.split(".")
-        if len(parts) != 4:
-            raise Exception(
-                f"Invalid release file name. Expected `major.minor.patch.extension` "
-                f"(e.g. `1.2.3.json`), but found: {path.name}"
-            )
-        return cls(major=int(parts[0]), minor=int(parts[1]), patch=int(parts[2]))


### PR DESCRIPTION
This adds a script that handles updating the changelog and version number for a release. This is intended to be run as part of a GitHub workflow, but in the meantime it can be done manually to cut down some effort.

To bump the version and update the changelog you'll just run `uv run release`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
