### PR TITLE
Fix topological sort NPE when re-enqueueing shapes

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/TopologicalShapeSort.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/TopologicalShapeSort.java
@@ -56,11 +56,11 @@ public final class TopologicalShapeSort {
     public void enqueue(ShapeId shape, Collection<ShapeId> dependencies) {
         if (dependencies.isEmpty()) {
             satisfiedShapes.offer(shape);
-            
+
             // Remove dependencies if this shape was enqueued in the past with them.
             Set<ShapeId> previousDependencies = forwardDependencies.remove(shape);
-            if(previousDependencies != null) {
-                for(ShapeId dependency : previousDependencies) {
+            if (previousDependencies != null) {
+                for (ShapeId dependency : previousDependencies) {
                     reverseDependencies.get(dependency).remove(shape);
                 }
             }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/TopologicalShapeSort.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/TopologicalShapeSort.java
@@ -56,6 +56,14 @@ public final class TopologicalShapeSort {
     public void enqueue(ShapeId shape, Collection<ShapeId> dependencies) {
         if (dependencies.isEmpty()) {
             satisfiedShapes.offer(shape);
+            
+            // Remove dependencies if this shape was enqueued in the past with them.
+            Set<ShapeId> previousDependencies = forwardDependencies.remove(shape);
+            if(previousDependencies != null) {
+                for(ShapeId dependency : previousDependencies) {
+                    reverseDependencies.get(dependency).remove(shape);
+                }
+            }
         } else {
             for (ShapeId dependency : dependencies) {
                 reverseDependencies.computeIfAbsent(dependency, unused -> new HashSet<>()).add(shape);
@@ -63,7 +71,8 @@ public final class TopologicalShapeSort {
             forwardDependencies.put(shape, new HashSet<>(dependencies));
 
             if (satisfiedShapes.contains(shape)) {
-                // This shape was previously marked as satisfied, but now we know it has dependencies.
+                // This shape was previously enqueued with no dependencies and marked as satisfied.
+                // Now it has dependencies.
                 satisfiedShapes.remove(shape);
             }
         }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/TopologicalShapeSort.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/TopologicalShapeSort.java
@@ -61,6 +61,11 @@ public final class TopologicalShapeSort {
                 reverseDependencies.computeIfAbsent(dependent, unused -> new HashSet<>()).add(shape);
             }
             forwardDependencies.put(shape, new HashSet<>(dependencies));
+
+            if (satisfiedShapes.contains(shape)) {
+                // This shape was previously marked as satisfied, but now we know it has dependencies.
+                satisfiedShapes.remove(shape);
+            }
         }
     }
 

--- a/smithy-model/src/main/java/software/amazon/smithy/model/loader/TopologicalShapeSort.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/loader/TopologicalShapeSort.java
@@ -57,8 +57,8 @@ public final class TopologicalShapeSort {
         if (dependencies.isEmpty()) {
             satisfiedShapes.offer(shape);
         } else {
-            for (ShapeId dependent : dependencies) {
-                reverseDependencies.computeIfAbsent(dependent, unused -> new HashSet<>()).add(shape);
+            for (ShapeId dependency : dependencies) {
+                reverseDependencies.computeIfAbsent(dependency, unused -> new HashSet<>()).add(shape);
             }
             forwardDependencies.put(shape, new HashSet<>(dependencies));
 

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/TopologicalShapeSortTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/TopologicalShapeSortTest.java
@@ -73,7 +73,7 @@ public class TopologicalShapeSortTest {
         input.add(Pair.of(from("test#B"), SetUtils.of()));
         input.add(Pair.of(from("test#B"), SetUtils.of(from("test#A"))));
         input.add(Pair.of(from("test#A"), SetUtils.of()));
-            
+
         TopologicalShapeSort sort = new TopologicalShapeSort();
         input.forEach(pair -> sort.enqueue(pair.getLeft(), pair.getRight()));
         List<ShapeId> result = sort.dequeueSortedShapes();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/TopologicalShapeSortTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/TopologicalShapeSortTest.java
@@ -66,4 +66,17 @@ public class TopologicalShapeSortTest {
             }
         }
     }
+
+    @Test
+    public void testReEnqueueWithDependencies() {
+        List<Pair<ShapeId, Set<ShapeId>>> input = new ArrayList<>();
+        input.add(Pair.of(from("test#B"), SetUtils.of()));
+        input.add(Pair.of(from("test#B"), SetUtils.of(from("test#A"))));
+        input.add(Pair.of(from("test#A"), SetUtils.of()));
+            
+        TopologicalShapeSort sort = new TopologicalShapeSort();
+        input.forEach(pair -> sort.enqueue(pair.getLeft(), pair.getRight()));
+        List<ShapeId> result = sort.dequeueSortedShapes();
+    }
+
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/TopologicalShapeSortTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/TopologicalShapeSortTest.java
@@ -81,7 +81,7 @@ public class TopologicalShapeSortTest {
         assertThat(result.get(0), equalTo(from("test#A")));
         assertThat(result.get(1), equalTo(from("test#B")));
     }
-    
+
     @Test
     public void testReEnqueueWithoutDependencies() {
         List<Pair<ShapeId, Set<ShapeId>>> input = new ArrayList<>();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/TopologicalShapeSortTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/TopologicalShapeSortTest.java
@@ -81,5 +81,37 @@ public class TopologicalShapeSortTest {
         assertThat(result.get(0), equalTo(from("test#A")));
         assertThat(result.get(1), equalTo(from("test#B")));
     }
+    
+    @Test
+    public void testReEnqueueWithoutDependencies() {
+        List<Pair<ShapeId, Set<ShapeId>>> input = new ArrayList<>();
+        input.add(Pair.of(from("test#B"), SetUtils.of(from("test#A"))));
+        input.add(Pair.of(from("test#B"), SetUtils.of()));
+        input.add(Pair.of(from("test#A"), SetUtils.of()));
+
+        TopologicalShapeSort sort = new TopologicalShapeSort();
+        input.forEach(pair -> sort.enqueue(pair.getLeft(), pair.getRight()));
+        List<ShapeId> result = sort.dequeueSortedShapes();
+
+        assertThat(result.get(0), equalTo(from("test#B")));
+        assertThat(result.get(1), equalTo(from("test#A")));
+    }
+
+    @Test
+    public void testReEnqueueSwapDependencies() {
+        List<Pair<ShapeId, Set<ShapeId>>> input = new ArrayList<>();
+        input.add(Pair.of(from("test#B"), SetUtils.of()));
+        input.add(Pair.of(from("test#A"), SetUtils.of(from("test#B"))));
+
+        input.add(Pair.of(from("test#B"), SetUtils.of(from("test#A"))));
+        input.add(Pair.of(from("test#A"), SetUtils.of()));
+
+        TopologicalShapeSort sort = new TopologicalShapeSort();
+        input.forEach(pair -> sort.enqueue(pair.getLeft(), pair.getRight()));
+        List<ShapeId> result = sort.dequeueSortedShapes();
+
+        assertThat(result.get(0), equalTo(from("test#A")));
+        assertThat(result.get(1), equalTo(from("test#B")));
+    }
 
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/loader/TopologicalShapeSortTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/loader/TopologicalShapeSortTest.java
@@ -77,6 +77,9 @@ public class TopologicalShapeSortTest {
         TopologicalShapeSort sort = new TopologicalShapeSort();
         input.forEach(pair -> sort.enqueue(pair.getLeft(), pair.getRight()));
         List<ShapeId> result = sort.dequeueSortedShapes();
+
+        assertThat(result.get(0), equalTo(from("test#A")));
+        assertThat(result.get(1), equalTo(from("test#B")));
     }
 
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
@@ -443,4 +443,38 @@ public class ReplaceShapesTest {
         assertThat(result.getShape(otherId).get(), Matchers.is(otherWithBase));
         assertThat(result.getShape(baseId).get(), Matchers.is(base));
     }
+    
+    @Test
+    public void canSwapMixinRelationships() {
+        ShapeId aId = ShapeId.from("ns.foo#A");
+        ShapeId bId = ShapeId.from("ns.foo#B");
+
+        StructureShape a = StructureShape.builder()
+                .id(aId)
+                .addTrait(MixinTrait.builder().build())
+                .build();
+        
+
+        StructureShape b = StructureShape.builder()
+                .id(bId)
+                .addTrait(MixinTrait.builder().build())
+                .build();
+        
+        StructureShape aWithMixin = a.toBuilder()
+                .addMixin(b)
+                .build();
+        
+        StructureShape bWithMixin = b.toBuilder()
+                .addMixin(a)
+                .build();
+
+        Model model = Model.builder().addShapes(a, bWithMixin).build();
+
+        ModelTransformer transformer = ModelTransformer.create();
+
+        Model result = transformer.replaceShapes(model, Arrays.asList(aWithMixin, b));
+
+        assertThat(result.getShape(aId).get(), Matchers.is(aWithMixin));
+        assertThat(result.getShape(bId).get(), Matchers.is(b));
+    }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
@@ -28,6 +28,7 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.LengthTrait;
+import software.amazon.smithy.model.traits.MixinTrait;
 import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
 
@@ -415,5 +416,34 @@ public class ReplaceShapesTest {
         // This previously would have failed because ReplaceShapes only removed members when they were removed from
         // structures or unions. We now handle member removal generically instead.
         assertThat(modelB.getShape(shapeA.getAllMembers().get("b").getId()), Matchers.equalTo(Optional.empty()));
+    }
+
+    @Test
+    public void canAddMixinToAMixin() {
+        try {
+            ShapeId baseId = ShapeId.from("ns.foo#Base");
+            StructureShape base = StructureShape.builder()
+                    .id(baseId)
+                    .addTrait(MixinTrait.builder().build())
+                    .build();
+
+            ShapeId otherId = ShapeId.from("ns.foo#Other");
+            StructureShape other = StructureShape.builder()
+                    .id(otherId)
+                    .addTrait(MixinTrait.builder().build())
+                    .build();
+
+            Model model = Model.builder().addShapes(base, other).build();
+
+            ModelTransformer transformer = ModelTransformer.create();
+
+            StructureShape otherWithBase = other.toBuilder().addMixin(base).build();
+
+            Model result = transformer.replaceShapes(model, Arrays.asList(otherWithBase));
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
     }
 }

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
@@ -443,7 +443,7 @@ public class ReplaceShapesTest {
         assertThat(result.getShape(otherId).get(), Matchers.is(otherWithBase));
         assertThat(result.getShape(baseId).get(), Matchers.is(base));
     }
-    
+
     @Test
     public void canSwapMixinRelationships() {
         ShapeId aId = ShapeId.from("ns.foo#A");
@@ -453,17 +453,16 @@ public class ReplaceShapesTest {
                 .id(aId)
                 .addTrait(MixinTrait.builder().build())
                 .build();
-        
 
         StructureShape b = StructureShape.builder()
                 .id(bId)
                 .addTrait(MixinTrait.builder().build())
                 .build();
-        
+
         StructureShape aWithMixin = a.toBuilder()
                 .addMixin(b)
                 .build();
-        
+
         StructureShape bWithMixin = b.toBuilder()
                 .addMixin(a)
                 .build();

--- a/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/transform/ReplaceShapesTest.java
@@ -420,30 +420,27 @@ public class ReplaceShapesTest {
 
     @Test
     public void canAddMixinToAMixin() {
-        try {
-            ShapeId baseId = ShapeId.from("ns.foo#Base");
-            StructureShape base = StructureShape.builder()
-                    .id(baseId)
-                    .addTrait(MixinTrait.builder().build())
-                    .build();
+        ShapeId baseId = ShapeId.from("ns.foo#Base");
+        StructureShape base = StructureShape.builder()
+                .id(baseId)
+                .addTrait(MixinTrait.builder().build())
+                .build();
 
-            ShapeId otherId = ShapeId.from("ns.foo#Other");
-            StructureShape other = StructureShape.builder()
-                    .id(otherId)
-                    .addTrait(MixinTrait.builder().build())
-                    .build();
+        ShapeId otherId = ShapeId.from("ns.foo#Other");
+        StructureShape other = StructureShape.builder()
+                .id(otherId)
+                .addTrait(MixinTrait.builder().build())
+                .build();
 
-            Model model = Model.builder().addShapes(base, other).build();
+        Model model = Model.builder().addShapes(base, other).build();
 
-            ModelTransformer transformer = ModelTransformer.create();
+        ModelTransformer transformer = ModelTransformer.create();
 
-            StructureShape otherWithBase = other.toBuilder().addMixin(base).build();
+        StructureShape otherWithBase = other.toBuilder().addMixin(base).build();
 
-            Model result = transformer.replaceShapes(model, Arrays.asList(otherWithBase));
+        Model result = transformer.replaceShapes(model, Arrays.asList(otherWithBase));
 
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw e;
-        }
+        assertThat(result.getShape(otherId).get(), Matchers.is(otherWithBase));
+        assertThat(result.getShape(baseId).get(), Matchers.is(base));
     }
 }


### PR DESCRIPTION
#### Background
I have, on several occasions, run in to issues with an NPE coming out of the TopologicalShapeSort class. Specifically:
```
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Set.remove(Object)" because "dependentDependencies" is null
    at software.amazon.smithy.model.loader.TopologicalShapeSort.dequeueSortedShapes(TopologicalShapeSort.java:83)
    at software.amazon.smithy.model.transform.ReplaceShapes.updateMixins(ReplaceShapes.java:183)
    at software.amazon.smithy.model.transform.ReplaceShapes.transform(ReplaceShapes.java:80)
    at software.amazon.smithy.model.transform.ModelTransformer.replaceShapes(ModelTransformer.java:102)
    ...
```
In some of these situations, I was able to alleviate the problem by changing the order in which I perform my model transformations, but I finally ran in to a case where I could not. I decided to look a little deeper.

When running `dequeueSortedShapes`, each shape that has no dependencies is processed in the order that they are enqueued. Upon dequeuing, they are removed from the forward dependencies map.  This is fine when `satisfiedShapes` only contains satisfied shapes, but presents issues when something with an unsatisfied dependency is marked as satisfied.  In this scenario, a given dependent may be processed before its dependencies and results in the case below:
* B is enqueued with no dependencies
* A is enqueued with no dependencies
* B is then re-enqueued, with a dependency on A
* ...
* `dequeueSortedShapes` is called
* B is processed as a satisfied shape immediately
  * Removes itself from forward dependencies
  * Has no reverse dependencies, so this shape is done processing
* A is processed as a satisfied shape
  * Removes itself from forward dependencies 
  * Detects B as a reverse dependency
  * Attempts to fetch the forward dependencies of B
  * forward dependencies are null, because B was already processed

The solution winds up being very simple. When a shape is enqueued with dependencies, we should check if it was previously marked as satisfied, and remove it from the queue if it was.

A related/opposite case was identified here: https://github.com/smithy-lang/smithy/pull/2785#discussion_r2379883973
This PR fixes that case as well.

#### Testing
* I reproduced the failure using model interactions exclusively, then reproduced the failure directly with the topological sorter.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
