### PR TITLE
Improve naming conflict resolution in Trait Codegen

### DIFF
--- a/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/CreatesTraitTest.java
+++ b/smithy-trait-codegen/src/it/java/software/amazon/smithy/traitcodegen/test/CreatesTraitTest.java
@@ -61,7 +61,7 @@ import com.example.traits.timestamps.EpochSecondsTimestampTrait;
 import com.example.traits.timestamps.HttpDateTimestampTrait;
 import com.example.traits.timestamps.TimestampTrait;
 import com.example.traits.unions.NestedUnionA;
-import com.example.traits.unions.TypeShape;
+import com.example.traits.unions.Type;
 import com.example.traits.unions.UnionTrait;
 import com.example.traits.uniqueitems.NumberSetTrait;
 import com.example.traits.uniqueitems.SetMember;
@@ -299,7 +299,7 @@ public class CreatesTraitTest {
                 Arguments.of(UnionTrait.ID,
                         UnionTrait.builder()
                                 .structVariantMember(
-                                        TypeShape.builder()
+                                        Type.builder()
                                                 .memberA("123")
                                                 .build())
                                 .build()

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeMapperVisitor.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/FromNodeMapperVisitor.java
@@ -42,7 +42,6 @@ import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.IdRefTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.model.traits.UniqueItemsTrait;
-import software.amazon.smithy.traitcodegen.TraitCodegenUtils;
 import software.amazon.smithy.traitcodegen.writer.TraitCodegenWriter;
 
 /**
@@ -262,7 +261,7 @@ final class FromNodeMapperVisitor extends ShapeVisitor.DataShapeVisitor<Void> {
 
     @Override
     public Void structureShape(StructureShape shape) {
-        writer.write("$L.fromNode($L)", TraitCodegenUtils.getDefaultName(shape), varName);
+        writer.write("$T.fromNode($L)", symbolProvider.toSymbol(shape), varName);
         return null;
     }
 
@@ -278,7 +277,7 @@ final class FromNodeMapperVisitor extends ShapeVisitor.DataShapeVisitor<Void> {
 
     @Override
     public Void unionShape(UnionShape shape) {
-        writer.write("$L.fromNode($L)", TraitCodegenUtils.getDefaultName(shape), varName);
+        writer.write("$T.fromNode($L)", symbolProvider.toSymbol(shape), varName);
         return null;
     }
 
@@ -301,7 +300,7 @@ final class FromNodeMapperVisitor extends ShapeVisitor.DataShapeVisitor<Void> {
 
     @Override
     public Void enumShape(EnumShape shape) {
-        writer.write("$L.fromNode($L)", TraitCodegenUtils.getDefaultName(shape), varName);
+        writer.write("$T.fromNode($L)", symbolProvider.toSymbol(shape), varName);
         return null;
     }
 

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/TraitGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/TraitGenerator.java
@@ -45,6 +45,7 @@ class TraitGenerator implements Consumer<GenerateTraitDirective> {
     @Override
     public void accept(GenerateTraitDirective directive) {
         directive.context().writerDelegator().useShapeWriter(directive.shape(), writer -> {
+            writer.addLocalDefinedName("Provider");
             writer.pushState(new ClassSection(directive.shape()));
             // Add class definition context
             writer.putContext("baseClass", directive.shape().accept(new BaseClassVisitor(directive.symbolProvider())));

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/UnionShapeGenerator.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/generators/UnionShapeGenerator.java
@@ -109,6 +109,7 @@ public final class UnionShapeGenerator implements Consumer<GenerateTraitDirectiv
             writer.pushState(new ClassSection(memberShape));
             String tag = memberShape.getMemberName();
             String variantClassName = symbolProvider.toMemberName(memberShape) + "Member";
+            writer.addLocalDefinedName(variantClassName);
             Symbol memberSymbol = symbolProvider.toSymbol(memberShape);
             boolean isTargetUnitType = model.expectShape(memberShape.getTarget()).hasTrait(UnitTypeTrait.ID);
             writer.putContext("isTargetUnitType", isTargetUnitType);
@@ -136,6 +137,7 @@ public final class UnionShapeGenerator implements Consumer<GenerateTraitDirectiv
     }
 
     private void writeEnumClass(TraitCodegenWriter writer, Shape shape, SymbolProvider symbolProvider) {
+        writer.addLocalDefinedName("Type");
         List<String> enumList = new ArrayList<>();
         writer.putContext("variants", enumList);
         for (MemberShape member : shape.members()) {
@@ -270,6 +272,7 @@ public final class UnionShapeGenerator implements Consumer<GenerateTraitDirectiv
                             }).newLine();
                     writer.enableNewlines();
                 });
+        writer.newLine();
     }
 
     private void writeHashCode(TraitCodegenWriter writer) {

--- a/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/writer/TraitCodegenWriter.java
+++ b/smithy-trait-codegen/src/main/java/software/amazon/smithy/traitcodegen/writer/TraitCodegenWriter.java
@@ -49,6 +49,7 @@ public class TraitCodegenWriter extends SymbolWriter<TraitCodegenWriter, TraitCo
     private final String fileName;
     private final TraitCodegenSettings settings;
     private final Map<String, Set<Symbol>> symbolNames = new HashMap<>();
+    private final Set<String> localDefinedNames = new HashSet<>();
 
     public TraitCodegenWriter(
             String fileName,
@@ -67,6 +68,16 @@ public class TraitCodegenWriter extends SymbolWriter<TraitCodegenWriter, TraitCo
         putFormatter('T', new JavaTypeFormatter());
         putFormatter('B', new BaseTypeFormatter());
         putFormatter('U', new CapitalizingFormatter());
+    }
+
+    /**
+     * Store pre-defined class name in current file.
+     *
+     * @param name a name pre-defined in the clas.
+     */
+    public void addLocalDefinedName(String name) {
+        localDefinedNames.add(name);
+        symbolNames.computeIfAbsent(name, k -> new HashSet<>()).add(Symbol.builder().name(name).build());
     }
 
     private void addImport(Symbol symbol) {
@@ -138,7 +149,8 @@ public class TraitCodegenWriter extends SymbolWriter<TraitCodegenWriter, TraitCo
                 duplicates.forEach(dupe -> {
                     // If we are in the namespace of a Symbol, use its
                     // short name, otherwise use the full name
-                    if (dupe.getNamespace().equals(namespace)) {
+                    if (dupe.getNamespace().equals(namespace)
+                            && !localDefinedNames.contains(dupe.getName())) {
                         putContext(dupe.getFullName(), dupe.getName());
                     } else {
                         putContext(dupe.getFullName(), dupe.getFullName());

--- a/smithy-trait-codegen/src/main/resources/software/amazon/smithy/traitcodegen/reserved-words.txt
+++ b/smithy-trait-codegen/src/main/resources/software/amazon/smithy/traitcodegen/reserved-words.txt
@@ -46,7 +46,6 @@ throw
 throws
 transient
 try
-type
 void
 volatile
 while

--- a/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
+++ b/smithy-trait-codegen/src/test/java/software/amazon/smithy/traitcodegen/TraitCodegenPluginTest.java
@@ -26,7 +26,7 @@ import software.amazon.smithy.model.node.ArrayNode;
 import software.amazon.smithy.model.node.ObjectNode;
 
 public class TraitCodegenPluginTest {
-    private static final int EXPECTED_NUMBER_OF_FILES = 86;
+    private static final int EXPECTED_NUMBER_OF_FILES = 99;
 
     private MockManifest manifest;
     private Model model;

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/conflicts/list-with-name-conflict.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/conflicts/list-with-name-conflict.smithy
@@ -1,0 +1,17 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen.conflicts
+
+use test.smithy.traitcodegen.conflicts#ListOfList
+use test.smithy.traitcodegen.conflicts#SetOfSet
+
+@trait
+list ListWithNameConflict {
+    member: ListOfList
+}
+
+@trait
+@uniqueItems
+list SetWithNameConflict {
+    member: SetOfSet
+}

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/conflicts/map-with-name-conflict.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/conflicts/map-with-name-conflict.smithy
@@ -1,0 +1,11 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen.conflicts
+
+use test.smithy.traitcodegen.conflicts#MapOfMap
+
+@trait
+map MapWithNameConflict {
+    key: String
+    value: MapOfMap
+}

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/conflicts/struct-with-name-conflict.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/conflicts/struct-with-name-conflict.smithy
@@ -1,0 +1,52 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen.conflicts
+
+@trait
+structure StructWithNameConflict {
+    provider: Provider
+
+    list: ListOfList
+
+    map: MapOfMap
+
+    set: SetOfSet
+
+    shapeId: ShapeId
+}
+
+
+enum Provider {
+    ONE = "1"
+}
+
+structure ShapeId {
+    @idRef
+    id: String
+}
+
+structure List {
+    provider: Provider
+}
+
+structure Map {
+    member: String
+}
+
+structure Set {
+    member: String
+}
+
+list ListOfList {
+    member: List
+}
+
+@uniqueItems
+list SetOfSet{
+    member: Set
+}
+
+map MapOfMap {
+    key: String
+    value: Map
+}

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/conflicts/union-with-name-conflict.smithy
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/conflicts/union-with-name-conflict.smithy
@@ -1,0 +1,30 @@
+$version: "2.0"
+
+namespace test.smithy.traitcodegen.conflicts
+
+@trait
+union UnionWithNameConflict{
+    type: Type
+
+    provider: Provider
+
+    Id: IdMember
+
+    union: NestedConflictUnion
+}
+
+structure IdMember {
+    member: String
+}
+
+structure Type {
+    member: String
+}
+
+union NestedConflictUnion {
+    type: Type
+    
+    provider: Provider
+
+    Id: IdMember
+}

--- a/smithy-trait-codegen/src/test/resources/META-INF/smithy/manifest
+++ b/smithy-trait-codegen/src/test/resources/META-INF/smithy/manifest
@@ -1,3 +1,7 @@
+conflicts/struct-with-name-conflict.smithy
+conflicts/list-with-name-conflict.smithy
+conflicts/map-with-name-conflict.smithy
+conflicts/union-with-name-conflict.smithy
 deprecated.smithy
 documents/document-trait.smithy
 documents/struct-with-nested-document.smithy


### PR DESCRIPTION
#### Background
Currently, Trait Codegen added `Type` to `reserved-words.txt` to resolute the name conflicts for `UnionShapes` and the conflict shapes class names would be `TypeShape`. This approach is not ideal since `Type` is used commonly and it is only reserved for Union shapes.
This PR added a Set to store those locally defined class names for each file within the writer and use fully qualified names for non-locally defined shapes to resolute the naming conflict.

Example:

For the following model:
```smithy
$version: "2.0"

namespace test.smithy.traitcodegen.conflicts

@trait
union UnionWithNameConflict{
    type: Type

    provider: Provider

    Id: IdMember

    union: NestedConflictUnion
}

structure IdMember {
    member: String
}

structure Type {
    member: String
}

union NestedConflictUnion {
    type: Type
    
    provider: Provider

    Id: IdMember
}

```

The generated code would use a fully qualified name for the structure `Type`, `Provider` and `IdMember`:

```java
@SmithyGenerated
public abstract class UnionWithNameConflictTrait extends AbstractTrait {
    public static final ShapeId ID = ShapeId.from("test.smithy.traitcodegen.conflicts#UnionWithNameConflict");

    private final Type type;

    private UnionWithNameConflictTrait(Type type, FromSourceLocation sourceLocation) {
        super(ID, sourceLocation);
        this.type = Objects.requireNonNull(type);
    }

    @Override
    protected Node createNode() {
        return Node.objectNodeBuilder().withMember(getTag(), asNode()).build();
    }

    public static UnionWithNameConflictTrait fromNode(Node node) {
        Map<StringNode, Node> members = node.expectObjectNode().getMembers();
        if (members.size() != 1) {
            throw new IllegalArgumentException("Expected only one member for union node.");
        }
        Entry<StringNode, Node> value = members.entrySet().iterator().next();
        switch (value.getKey().getValue()) {
            case "type":
                return TypeMember.from(value.getValue());
            case "provider":
                return ProviderMember.from(value.getValue());
            case "Id":
                return IdMember.from(value.getValue());
            case "union":
                return UnionMember.from(value.getValue());
            default:
                throw new IllegalArgumentException("Unknown union variant.");
        }
    }

    public String getTag() {
        return type.getValue();
    }

    public Type getType() {
        return type;
    }

    public enum Type {
        type("type"),
        provider("provider"),
        Id("Id"),
        union("union");

        private final String value;

        Type(String value) {
            this.value = value;
        }

        public String getValue() {
            return this.value;
        }
    }

    abstract Node asNode();

    public abstract <T> T getValue();

    @SmithyGenerated
    private static final class TypeMember extends UnionWithNameConflictTrait {
        private final com.example.traits.conflicts.Type value;

        private TypeMember(com.example.traits.conflicts.Type value) {
            this(value, SourceLocation.NONE);
        }

        private TypeMember(com.example.traits.conflicts.Type value, FromSourceLocation sourceLocation) {
            super(Type.type, sourceLocation);
            this.value = Objects.requireNonNull(value);
        }

        private static TypeMember from(Node node) {
            return new TypeMember(com.example.traits.conflicts.Type.fromNode(node), node);
        }

        @Override
        Node asNode() {
            return value.toNode();
        }

        @Override
        @SuppressWarnings("unchecked")
        public <T> T getValue() {
            return (T) value;
        }
    }

    @SmithyGenerated
    private static final class ProviderMember extends UnionWithNameConflictTrait {
        private final com.example.traits.conflicts.Provider value;

        private ProviderMember(com.example.traits.conflicts.Provider value) {
            this(value, SourceLocation.NONE);
        }

        private ProviderMember(com.example.traits.conflicts.Provider value, FromSourceLocation sourceLocation) {
            super(Type.provider, sourceLocation);
            this.value = Objects.requireNonNull(value);
        }

        private static ProviderMember from(Node node) {
            return new ProviderMember(com.example.traits.conflicts.Provider.fromNode(node), node);
        }

        @Override
        Node asNode() {
            return Node.from(value.getValue());
        }

        @Override
        @SuppressWarnings("unchecked")
        public <T> T getValue() {
            return (T) value;
        }
    }

    @SmithyGenerated
    private static final class IdMember extends UnionWithNameConflictTrait {
        private final com.example.traits.conflicts.IdMember value;

        private IdMember(com.example.traits.conflicts.IdMember value) {
            this(value, SourceLocation.NONE);
        }

        private IdMember(com.example.traits.conflicts.IdMember value, FromSourceLocation sourceLocation) {
            super(Type.Id, sourceLocation);
            this.value = Objects.requireNonNull(value);
        }

        private static IdMember from(Node node) {
            return new IdMember(com.example.traits.conflicts.IdMember.fromNode(node), node);
        }

        @Override
        Node asNode() {
            return value.toNode();
        }

        @Override
        @SuppressWarnings("unchecked")
        public <T> T getValue() {
            return (T) value;
        }
    }

    @SmithyGenerated
    private static final class UnionMember extends UnionWithNameConflictTrait {
        private final NestedConflictUnion value;

        private UnionMember(NestedConflictUnion value) {
            this(value, SourceLocation.NONE);
        }

        private UnionMember(NestedConflictUnion value, FromSourceLocation sourceLocation) {
            super(Type.union, sourceLocation);
            this.value = Objects.requireNonNull(value);
        }

        private static UnionMember from(Node node) {
            return new UnionMember(NestedConflictUnion.fromNode(node), node);
        }

        @Override
        Node asNode() {
            return value.toNode();
        }

        @Override
        @SuppressWarnings("unchecked")
        public <T> T getValue() {
            return (T) value;
        }
    }

    public interface BuildStage {
        UnionWithNameConflictTrait build();
    }

    public static Builder builder() {
        return new Builder();
    }

    /**
     * Builder for {@link UnionWithNameConflictTrait}.
     */
    public static final class Builder extends AbstractTraitBuilder<UnionWithNameConflictTrait, Builder> implements BuildStage {
        private UnionWithNameConflictTrait value;

        private Builder() {}

        public BuildStage typeMember(com.example.traits.conflicts.Type value) {
            return setValue(new TypeMember(value));
        }

        public BuildStage providerMember(com.example.traits.conflicts.Provider value) {
            return setValue(new ProviderMember(value));
        }

        public BuildStage IdMember(com.example.traits.conflicts.IdMember value) {
            return setValue(new IdMember(value));
        }

        public BuildStage unionMember(NestedConflictUnion value) {
            return setValue(new UnionMember(value));
        }

        private BuildStage setValue(UnionWithNameConflictTrait value) {
            if (this.value != null) {
                throw new IllegalArgumentException("Only one value may be set for unions.");
            }
            this.value = value;
            return this;
        }

        @Override
        public UnionWithNameConflictTrait build() {
            return Objects.requireNonNull(value, "no union value set.");
        }
    }

    public static final class Provider extends AbstractTrait.Provider {
        public Provider() {
            super(ID);
        }

        @Override
        public Trait createTrait(ShapeId target, Node value) {
            UnionWithNameConflictTrait result = UnionWithNameConflictTrait.fromNode(value);
            result.setNodeCache(value);
            return result;
        }
    }
}
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
