### PR TITLE
Fix new change

### DIFF
--- a/.changes/smithy_changelog/new.py
+++ b/.changes/smithy_changelog/new.py
@@ -164,8 +164,9 @@ def parse_filled_in_contents(contents: str) -> Change | None:
             # Assume that everything until the end of the file is part
             # of the description, so we can break once we pull in the
             # remaining lines.
-            first_line = line.split(":")[1].strip()
-            full_description = "\n".join([first_line], *list(lines))
+            description_lines = [line.split(":")[1].strip()]
+            description_lines.extend(lines)
+            full_description = "\n".join(description_lines)
             parsed["description"] = full_description.strip()
             break
 

--- a/.changes/smithy_changelog/new.py
+++ b/.changes/smithy_changelog/new.py
@@ -63,7 +63,7 @@ def main() -> None:
 
     args = parser.parse_args()
     new_change(
-        change_type=ChangeType[args.type.upper()],
+        change_type=ChangeType[args.type.upper()] if args.type is not None else None,
         description=args.description,
         pull_requests=args.pull_requests,
         repository=args.repository,


### PR DESCRIPTION
This fixes a pair of bugs I found in the workflow of new-change where it prompts for missing inputs:

* Fixes an issue where specifying the type was technically required anyway
* Fixes an issue where joining of description lines wasn't working as intended

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
