### PR TITLE
Revert substring validation change

### DIFF
--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/expressions/functions/Substring.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/expressions/functions/Substring.java
@@ -122,18 +122,22 @@ public final class Substring extends LibraryFunction {
         }
 
         int len = value.length();
-        if (startIndex < 0 || stopIndex > len || startIndex >= stopIndex) {
+        if (startIndex >= stopIndex || len < stopIndex) {
             return null;
         }
 
-        int from = reverse ? len - stopIndex : startIndex;
-        int to = reverse ? len - startIndex : stopIndex;
-        for (int i = from; i < to; i++) {
+        for (int i = 0; i < len; i++) {
             if (value.charAt(i) > 127) {
                 return null;
             }
         }
 
-        return value.substring(from, to);
+        if (reverse) {
+            int revStart = len - stopIndex;
+            int revStop = len - startIndex;
+            return value.substring(revStart, revStop);
+        } else {
+            return value.substring(startIndex, stopIndex);
+        }
     }
 }

--- a/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/valid/substring.smithy
+++ b/smithy-rules-engine/src/test/resources/software/amazon/smithy/rulesengine/language/errorfiles/valid/substring.smithy
@@ -158,7 +158,7 @@ use smithy.rules#endpointTests
       "documentation": "unicode characters always return `None`",
       "params": {
         "TestCaseId": "1",
-        "Input": "\uD83D\uDC31abcdef"
+        "Input": "abcdef\uD83D\uDC31"
       },
       "expect": {
         "error": "No tests matched"
@@ -168,7 +168,7 @@ use smithy.rules#endpointTests
       "documentation": "non-ascii cause substring to always return `None`",
       "params": {
         "TestCaseId": "1",
-        "Input": "ab\u0080cdef"
+        "Input": "abcdef\u0080"
       },
       "expect": {
         "error": "No tests matched"


### PR DESCRIPTION
Rather than validating the slice, first iterate over the whole string and validate it. Restores to the state before https://github.com/smithy-lang/smithy/pull/2703


#### Background
* What do these changes do? 
* Why are they important?

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
