### PR TITLE
Fix trait codegen for structure's string member with @idRef

### DIFF
--- a/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/CreatesTraitTest.java
+++ b/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/CreatesTraitTest.java
@@ -41,6 +41,7 @@ import com.example.traits.numbers.ShortTrait;
 import com.example.traits.structures.BasicAnnotationTrait;
 import com.example.traits.structures.NestedA;
 import com.example.traits.structures.NestedB;
+import com.example.traits.structures.StructWithIdrefMemberTrait;
 import com.example.traits.structures.StructWithListOfMapTrait;
 import com.example.traits.structures.StructWithUniqueItemsListTrait;
 import com.example.traits.structures.StructureTrait;
@@ -198,6 +199,12 @@ public class CreatesTraitTest {
                 Arguments.of(StructWithUniqueItemsListTrait.ID,
                         StructWithUniqueItemsListTrait.builder()
                                 .addItems(SetUtils.of("a", "b", "c"))
+                                .build()
+                                .toNode()),
+                Arguments.of(StructWithIdrefMemberTrait.ID,
+                        StructWithIdrefMemberTrait.builder()
+                                .idRefMemberA(ShapeId.from("test.smithy.traitcodegen#a"))
+                                .idRefMemberB(ShapeId.from("test.smithy.traitcodegen#b"))
                                 .build()
                                 .toNode()),
                 // Timestamps

--- a/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/LoadsFromModelTest.java
+++ b/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/LoadsFromModelTest.java
@@ -48,6 +48,7 @@ import com.example.traits.numbers.ShortTrait;
 import com.example.traits.structures.BasicAnnotationTrait;
 import com.example.traits.structures.NestedA;
 import com.example.traits.structures.NestedB;
+import com.example.traits.structures.StructWithIdrefMemberTrait;
 import com.example.traits.structures.StructWithListOfMapTrait;
 import com.example.traits.structures.StructWithUniqueItemsListTrait;
 import com.example.traits.structures.StructureTrait;
@@ -324,6 +325,13 @@ public class LoadsFromModelTest {
                                 Optional.of("a"),
                                 "getItems",
                                 Optional.of(SetUtils.of(SetUtils.of("b", "c"), SetUtils.of("d", "e"))))),
