### PR TITLE
Fix incorrect tags in smithy-java related docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,7 @@
 from smithy.lexer import SmithyLexer
 import requests
 import xml.etree.ElementTree as ET
+import re
 
 project = u'Smithy'
 copyright = u'2022, Amazon Web Services'
@@ -84,7 +85,8 @@ def __load_typescript_codegen_version():
 
 # Find the latest version of smithy-java from github
 def __load_java_version():
-    return requests.get('https://api.github.com/repos/smithy-lang/smithy-java/tags').json()[0]['name']
+    tags = requests.get('https://api.github.com/repos/smithy-lang/smithy-java/tags').json()
+    return next(tag['name'] for tag in tags if re.match(r'^\d+\.\d+\.\d+$', tag['name']))
 
 # We use this list of replacements to replace placeholder values in the documentation
 # with computed values. These are found and replaced


### PR DESCRIPTION
#### Background

Current smithy-java related docs are using `smithy-call` as smithy-java's version, this PR fixed this issue.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
