### PR TITLE
Add missing sourceLocation setting in fromNode() in trait codegen

### DIFF
--- a/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/CreatesTraitTest.java
+++ b/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/CreatesTraitTest.java
@@ -60,7 +60,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.NumberNode;
 import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.Trait;
 import software.amazon.smithy.model.traits.TraitFactory;
@@ -240,6 +242,16 @@ public class CreatesTraitTest {
 
     static Stream<Arguments> createSourceLocationTests() {
         return Stream.of(
+                Arguments.of(BigDecimalTrait.ID, new NumberNode(1, testLocation)),
+                Arguments.of(BigIntegerTrait.ID, new NumberNode(1, testLocation)),
+                Arguments.of(ByteTrait.ID, new NumberNode(1, testLocation)),
+                Arguments.of(DoubleTrait.ID, new NumberNode(1.2, testLocation)),
+                Arguments.of(FloatTrait.ID, new NumberNode(1.2, testLocation)),
+                Arguments.of(IntegerTrait.ID, new NumberNode(1, testLocation)),
+                Arguments.of(LongTrait.ID, new NumberNode(1L, testLocation)),
+                Arguments.of(ShortTrait.ID, new NumberNode(1, testLocation)),
+                Arguments.of(StringTrait.ID, new StringNode("a", testLocation)),
+                Arguments.of(TimestampTrait.ID, new StringNode("1985-04-12T23:20:50.52Z", testLocation)),
                 Arguments.of(NumberListTrait.ID,
                         ArrayNode.builder()
                                 .withValue(Node.from(1))

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeGenerator.java
@@ -37,6 +37,7 @@ import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.IdRefTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
+import software.amazon.smithy.model.traits.TraitDefinition;
 import software.amazon.smithy.model.traits.UniqueItemsTrait;
 import software.amazon.smithy.traitcodegen.SymbolProperties;
 import software.amazon.smithy.traitcodegen.TraitCodegenUtils;
@@ -83,7 +84,8 @@ final class FromNodeGenerator extends TraitVisitor<Void> implements Runnable {
                 symbol,
                 Node.class,
                 () -> {
-                    writer.writeWithNoFormatting("Builder builder = builder();");
+                    writer.writeWithNoFormatting("Builder builder = builder()" +
+                            (shape.hasTrait(TraitDefinition.ID) ? ".sourceLocation(node);" : ";"));
                     shape.accept(new FromNodeMapperVisitor(writer, model, "node", symbolProvider));
                     writer.write("builder.values(value0);");
                     writer.writeWithNoFormatting("return builder.build();");
@@ -101,7 +103,8 @@ final class FromNodeGenerator extends TraitVisitor<Void> implements Runnable {
                 symbol,
                 Node.class,
                 () -> {
-                    writer.writeWithNoFormatting("Builder builder = builder();");
+                    writer.writeWithNoFormatting("Builder builder = builder()" +
+                            (shape.hasTrait(TraitDefinition.ID) ? ".sourceLocation(node);" : ";"));
                     shape.accept(new FromNodeMapperVisitor(writer, model, "node", symbolProvider));
                     writer.writeWithNoFormatting("return builder.build();");
                 });
@@ -159,7 +162,8 @@ final class FromNodeGenerator extends TraitVisitor<Void> implements Runnable {
         writeFromNodeJavaDoc();
         writer.write("public static $T fromNode($T node) {", symbol, Node.class);
         writer.indent();
-        writer.write("Builder builder = builder();");
+        writer.write("Builder builder = builder()" +
+                (shape.hasTrait(TraitDefinition.ID) ? ".sourceLocation(node);" : ";"));
         // If the shape has no members (i.e. is an annotation trait) then there will be no member setters, and we
         // need to terminate the line.
         writer.putContext("isEmpty", shape.members().isEmpty());


### PR DESCRIPTION
#### Background
Current trait codegen missed the sourceLocation setting in `fromNode()` for list, map and structure traits. This PR will fix #2719 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
