### PR TITLE
Refactor format task to take `--check`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,19 +61,7 @@ jobs:
           cache: gradle
 
       - name: Check Smithy formatting
-        # The convention-driven smithyFormat tasks honor -PsmithyFormatCheck and fail
-        # without writing. The four packages on smithy-jar's bundled smithyFormat task
-        # need to wait for that to get plumbed through the gradle plugin, so for now
-        # they use git to check changes.
-        run: ./gradlew smithyFormat -PsmithyFormatCheck --stacktrace
-
-      - name: Assert no formatting changes from smithy-jar packages
-        run: |
-          if ! git diff --quiet; then
-            echo "::error::smithyFormat rewrote files in smithy-jar-managed packages. Run './gradlew smithyFormat' locally and commit the result."
-            git diff
-            exit 1
-          fi
+        run: ./gradlew smithyFormat --check --stacktrace
 
   cli-distributions:
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,15 +38,6 @@ allprojects {
     version = libraryVersion
 }
 
-// Aggregator that runs `smithyFormat` on every subproject that registers it.
-tasks.register("smithyFormat") {
-    group = "formatting"
-    description = "Runs smithyFormat on all subprojects that have it."
-    dependsOn(provider {
-        subprojects.mapNotNull { it.tasks.findByName("smithyFormat") }
-    })
-}
-
 // Consolidated Javadoc creation
 afterEvaluate {
     tasks {

--- a/buildSrc/src/main/kotlin/smithy.smithy-format-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy.smithy-format-conventions.gradle.kts
@@ -10,6 +10,51 @@
 // consumers here are themselves dependencies of :smithy-cli, so that wiring forms
 // a Gradle task cycle. A standalone JavaExec task avoids the cycle.
 
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.options.Option
+
+abstract class SmithyFormatTask : JavaExec() {
+
+    private var check: Boolean = false
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:SkipWhenEmpty
+    abstract val sources: ConfigurableFileCollection
+
+    @Option(option = "check", description = "Fail if files need formatting instead of rewriting them.")
+    fun setCheck(check: Boolean) {
+        this.check = check
+    }
+
+    @Internal
+    fun getCheck(): Boolean = check
+
+    init {
+        group = "formatting"
+        description = "Formats Smithy IDL files in this project."
+        mainClass.set("software.amazon.smithy.cli.SmithyCli")
+
+        // The format task mutates .smithy files in place, so the same files are both
+        // input and output. Declaring outputs makes Gradle flag every task that reads
+        // them as implicitly depending on us, which Gradle 9 promotes to a failure.
+        // Wiring dependsOn onto each consumer would satisfy the validator but creates a
+        // cycle through :smithy-cli. Instead we declare no outputs and rely on inputs
+        // for up-to-date checking and the explicit `build dependsOn` wiring below.
+        outputs.upToDateWhen { true }
+    }
+
+    override fun exec() {
+        val cliArgs = mutableListOf("format")
+        if (check) {
+            cliArgs.add("--check")
+        }
+        cliArgs.addAll(sources.files.map { it.absolutePath })
+        args = cliArgs
+        super.exec()
+    }
+}
+
 // We use a private configuration name (rather than `smithyCli`) because the smithy-jar
 // plugin already creates one with that name and would clash if both plugins are applied.
 val smithyFormatCli: Configuration by configurations.creating {
@@ -22,53 +67,18 @@ dependencies {
     smithyFormatCli(project(path = ":smithy-cli", configuration = "shadow"))
 }
 
-// Default discovery roots. Source models live either in `src/main` (jar-resource layout)
-// or a top-level `model/` directory (smithy-jar plugin's default model directory). We
-// keep each root as a separately-anchored FileTree so Gradle's implicit-dependency
-// validation sees narrow output locations, not the whole project root.
-val smithyFormatSources: FileCollection = files(
-    fileTree("src/main") { include("**/*.smithy") },
-    fileTree("model") { include("**/*.smithy") },
-)
-
-// When `-PsmithyFormatCheck` is set, the task passes `--check` to the CLI: it fails
-// instead of writing changes. Useful for CI to assert that committed files are formatted.
-val checkOnly = project.hasProperty("smithyFormatCheck")
-
-val smithyFormat = tasks.register<JavaExec>("smithyFormat") {
-    group = "formatting"
-    description = "Formats Smithy IDL files in this project."
+tasks.register<SmithyFormatTask>("smithyFormat") {
     classpath = smithyFormatCli
-    mainClass.set("software.amazon.smithy.cli.SmithyCli")
-    val sources = smithyFormatSources
-    inputs.files(sources).withPathSensitivity(PathSensitivity.RELATIVE).skipWhenEmpty()
 
-    // The format task mutates .smithy files in place, so the same files are both input
-    // and output. Declaring them as `outputs.files(sources)` is the natural thing to do,
-    // but it makes Gradle flag every other task that reads them (compileJava,
-    // processResources, ...) as implicitly depending on us, which Gradle 9 promotes from
-    // a warning to a failure. Wiring dependsOn(smithyFormat) onto each consumer would
-    // satisfy the validator but creates a cycle: this task pulls in :smithy-cli's shadow
-    // jar, which transitively needs :smithy-model:processResources, which would then
-    // depend back on :smithy-model:smithyFormat.
-    //
-    // Instead we declare no outputs and tell Gradle "trust me, you're up to date as long
-    // as inputs haven't changed". The trade-off is losing automatic ordering -- other
-    // tasks no longer implicitly know format must run first -- which we compensate for
-    // with the explicit `build dependsOn smithyFormat` wiring below.
-    outputs.upToDateWhen { true }
-    doFirst {
-        val cliArgs = mutableListOf("format")
-        if (checkOnly) {
-            cliArgs.add("--check")
-        }
-        cliArgs.addAll(sources.files.map { it.absolutePath })
-        args = cliArgs
-        if (sources.files.isEmpty()) {
-            // JavaExec fails on empty args list -- short-circuit.
-            throw StopExecutionException("No .smithy files to format.")
-        }
-    }
+    // Default discovery roots. Source models live either in `src/main` (jar-resource layout)
+    // or a top-level `model/` directory (smithy-jar plugin's default model directory). We
+    // keep each root as a separately-anchored FileTree so Gradle's implicit-dependency
+    // keep each root as a separately-anchored FileTree so Gradle's implicit-dependency
+    // validation sees narrow output locations, not the whole project root.
+    sources.from(
+        fileTree("src/main") { include("**/*.smithy") },
+        fileTree("model") { include("**/*.smithy") },
+    )
 }
 
-tasks.named("build") { dependsOn(smithyFormat) }
+tasks.named("build") { dependsOn("smithyFormat") }


### PR DESCRIPTION
This refactors the inline smithyFormat task to accept a `--check` argument instead of reading a gradle property. This is done because it prevents check-mode from being toggled on when you're not explicitly running the check task.

The task had to be updated from a fully-inline definition to a more static definition to be able to accept an explicit arg like that.

See also: https://github.com/smithy-lang/smithy-gradle-plugin/pull/168

This is in draft until the above is released because we need the gradle task to also be supporting `--check`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
