### PR TITLE
Fix trait codegen for timestamp member with timestampformat trait

### DIFF
--- a/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/CreatesTraitTest.java
+++ b/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/CreatesTraitTest.java
@@ -41,6 +41,7 @@ import com.example.traits.numbers.ShortTrait;
 import com.example.traits.structures.BasicAnnotationTrait;
 import com.example.traits.structures.NestedA;
 import com.example.traits.structures.NestedB;
+import com.example.traits.structures.StructMemberWithTimestampFormatTrait;
 import com.example.traits.structures.StructWithIdrefMemberTrait;
 import com.example.traits.structures.StructWithListOfMapTrait;
 import com.example.traits.structures.StructWithUniqueItemsListTrait;
@@ -53,6 +54,8 @@ import com.example.traits.uniqueitems.NumberSetTrait;
 import com.example.traits.uniqueitems.SetMember;
 import com.example.traits.uniqueitems.StringSetTrait;
 import com.example.traits.uniqueitems.StructureSetTrait;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -208,6 +211,14 @@ public class CreatesTraitTest {
                         StructWithIdrefMemberTrait.builder()
                                 .idRefMemberA(ShapeId.from("test.smithy.traitcodegen#a"))
                                 .idRefMemberB(ShapeId.from("test.smithy.traitcodegen#b"))
+                                .build()
+                                .toNode()),
+                Arguments.of(StructMemberWithTimestampFormatTrait.ID,
+                        StructMemberWithTimestampFormatTrait.builder()
+                                .memberDateTime(Instant.parse("1985-04-12T23:20:50.52Z"))
+                                .memberHttpDate(Instant.from(
+                                        DateTimeFormatter.RFC_1123_DATE_TIME.parse("Tue, 29 Apr 2014 18:30:38 GMT")))
+                                .memberEpochSeconds(Instant.ofEpochSecond((long) 1515531081.123))
                                 .build()
                                 .toNode()),
                 // Timestamps

--- a/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/LoadsFromModelTest.java
+++ b/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/LoadsFromModelTest.java
@@ -48,6 +48,7 @@ import com.example.traits.numbers.ShortTrait;
 import com.example.traits.structures.BasicAnnotationTrait;
 import com.example.traits.structures.NestedA;
 import com.example.traits.structures.NestedB;
+import com.example.traits.structures.StructMemberWithTimestampFormatTrait;
 import com.example.traits.structures.StructWithIdrefMemberTrait;
 import com.example.traits.structures.StructWithListOfMapTrait;
 import com.example.traits.structures.StructWithUniqueItemsListTrait;
@@ -332,6 +333,16 @@ public class LoadsFromModelTest {
                                 Optional.of(ShapeId.from("test.smithy.traitcodegen#a")),
                                 "getIdRefMemberB",
                                 Optional.of(ShapeId.from("test.smithy.traitcodegen#b")))),
