### PR TITLE
Checkout before Java setup in build-docs

### DIFF
--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -20,6 +20,12 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout repo 
+      uses: actions/checkout@v5
+    - name: Setup
+      run: |
+        mkdir -p $ARTIFACTS_DIR
+
     - name: Setup Java 17
       uses: actions/setup-java@v5
       with:
@@ -31,12 +37,6 @@ jobs:
       uses: actions/setup-node@v5
       with:
         node-version: latest
-
-    - name: Checkout repo 
-      uses: actions/checkout@v5
-    - name: Setup
-      run: |
-        mkdir -p $ARTIFACTS_DIR
 
     - name: Build JavaDocs
       # run if 'javadocs' is not set to false 


### PR DESCRIPTION
This appears to be the issue causing a failure in the build-docs workflow, all other workflows check out the repository first.

See: https://github.com/smithy-lang/smithy/actions/runs/18046074400/job/51357761547

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
