### PR TITLE
Add builder method support for ServiceResolvedConditionKeysTrait

### DIFF
--- a/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ServiceResolvedConditionKeysTrait.java
+++ b/smithy-aws-iam-traits/src/main/java/software/amazon/smithy/aws/iam/traits/ServiceResolvedConditionKeysTrait.java
@@ -12,8 +12,10 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.StringListTrait;
 import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.ToSmithyBuilder;
 
-public final class ServiceResolvedConditionKeysTrait extends StringListTrait {
+public final class ServiceResolvedConditionKeysTrait extends StringListTrait
+        implements ToSmithyBuilder<ServiceResolvedConditionKeysTrait> {
     public static final ShapeId ID = ShapeId.from("aws.iam#serviceResolvedConditionKeys");
     private List<String> resolvedConditionKeys;
 
@@ -45,6 +47,22 @@ public final class ServiceResolvedConditionKeysTrait extends StringListTrait {
     public static final class Provider extends StringListTrait.Provider<ServiceResolvedConditionKeysTrait> {
         public Provider() {
             super(ID, ServiceResolvedConditionKeysTrait::new);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return builder().sourceLocation(getSourceLocation()).values(getValues());
+    }
+
+    public static final class Builder extends StringListTrait.Builder<ServiceResolvedConditionKeysTrait, Builder> {
+        @Override
+        public ServiceResolvedConditionKeysTrait build() {
+            return new ServiceResolvedConditionKeysTrait(getValues(), getSourceLocation());
         }
     }
 }

--- a/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/ServiceResolvedConditionKeysTraitTest.java
+++ b/smithy-aws-iam-traits/src/test/java/software/amazon/smithy/aws/iam/traits/ServiceResolvedConditionKeysTraitTest.java
@@ -6,6 +6,7 @@ package software.amazon.smithy.aws.iam.traits;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
@@ -14,6 +15,18 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.ListUtils;
 
 public class ServiceResolvedConditionKeysTraitTest {
+
+    @Test
+    public void testBuilder() {
+        ServiceResolvedConditionKeysTrait.Builder builder = ServiceResolvedConditionKeysTrait.builder();
+        builder.addValue("one");
+        builder.addValue("two");
+        ServiceResolvedConditionKeysTrait trait = builder.build();
+        assertEquals(2, trait.getValues().size());
+        assertThat(trait.getValues(),
+                equalTo(ListUtils.of("one", "two")));
+    }
+
     @Test
     public void loadsFromModel() {
         Model result = Model.assembler()


### PR DESCRIPTION
#### Background
* What do these changes do?
Add builder method support for ServiceResolvedConditionKeysTrait

* Why are they important?
Allows one to dynamically build a Smithy API model without having to know all the condition keys at the start or blocking at the end to aggregate all the condition keys to be added.

#### Testing
* How did you test these changes?
Unit test


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
