### PR TITLE
Remove the `breakingChanges` member from the required trait

### DIFF
--- a/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
+++ b/smithy-model/src/main/resources/software/amazon/smithy/model/loader/prelude.smithy
@@ -767,13 +767,6 @@ string pattern
 /// be present.
 @trait(
     selector: "structure > member"
-    breakingChanges: [
-        {
-            change: "add"
-            severity: "WARNING"
-            message: "If any consumers were previously omitting this member in operation inputs, making it required is backwards incompatible"
-        }
-    ]
 )
 structure required {}
 


### PR DESCRIPTION


#### Background
The validation logic for required is done by the `ChangedNullability` validator. Using breaking changes without context can be misleading, e.g., adding `@required` is OK as long as it's accompanied by `@clientOptional`.

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
