### PR TITLE
Fix loading jars with encoded paths

### DIFF
--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelAssemblerTest.java
@@ -1459,4 +1459,36 @@ public class ModelAssemblerTest {
         assertTrue(combinedModel.expectShape(ShapeId.from("smithy.example#MachineData$machineId"), MemberShape.class)
                 .hasTrait(RequiredTrait.ID));
     }
+
+    @Test
+    public void loadsJarFromPathWithEncodedChars() throws Exception {
+        Path source = Paths.get(getClass().getResource("assembler-valid-jar").toURI());
+        Path jarPath = outputDirectory.resolve(Paths.get("path%20with%45encoded%25chars", "test.jar"));
+
+        Files.createDirectories(jarPath.getParent());
+        Files.copy(JarUtils.createJarFromDir(source), jarPath);
+
+        Model model = Model.assembler()
+                .addImport(jarPath)
+                .assemble()
+                .unwrap();
+
+        assertTrue(model.getShape(ShapeId.from("smithy.example#ExampleString")).isPresent());
+    }
+
+    @Test
+    public void loadsJarFromUrlWithEncodedChars() throws Exception {
+        Path source = Paths.get(getClass().getResource("assembler-valid-jar").toURI());
+        Path jarPath = outputDirectory.resolve(Paths.get("path%20with%45encoded%25chars", "test.jar"));
+
+        Files.createDirectories(jarPath.getParent());
+        Files.copy(JarUtils.createJarFromDir(source), jarPath);
+
+        Model model = Model.assembler()
+                .addImport(jarPath.toUri().toURL())
+                .assemble()
+                .unwrap();
+
+        assertTrue(model.getShape(ShapeId.from("smithy.example#ExampleString")).isPresent());
+    }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelDiscoveryTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/ModelDiscoveryTest.java
@@ -147,4 +147,14 @@ public class ModelDiscoveryTest {
         assertThat(ModelDiscovery.createSmithyJarManifestUrl("jar:file:/foo.jar"),
                 equalTo(new URL("jar:file:/foo.jar!/META-INF/smithy/manifest")));
     }
+
+    @Test
+    public void encodesSmithyManifestUrl() throws IOException {
+        assertThat(ModelDiscovery.createSmithyJarManifestUrl("/foo bar.jar"),
+                equalTo(new URL("jar:file:/foo%20bar.jar!/META-INF/smithy/manifest")));
+        assertThat(ModelDiscovery.createSmithyJarManifestUrl("file:/foo bar.jar"),
+                equalTo(new URL("jar:file:/foo%20bar.jar!/META-INF/smithy/manifest")));
+        assertThat(ModelDiscovery.createSmithyJarManifestUrl("jar:file:/foo bar.jar"),
+                equalTo(new URL("jar:file:/foo%20bar.jar!/META-INF/smithy/manifest")));
+    }
 }

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/assembler-valid-jar/META-INF/MANIFEST.MF
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/assembler-valid-jar/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Created-By: 11.0.6 (Amazon.com Inc.)

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/assembler-valid-jar/META-INF/smithy/manifest
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/assembler-valid-jar/META-INF/smithy/manifest
@@ -1,0 +1,1 @@
+valid.smithy

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/loader/assembler-valid-jar/META-INF/smithy/valid.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/loader/assembler-valid-jar/META-INF/smithy/valid.smithy
@@ -1,0 +1,5 @@
+$version: "2.0"
+
+namespace smithy.example
+
+string ExampleString


### PR DESCRIPTION
#### Background

The model assembler can load Smithy files from a jar - model discovery. This works by looking for a 'META-INF/smithy/manifest' file within the jar, which contains the paths of smithy model files within the jar. You can give the model assembler a class loader to use for model discovery, but you can also add a jar to discover models from using a regular `addImport`. The problem is with the latter case. Because jars are like zip files, you can't read files within the jar using regular file system operations. Instead, you can either use the JarFile api to open the jar, and read specific entries (like a zip file), or you can directly read specific entries via a special URL with the format `jar:file:/path/to/jar.jar!/path/in/jar`. The latter is the way that our model discovery apis work. The problem was that URL doesn't perform any encoding or decoding itself, so callers/consumers have to take care of it, which we were not doing. For example, if the jar file has a path of `/foo/bar%45baz.jar`, we would create a URL like: `jar:file:/foo/bar%45baz.jar!/META-INF/smithy/manifest`, and when the JDK tried to use this URL to read from the file system, it would decode it and attempt to read `/foo/bar@baz.jar`. Since we weren't encoding the URL to begin with, this was only a problem when the path contained `%`.

I tried to preserve the existing model discovery api, and just make it work with these paths. The URL class has a section in its javadoc about this footgun, and in more recent jdk versions, URL constructors are deprecated in favor of `URI::toURL` to avoid it. So that's what I did.

This technically changes the `SourceLocation::filename` for jars that are `addImport`ed, when the jar path has reserved characters (like spaces). Such jars were importable before because URL doesn't validate encoding, and the JDK decoding the URL would be a no-op since it wasn't encoded to begin with. So we could _just_ encode `%`, meaning only the newly-allowed paths would have any encoding. Disregarding the fact that this side-steps the assumed pre-conditions of URL, it would actually exacerbate an existing inconsistency between `SourceLocation::filename` of models discovered on the classpath, and models discovered from imports. The JDK encodes the URLs of resources on the classpath, so their models' source locations will be encoded. Encoding URLs of imported jars means there's no difference. You can assume that a source location with `jar:file:` is a well-formed URL/URI.

#### Testing

Added new ModelAssembler tests for loading a jar via `addImport` when the jar's path has encoded characters.
I added one for adding the import via path, and via URL, in case the way we normalize import paths ever changes.

I also added a ModelDiscovery test to assert the new encoding behavior.

#### Links

Fixes #2576 , Fixes #2103 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
