### PR TITLE
Update query params output test in rest-json

### DIFF
--- a/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/http-query.smithy
@@ -414,22 +414,12 @@ apply IgnoreQueryParamsInResponse @httpResponseTests([
         headers: {
             "Content-Type": "application/json"
         },
-        body: "{}",
+        body: "{\"baz\":\"bam\"}",
         bodyMediaType: "application/json",
-        params: {}
-    },
-    {
-        id: "RestJsonIgnoreQueryParamsInResponseNoPayload",
-        documentation: """
-                This test is similar to RestJsonIgnoreQueryParamsInResponse,
-                but it ensures that clients gracefully handle responses from
-                the server that do not serialize an empty JSON object.""",
-        protocol: restJson1,
-        code: 200,
-        body: "",
-        params: {},
-        appliesTo: "client",
-    },
+        params: {
+            baz: "bam"
+        }
+    }
 ])
 
 structure IgnoreQueryParamsInResponseOutput {


### PR DESCRIPTION
#### Background
This change updates the RestJsonIgnoreQueryParamsInResponse test to enforce deserializing a body element that is also bound as a query parameter.

This test has a [rest-xml equivalent](https://github.com/smithy-lang/smithy/blob/38032229dd4c97a4792254350bf0ebe618e1738c/smithy-aws-protocol-tests/model/restXml/http-query.smithy#L371) that follows this same pattern.

Additionally, the extra test about "no payload" does not seem to make sense anymore in this context and has been deleted - the description of the test above says that server implementations have been updated to always return an empty json. Additionally, an empty string would never be returned in this case because there will be a payload that needs to be deserialized.

#### Testing
Smithy Ruby

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