+                Arguments.of("structures/struct-with-idref-member-trait.smithy",
+                        StructWithIdrefMemberTrait.class,
+                        MapUtils.of(
+                                "getIdRefMemberA",
+                                Optional.of(ShapeId.from("test.smithy.traitcodegen#a")),
+                                "getIdRefMemberB",
+                                Optional.of(ShapeId.from("test.smithy.traitcodegen#b")))),
                 // Timestamps
                 Arguments.of("timestamps/struct-with-nested-timestamps.smithy",
                         StructWithNestedTimestampsTrait.class,

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/structures/struct-with-idref-member-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/structures/struct-with-idref-member-trait.smithy
@@ -1,0 +1,12 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen
+
+use test.smithy.traitcodegen.structures#StructWithIdrefMember
+
+@StructWithIdrefMember(idRefMemberA: "test.smithy.traitcodegen#a", idRefMemberB: "test.smithy.traitcodegen#b")
+structure myStruct {}
+
+structure a {}
+
+structure b {}

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/BuilderGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/BuilderGenerator.java
@@ -37,6 +37,7 @@ import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.DefaultTrait;
+import software.amazon.smithy.model.traits.IdRefTrait;
 import software.amazon.smithy.model.traits.StringListTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.TraitDefinition;
@@ -371,6 +372,10 @@ final class BuilderGenerator implements Runnable {
 
         @Override
         public Void memberShape(MemberShape shape) {
+            if (shape.hasTrait(IdRefTrait.ID)) {
+                this.getDefault(shape);
+                return null;
+            }
             return model.expectShape(shape.getTarget()).accept(this);
         }
     }

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeGenerator.java
@@ -35,6 +35,7 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.IdRefTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.UniqueItemsTrait;
 import software.amazon.smithy.traitcodegen.SymbolProperties;
@@ -242,6 +243,14 @@ final class FromNodeGenerator extends TraitVisitor<Void> implements Runnable {
 
         @Override
         public Void memberShape(MemberShape shape) {
+            if (shape.hasTrait(IdRefTrait.ID)) {
+                writer.writeInline(memberPrefix + "Member($1S, n -> $3C, builder::$2L)",
+                        fieldName,
+                        memberName,
+                        (Runnable) () -> shape
+                                .accept(new FromNodeMapperVisitor(writer, model, "n", 1, symbolProvider)));
+                return null;
+            }
             return model.expectShape(shape.getTarget()).accept(this);
         }
 

--- a/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
+++ b/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
@@ -26,7 +26,7 @@ import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.ObjectNode;
 
 public class TraitCodegenPluginTest {
-    private static final int EXPECTED_NUMBER_OF_FILES = 67;
+    private static final int EXPECTED_NUMBER_OF_FILES = 68;
 
     private MockManifest manifest;
     private Model model;

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/manifest
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/manifest
@@ -42,6 +42,7 @@ structures/annotation-trait.smithy
 structures/structure-trait.smithy
 structures/struct-with-listofmap-trait.smithy
 structures/struct-with-uniqueitems-list-trait.smithy
+structures/struct-with-idref-member-trait.smithy
 timestamps/date-time-format-timestamp-trait.smithy
 timestamps/epoch-seconds-format-timestamp-trait.smithy
 timestamps/http-date-format-timestamp-trait.smithy

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/structures/struct-with-idref-member-trait.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/structures/struct-with-idref-member-trait.smithy
@@ -1,0 +1,13 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen.structures
+
+@trait
+structure StructWithIdrefMember {
+    @idRef(selector: "structure")
+    idRefMemberA: String
+    idRefMemberB: IdRefMemberB
+}
+
+@idRef(selector: "structure")
+string IdRefMemberB


### PR DESCRIPTION
#### Background
String shapes with `@idRef` are converted into `ShapeId` objects during the trait codegen.  However, the generated `fromNode()` method and Builder setters for string members with `@idRef` within structures are incorrect.
Because the `@idReft` info is binding with the member shape and those incorrect methods are generated based on member shape's targets.

For example the following smithy model:
```smithy
$version: "2.0"

namespace test.smithy.traitcodegen.structures

@trait
structure StructWithIdrefMember {
    @idRef(selector: "structure")
    idRefMemberA: String
    idRefMemberB: IdRefMemberB
}

@idRef(selector: "structure")
string IdRefMemberB

```
The generated `fromNode()` and builder's setter methods are incorrect.

```java
@SmithyGenerated
public final class StructWithIdrefMemberTrait extends AbstractTrait implements ToSmithyBuilder<StructWithIdrefMemberTrait> {
    public static final ShapeId ID = ShapeId.from("example.traits#StructWithIdrefMember");

    private final ShapeId idRefMemberA;
    private final ShapeId idRefMemberB;
    /**
     * Creates a {@link StructWithIdrefMemberTrait} from a {@link Node}.
     *
     * @param node Node to create the StructWithIdrefMemberTrait from.
     * @return Returns the created StructWithIdrefMemberTrait.
     * @throws ExpectationNotMetException if the given Node is invalid.
     */
    public static StructWithIdrefMemberTrait fromNode(Node node) {
        Builder builder = builder();
        node.expectObjectNode()
            .getStringMember("idRefMemberA", builder::idRefMemberA)
            .getMember("idRefMemberB", n -> ShapeId.fromNode(n), builder::idRefMemberB);
        return builder.build();
    }
    
    public static final class Builder extends AbstractTraitBuilder<StructWithIdrefMemberTrait, Builder> {
        private ShapeId idRefMemberA;
        private ShapeId idRefMemberB;

        private Builder() {}

        public Builder idRefMemberA(String idRefMemberA) {
            this.idRefMemberA = idRefMemberA;
            return this;
        }
    }
}
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