+                Arguments.of("structures/struct-member-with-timestamp-format-trait.smithy",
+                        StructMemberWithTimestampFormatTrait.class,
+                        MapUtils.of(
+                                "getMemberDateTime",
+                                Optional.of(Instant.parse("1985-04-12T23:20:50.52Z")),
+                                "getMemberHttpDate",
+                                Optional.of(Instant.from(
+                                        DateTimeFormatter.RFC_1123_DATE_TIME.parse("Tue, 29 Apr 2014 18:30:38 GMT"))),
+                                "getMemberEpochSeconds",
+                                Optional.of(Instant.ofEpochSecond((long) 1515531081.123)))),
                 // Timestamps
                 Arguments.of("timestamps/struct-with-nested-timestamps.smithy",
                         StructWithNestedTimestampsTrait.class,

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/structures/struct-member-with-timestamp-format-trait.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/structures/struct-member-with-timestamp-format-trait.smithy
@@ -1,0 +1,12 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen
+
+use test.smithy.traitcodegen.structures#StructMemberWithTimestampFormat
+
+@StructMemberWithTimestampFormat(
+    memberDateTime: "1985-04-12T23:20:50.52Z"
+    memberHttpDate: "Tue, 29 Apr 2014 18:30:38 GMT"
+    memberEpochSeconds: 1515531081.123
+)
+structure myStruct {}

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeGenerator.java
@@ -247,12 +247,8 @@ final class FromNodeGenerator extends TraitVisitor<Void> implements Runnable {
 
         @Override
         public Void memberShape(MemberShape shape) {
-            if (shape.hasTrait(IdRefTrait.ID)) {
-                writer.writeInline(memberPrefix + "Member($1S, n -> $3C, builder::$2L)",
-                        fieldName,
-                        memberName,
-                        (Runnable) () -> shape
-                                .accept(new FromNodeMapperVisitor(writer, model, "n", 1, symbolProvider)));
+            if (shape.hasTrait(IdRefTrait.ID) || shape.hasTrait(TimestampFormatTrait.ID)) {
+                writeObjectNodeMember(shape);
                 return null;
             }
             return model.expectShape(shape.getTarget()).accept(this);
@@ -413,19 +409,13 @@ final class FromNodeGenerator extends TraitVisitor<Void> implements Runnable {
 
         @Override
         public Void structureShape(StructureShape shape) {
-            writer.writeInline(memberPrefix + "Member($1S, n -> $3C, builder::$2L)",
-                    fieldName,
-                    memberName,
-                    (Runnable) () -> shape.accept(new FromNodeMapperVisitor(writer, model, "n", symbolProvider)));
+            writeObjectNodeMember(shape);
             return null;
         }
 
         @Override
         public Void timestampShape(TimestampShape shape) {
-            writer.writeInline(memberPrefix + "Member($1S, n -> $3C, builder::$2L)",
-                    fieldName,
-                    memberName,
-                    (Runnable) () -> shape.accept(new FromNodeMapperVisitor(writer, model, "n", symbolProvider)));
+            writeObjectNodeMember(shape);
             return null;
         }
 
@@ -437,6 +427,13 @@ final class FromNodeGenerator extends TraitVisitor<Void> implements Runnable {
         @Override
         public Void blobShape(BlobShape shape) {
             throw new UnsupportedOperationException("Shape not supported " + shape);
+        }
+
+        private void writeObjectNodeMember(Shape shape) {
+            writer.writeInline(memberPrefix + "Member($1S, n -> $3C, builder::$2L)",
+                    fieldName,
+                    memberName,
+                    (Runnable) () -> shape.accept(new FromNodeMapperVisitor(writer, model, "n", symbolProvider)));
         }
     }
 }

--- a/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
+++ b/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
@@ -26,7 +26,7 @@ import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.ObjectNode;
 
 public class TraitCodegenPluginTest {
-    private static final int EXPECTED_NUMBER_OF_FILES = 68;
+    private static final int EXPECTED_NUMBER_OF_FILES = 69;
 
     private MockManifest manifest;
     private Model model;

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/manifest
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/manifest
@@ -43,6 +43,7 @@ structures/structure-trait.smithy
 structures/struct-with-listofmap-trait.smithy
 structures/struct-with-uniqueitems-list-trait.smithy
 structures/struct-with-idref-member-trait.smithy
+structures/struct-member-with-timestamp-format-trait.smithy
 timestamps/date-time-format-timestamp-trait.smithy
 timestamps/epoch-seconds-format-timestamp-trait.smithy
 timestamps/http-date-format-timestamp-trait.smithy

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/structures/struct-member-with-timestamp-format-trait.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/structures/struct-member-with-timestamp-format-trait.smithy
@@ -1,0 +1,32 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen.structures
+
+@trait
+structure StructMemberWithTimestampFormat {
+    @timestampFormat("date-time")
+    memberDateTime: Timestamp
+
+    @timestampFormat("http-date")
+    memberHttpDate: Timestamp
+
+    memberEpochSeconds: MemberEpochSeconds
+
+    memberList: TimeStampList
+
+    memberMap: StringTimeStampMap
+}
+
+@timestampFormat("epoch-seconds")
+timestamp MemberEpochSeconds
+
+list TimeStampList {
+    @timestampFormat("http-date")
+    member: Timestamp
+}
+
+map StringTimeStampMap {
+    key: String
+    @timestampFormat("http-date")
+    value:Timestamp
+}


### PR DESCRIPTION
Current trait codegen implementation cannot generate correct `fromNode()` and `createNode()` for timestamp members because traits carried by the `MemberShape` are ignored by the generators. This PR fixes this by adding special handling for `@timestampFormat` trait.
For example, the following model:
```smithy
@trait
structure StructMemberWithTimestampFormat {
    @timestampFormat("date-time")
    memberDateTime: Timestamp

    @timestampFormat("http-date")
    memberHttpDate: Timestamp

    memberEpochSeconds: MemberEpochSeconds

    memberList: TimeStampList

    memberMap: StringTimeStampMap
}

@timestampFormat("epoch-seconds")
timestamp MemberEpochSeconds

list TimeStampList {
    @timestampFormat("http-date")
    member: Timestamp
}

map StringTimeStampMap {
    key: String
    @timestampFormat("http-date")
    value:Timestamp
}
```
The generated `fromNode()` method after fix:
```java
public static StructMemberWithTimestampFormatTrait fromNode(Node node) {
        Builder builder = builder().sourceLocation(node);
        node.expectObjectNode()
            .getMember("memberDateTime", n -> Instant.parse(n.expectStringNode().getValue()), builder::memberDateTime)
            .getMember("memberHttpDate", n -> Instant.from(DateTimeFormatter.RFC_1123_DATE_TIME.parse(n.expectStringNode().getValue())), builder::memberHttpDate)
            .getMember("memberEpochSeconds", n -> Instant.ofEpochSecond(n.expectNumberNode().getValue().longValue()), builder::memberEpochSeconds)
            .getArrayMember("memberList", n -> Instant.from(DateTimeFormatter.RFC_1123_DATE_TIME.parse(n.expectStringNode().getValue())), builder::memberList)
            .getObjectMember("memberMap", o -> {
                Map<String, Instant> value1 = new LinkedHashMap<>();
                Map<StringNode, Node> members1 = o.expectObjectNode().getMembers();
                for (Entry<StringNode, Node> entry1 : members1.entrySet()) {
                    Instant value2 = Instant.from(DateTimeFormatter.RFC_1123_DATE_TIME.parse(entry1.getValue().expectStringNode().getValue()));
                    String key2 = entry1.getKey().expectStringNode().getValue();
                    value1.put(key2, value2);
                }
                builder.memberMap(value1);
            });
        return builder.build();
}
```
The generated `createNode(()` method after fix:
```java 
@Override
protected Node createNode() {
        return Node.objectNodeBuilder()
            .sourceLocation(getSourceLocation())
            .withOptionalMember("memberDateTime", getMemberDateTime().map(m -> Node.from(m.toString())))
            .withOptionalMember("memberHttpDate", getMemberHttpDate().map(m -> Node.from(DateTimeFormatter.RFC_1123_DATE_TIME.format(ZonedDateTime.ofInstant(m, ZoneOffset.UTC)))))
            .withOptionalMember("memberEpochSeconds", getMemberEpochSeconds().map(m -> Node.from(m.getEpochSecond())))
            .withOptionalMember("memberList", getMemberList().map(m -> {
                ArrayNode.Builder builder1 = ArrayNode.builder();
                for (Instant element2 : m) {
                    builder1.withValue(Node.from(DateTimeFormatter.RFC_1123_DATE_TIME.format(ZonedDateTime.ofInstant(element2, ZoneOffset.UTC))));
                }
                return builder1.build();
            }))
            .withOptionalMember("memberMap", getMemberMap().map(m -> {
                ObjectNode.Builder builder1 = ObjectNode.builder();
                for (Entry<String, Instant> entry2 : m.entrySet()) {
                    StringNode key2 = Node.from(entry2.getKey());
                    builder1.withMember(key2, Node.from(DateTimeFormatter.RFC_1123_DATE_TIME.format(ZonedDateTime.ofInstant(entry2.getValue(), ZoneOffset.UTC))));
                }
                return builder1.build();
            }))
            .build();
}
```
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
