### PR TITLE
Update JSON error tests to include scenarios with nested "__type" properties

### DIFF
--- a/smithy-aws-protocol-tests/model/awsJson1_0/errors.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/errors.smithy
@@ -280,7 +280,7 @@ apply FooError @httpResponseTests([
                   "__type": "aws.protocoltests.json10#FooError",
                   "ErrorDetails": [
                     {
-                        "__type": "com.amazon.coral#ErrorDetails",
+                        "__type": "com.amazon.internal#ErrorDetails",
                         "reason": "Some reason"
                     }
                   ]

--- a/smithy-aws-protocol-tests/model/awsJson1_0/errors.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_0/errors.smithy
@@ -261,5 +261,31 @@ apply FooError @httpResponseTests([
               }""",
         bodyMediaType: "application/json",
         appliesTo: "client",
+    },
+    {
+        id: "AwsJson10FooErrorWithNestedTypeProperty",
+        documentation: """
+            Some services serialize errors using __type, and if the response includes additional shapes that belong \
+            to a different namespace there'll be a nested __type property that must not be considered when \
+            determining which error to be surfaced.
+
+            For an example service see Amazon DynamoDB.""",
+        protocol: awsJson1_0,
+        code: 500,
+        headers: {
+            "Content-Type": "application/x-amz-json-1.0"
+        },
+        body: """
+              {
+                  "__type": "aws.protocoltests.json10#FooError",
+                  "ErrorDetails": [
+                    {
+                        "__type": "com.amazon.coral#ErrorDetails",
+                        "reason": "Some reason"
+                    }
+                  ]
+              }""",
+        bodyMediaType: "application/json",
+        appliesTo: "client",
     }
 ])

--- a/smithy-aws-protocol-tests/model/awsJson1_1/errors.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/errors.smithy
@@ -272,7 +272,7 @@ apply FooError @httpResponseTests([
                   "__type": "aws.protocoltests.restjson#FooError",
                   "ErrorDetails": [
                     {
-                        "__type": "com.amazon.coral#ErrorDetails",
+                        "__type": "com.amazon.internal#ErrorDetails",
                         "reason": "Some reason"
                     }
                   ]

--- a/smithy-aws-protocol-tests/model/awsJson1_1/errors.smithy
+++ b/smithy-aws-protocol-tests/model/awsJson1_1/errors.smithy
@@ -253,5 +253,31 @@ apply FooError @httpResponseTests([
               }""",
         bodyMediaType: "application/json",
         appliesTo: "client",
+    },
+    {
+        id: "AwsJson11FooErrorWithNestedTypeProperty",
+        documentation: """
+            Some services serialize errors using __type, and if the response includes additional shapes that belong \
+            to a different namespace there'll be a nested __type property that must not be considered when \
+            determining which error to be surfaced.
+
+            For an example service see Amazon DynamoDB.""",
+        protocol: awsJson1_1,
+        code: 500,
+        headers: {
+            "Content-Type": "application/x-amz-json-1.1"
+        },
+        body: """
+              {
+                  "__type": "aws.protocoltests.restjson#FooError",
+                  "ErrorDetails": [
+                    {
+                        "__type": "com.amazon.coral#ErrorDetails",
+                        "reason": "Some reason"
+                    }
+                  ]
+              }""",
+        bodyMediaType: "application/json",
+        appliesTo: "client",
     }
 ])

--- a/smithy-aws-protocol-tests/model/restJson1/errors.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/errors.smithy
@@ -325,7 +325,7 @@ apply FooError @httpResponseTests([
                   "__type": "aws.protocoltests.restjson#FooError",
                   "ErrorDetails": [
                     {
-                        "__type": "com.amazon.coral#ErrorDetails",
+                        "__type": "com.amazon.internal#ErrorDetails",
                         "reason": "Some reason"
                     }
                   ]

--- a/smithy-aws-protocol-tests/model/restJson1/errors.smithy
+++ b/smithy-aws-protocol-tests/model/restJson1/errors.smithy
@@ -306,5 +306,31 @@ apply FooError @httpResponseTests([
               }""",
         bodyMediaType: "application/json",
         appliesTo: "client",
+    },
+    {
+        id: "RestJsonFooErrorWithNestedTypeProperty",
+        documentation: """
+            Some services serialize errors using __type, and if the response includes additional shapes that belong \
+            to a different namespace there'll be a nested __type property that must not be considered when \
+            determining which error to be surfaced.
+
+            For an example service see Amazon DynamoDB.""",
+        protocol: restJson1,
+        code: 500,
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: """
+              {
+                  "__type": "aws.protocoltests.restjson#FooError",
+                  "ErrorDetails": [
+                    {
+                        "__type": "com.amazon.coral#ErrorDetails",
+                        "reason": "Some reason"
+                    }
+                  ]
+              }""",
+        bodyMediaType: "application/json",
+        appliesTo: "client",
     }
 ])


### PR DESCRIPTION
#### Background
We recently had an issue in the .NET SDK where older versions could not handle the new responses returned by DynamoDB after the service team launched [Enhanced throttling observability](https://aws.amazon.com/blogs/database/enhanced-throttling-observability-in-amazon-dynamodb/).

Although this did not impact the latest versions (we accidentally fixed the bug in June of this year), I'm updating the protocol tests to make sure all clients can parse the response as expected (also, if these test cases existed last year when we made the .NET SDK compliant, we'd have noticed the problem at the time - the incorrect logic had existed since at least 2014).  

#### Testing
* How did you test these changes? Ran `./gradlew clean build` locally and manually updated the existing .NET SDK protocol tests to use the new responses (verifying that the correct error was returned):
```
PS> ./gradlew clean build

BUILD SUCCESSFUL in 5m 44s
509 actionable tasks: 499 executed, 10 up-to-date
```

#### Links
* Announcement in the AWS SDK for .NET repo with more details: https://github.com/aws/aws-sdk-net/issues/3996

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
