### PR TITLE
Cache gradle in GitHub workflows

### DIFF
--- a/.github/workflows/checkout-and-build-smithy/action.yml
+++ b/.github/workflows/checkout-and-build-smithy/action.yml
@@ -11,6 +11,7 @@ runs:
       with:
         java-version: 21
         distribution: 'corretto'
+        cache: gradle
 
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'corretto'
+          cache: gradle
 
       - name: Clean, build, test, and javadoc
         run: ./gradlew clean build javadoc -PnoFormat -Plog-tests --stacktrace
@@ -86,6 +87,7 @@ jobs:
         with:
           java-version: 17
           distribution: 'corretto'
+          cache: gradle
 
       - name: Publish Smithy to Maven local
         run: cd smithy && ./gradlew clean build pTML -PnoFormat

--- a/.github/workflows/codeguru-reviewer.yml
+++ b/.github/workflows/codeguru-reviewer.yml
@@ -34,6 +34,7 @@ jobs:
       with:
         distribution: 'corretto'
         java-version: 8
+        cache: gradle
 
     - name: Compile
       if: steps.iam-role.outcome == 'success'

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -25,6 +25,7 @@ jobs:
       with:
         java-version: 17
         distribution: 'corretto'
+        cache: gradle
 
     - name: Setup Node
       uses: actions/setup-node@v4

--- a/.github/workflows/sdk-codegen-ci.yml
+++ b/.github/workflows/sdk-codegen-ci.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           java-version: 17
           distribution: 'corretto'
+          cache: gradle
 
       - name: Set up Go 1.19
         uses: actions/setup-go@v5
@@ -134,6 +135,7 @@ jobs:
         with:
           java-version: 11
           distribution: 'corretto'
+          cache: gradle
 
       - uses: actions/checkout@v5
       - id: smithy-version
@@ -195,6 +197,7 @@ jobs:
         with:
           java-version: 11
           distribution: 'corretto'
+          cache: gradle
 
       - uses: actions/checkout@v5
       - id: smithy-version


### PR DESCRIPTION
#### Background
* These change add configuration to cache and restore gradle cache in GitHub workflows
* They're important as they shorten the time required for running CI. They also ensure CI can go through if gradle is down.

#### Testing
CI is successful

##### Before

Gradle build took 9m 27s
https://github.com/smithy-lang/smithy/actions/runs/17485026040/job/49702493915?pr=2767

Gradle is downloaded from network
```
Downloading https://services.gradle.org/distributions/gradle-8.14.3-bin.zip
.............10%.............20%.............30%.............40%.............50%.............60%.............70%.............80%.............90%..............100%
```

##### After

Gradle build took 9m 7s
https://github.com/smithy-lang/smithy/actions/runs/17657629935/job/50184162984?pr=2776

Gradle is used from cache
```
Cache hit for: setup-java-Linux-x64-gradle-9747105db696c51e598605430ba5768c03b834c6528543f1b60381c28225c14d
Received 20971520 of 568227640 (3.7%), 20.0 MBs/sec
Received 150994944 of 568227640 (26.6%), 72.0 MBs/sec
Received 281018368 of 568227640 (49.5%), 89.3 MBs/sec
Received 402653184 of 568227640 (70.9%), 96.0 MBs/sec
Received 536870912 of 568227640 (94.5%), 101.6 MBs/sec
Received 568227640 of 568227640 (100.0%), 100.9 MBs/sec
Cache Size: ~542 MB (568227640 B)
/usr/bin/tar -xf /home/runner/work/_temp/b8e59747-aef9-4168-9ec6-1abd4f1cf46b/cache.tzst -P -C /home/runner/work/smithy/smithy --use-compress-program unzstd
Cache restored successfully
Cache restored from key: setup-java-Linux-x64-gradle-9747105db696c51e598605430ba5768c03b834c6528543f1b60381c28225c14d
```

#### Links
* https://github.com/actions/setup-java#caching-packages-dependencies

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
