### PR TITLE
Fix trait codegen for class name conflicts in enum/intenum traits

### DIFF
--- a/smithy-trait-codegen/README.md
+++ b/smithy-trait-codegen/README.md
@@ -25,6 +25,18 @@ This package contains a Smithy build plugin that generates Java trait classes fr
 - [@externalDocumentation](https://smithy.io/2.0/spec/documentation-traits.html#externaldocumentation-trait)
 - [@timestampFormat](https://smithy.io/2.0/spec/protocol-traits.html#timestampformat-trait)
 
+## Naming of Generated Code
+
+The generated Java class will have a "Trait" suffix. For example, a Java class named `FooTrait.class` will be generated for a custom trait `@Foo`.
+
+### `enum` / `intEnum` Trait Naming Strategy
+
+For `enum` and `intEnum` traits, an inner `Enum` Java class is generated inside the trait Java class with the following naming convention:
+
+**Trait Class**: Uses the full name with "Trait" suffix (e.g., `MyEnumTrait`)
+
+**Inner Enum Class**: Uses the name without "Trait" suffix to avoid naming conflicts (e.g., `MyEnum`)
+
 ## Configuration
 
 The generator supports the following configuration options:

--- a/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/CreatesTraitTest.java
+++ b/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/CreatesTraitTest.java
@@ -12,6 +12,8 @@ import com.example.traits.documents.DocumentTrait;
 import com.example.traits.documents.StructWithNestedDocumentTrait;
 import com.example.traits.enums.EnumListMemberTrait;
 import com.example.traits.enums.IntEnumTrait;
+import com.example.traits.enums.MyEnumTrait;
+import com.example.traits.enums.MyIntEnumTrait;
 import com.example.traits.enums.StringEnumTrait;
 import com.example.traits.enums.SuitTrait;
 import com.example.traits.lists.DocumentListTrait;
@@ -105,6 +107,8 @@ public class CreatesTraitTest {
                         ObjectNode.objectNodeBuilder()
                                 .withMember("value", ArrayNode.fromStrings("some", "none", "some"))
                                 .build()),
+                Arguments.of(MyIntEnumTrait.ID, Node.from(1)),
+                Arguments.of(MyEnumTrait.ID, Node.from("1")),
                 // Lists
                 Arguments.of(NumberListTrait.ID,
                         ArrayNode.fromNodes(

--- a/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/LoadsFromModelTest.java
+++ b/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/LoadsFromModelTest.java
@@ -13,6 +13,8 @@ import com.example.traits.documents.DocumentTrait;
 import com.example.traits.documents.StructWithNestedDocumentTrait;
 import com.example.traits.enums.EnumListMemberTrait;
 import com.example.traits.enums.IntEnumTrait;
+import com.example.traits.enums.MyEnumTrait;
+import com.example.traits.enums.MyIntEnumTrait;
 import com.example.traits.enums.SomeEnum;
 import com.example.traits.enums.StringEnumTrait;
 import com.example.traits.enums.SuitTrait;
@@ -124,6 +126,18 @@ public class LoadsFromModelTest {
                         EnumListMemberTrait.class,
                         MapUtils.of("getValue",
                                 Optional.of(ListUtils.of(SomeEnum.SOME, SomeEnum.NONE, SomeEnum.SOME)))),
+                Arguments.of("enums/with-trait-suffix.smithy",
+                        MyIntEnumTrait.class,
+                        MapUtils.of("getValue",
+                                1,
+                                "getEnumValue",
+                                MyIntEnumTrait.MyIntEnum.ONE)),
+                Arguments.of("enums/with-trait-suffix.smithy",
+                        MyEnumTrait.class,
+                        MapUtils.of("getValue",
+                                "1",
+                                "getEnumValue",
+                                MyEnumTrait.MyEnum.ONE)),
                 // Id Refs
                 Arguments.of("idref/idref-string.smithy",
                         IdRefStringTrait.class,

--- a/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/enums/with-trait-suffix.smithy
+++ b/smithy-trait-codegen/src/it/resources/software/amazon/smithy/traitcodegen/test/enums/with-trait-suffix.smithy
@@ -1,0 +1,10 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen
+
+use test.smithy.traitcodegen.enums#MyIntEnumTrait
+use test.smithy.traitcodegen.enums#MyEnumTrait
+
+@MyIntEnumTrait(1)
+@MyEnumTrait("1")
+structure myStruct {}

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/TraitCodegenUtils.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/TraitCodegenUtils.java
@@ -148,4 +148,20 @@ public final class TraitCodegenUtils {
     public static boolean isNullableMember(MemberShape shape) {
         return !shape.isRequired() && !shape.hasNonNullDefault();
     }
+
+    /**
+     * Gets the proper inner {@link Enum} class name without `Trait` suffix.
+     *
+     * @param symbol the symbol of a {@link software.amazon.smithy.model.shapes.EnumShape} or
+     *               {@link software.amazon.smithy.model.shapes.IntEnumShape}.
+     *
+     * @return A processed name for {@link Enum} class.
+     */
+    public static String getEnumClassName(Symbol symbol) {
+        String enumName = symbol.getName();
+        if (enumName.endsWith("Trait")) {
+            enumName = enumName.substring(0, enumName.length() - "Trait".length());
+        }
+        return enumName;
+    }
 }

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/EnumShapeGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/EnumShapeGenerator.java
@@ -15,6 +15,7 @@ import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.EnumValueTrait;
 import software.amazon.smithy.traitcodegen.GenerateTraitDirective;
+import software.amazon.smithy.traitcodegen.TraitCodegenUtils;
 import software.amazon.smithy.traitcodegen.sections.ClassSection;
 import software.amazon.smithy.traitcodegen.sections.EnumVariantSection;
 import software.amazon.smithy.traitcodegen.writer.TraitCodegenWriter;
@@ -69,11 +70,12 @@ abstract class EnumShapeGenerator implements Consumer<GenerateTraitDirective> {
             boolean isStandaloneClass
     ) {
         Symbol enumSymbol = provider.toSymbol(enumShape);
+        String enumName = TraitCodegenUtils.getEnumClassName(enumSymbol);
         writer.pushState(new ClassSection(enumShape))
                 .putContext("standalone", isStandaloneClass)
-                .openBlock("public enum $B ${?standalone}implements $T ${/standalone}{",
+                .openBlock("public enum $L ${?standalone}implements $T ${/standalone}{",
                         "}",
-                        enumSymbol,
+                        enumName,
                         ToNode.class,
                         () -> {
                             writeVariants(enumShape, provider, writer);
@@ -82,12 +84,12 @@ abstract class EnumShapeGenerator implements Consumer<GenerateTraitDirective> {
                             writeValueField(writer);
                             writer.newLine();
 
-                            writeConstructor(enumSymbol, writer);
+                            writeConstructor(enumName, writer);
 
                             writeValueGetter(writer);
                             writer.newLine();
 
-                            writeFromMethod(enumSymbol, writer);
+                            writeFromMethod(enumName, writer);
 
                             // Only generate From and To Node when we are in a standalone class.
                             if (isStandaloneClass) {
@@ -133,29 +135,29 @@ abstract class EnumShapeGenerator implements Consumer<GenerateTraitDirective> {
         writer.newLine();
     }
 
-    private void writeConstructor(Symbol enumSymbol, TraitCodegenWriter writer) {
-        writer.openBlock("$B($T value) {",
+    private void writeConstructor(String enumName, TraitCodegenWriter writer) {
+        writer.openBlock("$L($T value) {",
                 "}",
-                enumSymbol,
+                enumName,
                 getValueType(),
                 () -> writer.write("this.value = value;"));
         writer.newLine();
     }
 
-    private void writeFromMethod(Symbol enumSymbol, TraitCodegenWriter writer) {
-        writer.writeDocString(writer.format("Create a {@code $1B} from a value in a model.\n\n"
+    private void writeFromMethod(String enumName, TraitCodegenWriter writer) {
+        writer.writeDocString(writer.format("Create a {@code $1L} from a value in a model.\n\n"
                 + "<p>Any unknown value is returned as {@code UNKNOWN}.\n"
                 + "@param value Value to create enum from.\n"
-                + "@return Returns the {@link $1B} enum value.", enumSymbol));
-        writer.openBlock("public static $B from($T value) {",
+                + "@return Returns the {@link $1L} enum value.", enumName));
+        writer.openBlock("public static $L from($T value) {",
                 "}",
-                enumSymbol,
+                enumName,
                 getValueType(),
                 () -> {
                     writer.write("$T.requireNonNull(value, \"Enum value should not be null.\");", Objects.class);
-                    writer.openBlock("for ($B val: values()) {",
+                    writer.openBlock("for ($L val: values()) {",
                             "}",
-                            enumSymbol,
+                            enumName,
                             () -> writer.openBlock("if ($T.equals(val.getValue(), value)) {",
                                     "}",
                                     Objects.class,

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/GetterGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/GetterGenerator.java
@@ -89,10 +89,11 @@ final class GetterGenerator implements Runnable {
         public Void enumShape(EnumShape shape) {
             Symbol shapeSymbol = symbolProvider.toSymbol(shape);
             generateEnumValueGetterDocstring(shapeSymbol);
-            writer.openBlock("public $B getEnumValue() {",
+            String enumName = TraitCodegenUtils.getEnumClassName(shapeSymbol);
+            writer.openBlock("public $L getEnumValue() {",
                     "}",
-                    shapeSymbol,
-                    () -> writer.write("return $B.from(getValue());", shapeSymbol));
+                    enumName,
+                    () -> writer.write("return $L.from(getValue());", enumName));
             writer.newLine();
             return null;
         }
@@ -109,10 +110,11 @@ final class GetterGenerator implements Runnable {
 
             Symbol shapeSymbol = symbolProvider.toSymbol(shape);
             generateEnumValueGetterDocstring(shapeSymbol);
-            writer.openBlock("public $B getEnumValue() {",
+            String enumName = TraitCodegenUtils.getEnumClassName(shapeSymbol);
+            writer.openBlock("public $L getEnumValue() {",
                     "}",
-                    shapeSymbol,
-                    () -> writer.write("return $B.from(value);", shapeSymbol));
+                    enumName,
+                    () -> writer.write("return $L.from(value);", enumName));
             writer.newLine();
             return null;
         }

--- a/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
+++ b/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
@@ -26,7 +26,7 @@ import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.ObjectNode;
 
 public class TraitCodegenPluginTest {
-    private static final int EXPECTED_NUMBER_OF_FILES = 72;
+    private static final int EXPECTED_NUMBER_OF_FILES = 74;
 
     private MockManifest manifest;
     private Model model;

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/enums/with-trait-suffix.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/enums/with-trait-suffix.smithy
@@ -1,0 +1,27 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen.enums
+
+@mixin
+@trait
+enum MyMixinEnum {
+    THREE = "3"
+}
+
+@mixin
+@trait
+intEnum MyMixinIntEnum {
+    THREE = 3
+}
+
+@trait
+enum MyEnumTrait with [MyMixinEnum] {
+    ONE = "1"
+    TWO = "2"
+}
+
+@trait
+intEnum MyIntEnumTrait with [MyMixinIntEnum]{
+    ONE = 1
+    TWO = 2
+}

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/manifest
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/manifest
@@ -5,6 +5,7 @@ enums/enum-trait.smithy
 enums/int-enum-trait.smithy
 enums/string-enum-compatibility.smithy
 enums/enum-list-member-trait.smithy
+enums/with-trait-suffix.smithy
 idref/idref-list.smithy
 idref/idref-map.smithy
 idref/idref-string.smithy


### PR DESCRIPTION
#### Background
Current trait codegen will generate an inner `enum` java class within the trait's java class using the trait name for `enum` or `intEnum` traits. This is causing name conflicts in the java class.
For the following model:
```smithy
$version: "2.0"

namespace example.traits

@trait
enum MyEnumTrait{
    ONE = "1"
}
```
The generated Java code will look like:
```java
@SmithyGenerated
public final class MyEnumTrait extends StringTrait {
    public static final ShapeId ID = ShapeId.from("example.traits#MyEnumTrait");

    public MyEnumTrait(String value) {
        super(ID, value, SourceLocation.NONE);
    }

    public MyEnumTrait(String value, FromSourceLocation sourceLocation) {
        super(ID, value, sourceLocation);
    }

    /**
     * Gets the {@code MyEnumTrait} value as a {@code MyEnumTrait} enum.
     *
     * @return Returns the {@code MyEnumTrait} enum.
     */
    public MyEnumTrait getEnumValue() {
        return MyEnumTrait.from(getValue());
    }

    @SmithyGenerated
    public enum MyEnumTrait {
        ONE("1"),
        UNKNOWN(null);

        private final String value;

        MyEnumTrait(String value) {
            this.value = value;
        }

        public String getValue() {
            return value;
        }

        // Other code 

    }
}
```
This PR fixes the above problem.
For the following model:
```smithy
@trait
enum MyEnumTrait {
    ONE = "1"
    TWO = "2"
}
```
The generated code after the fix:
```java
@SmithyGenerated
public final class MyIntEnumTrait extends AbstractTrait {
    public static final ShapeId ID = ShapeId.from("test.smithy.traitcodegen.enums#MyIntEnumTrait");

    private final Integer value;

    public MyIntEnumTrait(Integer value) {
        super(ID, SourceLocation.NONE);
        this.value = value;
    }

    public MyIntEnumTrait(Integer value, FromSourceLocation sourceLocation) {
        super(ID, sourceLocation);
        this.value = value;
    }

    @Override
    protected Node createNode() {
        return new NumberNode(value, getSourceLocation());
    }

    public Integer getValue() {
        return value;
    }

    /**
     * Gets the {@code MyIntEnumTrait} value as a {@code
     * MyIntEnumTrait} enum.
     *
     * @return Returns the {@code MyIntEnumTrait} enum.
     */
    public MyIntEnum getEnumValue() {
        return MyIntEnum.from(value);
    }

    @SmithyGenerated
    public enum MyIntEnum {
        ONE(1),
        TWO(2),
        UNKNOWN(null);

        private final Integer value;

        MyIntEnum(Integer value) {
            this.value = value;
        }

        public Integer getValue() {
            return value;
        }

        /**
         * Create a {@code MyIntEnum} from a value in a model.
         *
         * <p>Any unknown value is returned as {@code UNKNOWN}.
         * @param value Value to create enum from.
         * @return Returns the {@link MyIntEnum} enum value.
         */
        public static MyIntEnum from(Integer value) {
            Objects.requireNonNull(value, "Enum value should not be null.");
            for (MyIntEnum val: values()) {
                if (Objects.equals(val.getValue(), value)) {
                    return val;
                }
            }
            return UNKNOWN;
        }

    }
    // Provider Implementation
}
```

Also updated the `README.md` to illustrate the naming strategy of the trait codegen, especially for the `enum` and `intEnum` traits.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
