### PR TITLE
Revert casting terminal endpoint builder methods

### DIFF
--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/rule/Rule.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/rule/Rule.java
@@ -255,24 +255,24 @@ public abstract class Rule implements TypeCheck, ToNode, FromSourceLocation {
             return this;
         }
 
-        public EndpointRule endpoint(Endpoint endpoint) {
-            return (EndpointRule) this.onBuild.apply(new EndpointRule(this, endpoint));
+        public Rule endpoint(Endpoint endpoint) {
+            return this.onBuild.apply(new EndpointRule(this, endpoint));
         }
 
-        public ErrorRule error(Node error) {
+        public Rule error(Node error) {
             return error(Expression.fromNode(error));
         }
 
-        public ErrorRule error(String error) {
+        public Rule error(String error) {
             return error(Literal.of(error));
         }
 
-        public ErrorRule error(Expression error) {
-            return (ErrorRule) this.onBuild.apply(new ErrorRule(this, error));
+        public Rule error(Expression error) {
+            return this.onBuild.apply(new ErrorRule(this, error));
         }
 
-        public TreeRule treeRule(Rule... rules) {
-            return (TreeRule) this.treeRule(Arrays.asList(rules));
+        public Rule treeRule(Rule... rules) {
+            return this.treeRule(Arrays.asList(rules));
         }
 
         @SafeVarargs

--- a/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/logic/cfg/CfgTest.java
+++ b/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/logic/cfg/CfgTest.java
@@ -50,7 +50,7 @@ class CfgTest {
 
     @Test
     void fromCreatesSimpleCfg() {
-        EndpointRule rule = EndpointRule.builder()
+        EndpointRule rule = (EndpointRule) EndpointRule.builder()
                 .endpoint(TestHelpers.endpoint("https://example.com"));
 
         EndpointRuleSet ruleSet = EndpointRuleSet.builder()
@@ -75,7 +75,7 @@ class CfgTest {
                 .addParameter(Parameter.builder().name("region").type(ParameterType.STRING).build())
                 .build();
 
-        EndpointRule rule = EndpointRule.builder()
+        EndpointRule rule = (EndpointRule) EndpointRule.builder()
                 .condition(Condition.builder().fn(TestHelpers.isSet("region")).build())
                 .endpoint(TestHelpers.endpoint("https://example.com"));
 

--- a/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/logic/cfg/SsaTransformTest.java
+++ b/smithy-rules-engine/src/test/java/software/amazon/smithy/rulesengine/logic/cfg/SsaTransformTest.java
@@ -41,7 +41,7 @@ public class SsaTransformTest {
                 .result("bucketMatches")
                 .build();
 
-        EndpointRule rule = EndpointRule.builder()
+        EndpointRule rule = (EndpointRule) EndpointRule.builder()
                 .conditions(Collections.singletonList(condition1))
                 .endpoint(endpoint("https://example.com"));
 
@@ -127,7 +127,7 @@ public class SsaTransformTest {
                 .result("hasError")
                 .build();
 
-        ErrorRule errorRule = ErrorRule.builder()
+        ErrorRule errorRule = (ErrorRule) ErrorRule.builder()
                 .conditions(Collections.singletonList(cond))
                 .error(Expression.of("Error occurred"));
 
@@ -161,7 +161,7 @@ public class SsaTransformTest {
         EndpointRule innerRule1 = createRuleWithBinding("Region", "us-east-1", "isEast", "https://east.com");
         EndpointRule innerRule2 = createRuleWithBinding("Region", "us-west-2", "isWest", "https://west.com");
 
-        TreeRule treeRule = TreeRule.builder()
+        TreeRule treeRule = (TreeRule) TreeRule.builder()
                 .conditions(Collections.singletonList(outerCond))
                 .treeRule(innerRule1, innerRule2);
 
@@ -193,7 +193,7 @@ public class SsaTransformTest {
                 .result("Bucket_shadow")
                 .build();
 
-        EndpointRule rule = EndpointRule.builder()
+        EndpointRule rule = (EndpointRule) EndpointRule.builder()
                 .conditions(Collections.singletonList(shadowingCond))
                 .endpoint(endpoint("https://example.com"));
 
@@ -216,7 +216,7 @@ public class SsaTransformTest {
                 .result(resultVar)
                 .build();
 
-        return EndpointRule.builder()
+        return (EndpointRule) EndpointRule.builder()
                 .conditions(Collections.singletonList(cond))
                 .endpoint(endpoint(url));
     }


### PR DESCRIPTION
I didn't realize the onBuild function was used to intercept terminal builder results and rewrite them to a different type. While this is extremely unintuitive, changing it now breaks existing usage of these builders.


#### Background
* What do these changes do? 
* Why are they important?

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
