### PR TITLE
Note when removed service operation remains in closure

### DIFF
--- a/.changes/next-release/feature-693344fa645e321a5cf5076fa3ce892fbe252215.json
+++ b/.changes/next-release/feature-693344fa645e321a5cf5076fa3ce892fbe252215.json
@@ -1,6 +1,6 @@
 {
   "type": "feature",
-  "description": "The `RemovedOperationBinding` diff event is now a `WARNING` instead of an `ERROR` when a service operation is moved to a resource within the same service closure",
+  "description": "The `RemovedOperationBinding` diff event is now a `NOTE` instead of an `ERROR` when a service operation is moved to a resource within the same service closure",
   "pull_requests": [
     "[#3244](https://github.com/smithy-lang/smithy/pull/3244)"
   ]

--- a/.changes/next-release/feature-693344fa645e321a5cf5076fa3ce892fbe252215.json
+++ b/.changes/next-release/feature-693344fa645e321a5cf5076fa3ce892fbe252215.json
@@ -1,6 +1,6 @@
 {
   "type": "feature",
-  "description": "Update RemovedEntityBinding diff evaluator to warn when removed service operation remains in closure",
+  "description": "The `RemovedOperationBinding` diff event is now a `WARNING` instead of an `ERROR` when a service operation is moved to a resource within the same service closure",
   "pull_requests": [
     "[#3244](https://github.com/smithy-lang/smithy/pull/3244)"
   ]

--- a/.changes/next-release/feature-693344fa645e321a5cf5076fa3ce892fbe252215.json
+++ b/.changes/next-release/feature-693344fa645e321a5cf5076fa3ce892fbe252215.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Update RemovedEntityBinding diff evaluator to warn when removed service operation remains in closure",
+  "pull_requests": [
+    "[#3244](https://github.com/smithy-lang/smithy/pull/3244)"
+  ]
+}

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedEntityBinding.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedEntityBinding.java
@@ -66,10 +66,11 @@ public final class RemovedEntityBinding extends AbstractDiffEvaluator {
 
         for (OperationShape operation : topDownIndex.getContainedOperations(entity)) {
             ShapeId currentId = operation.getId();
-            if (currentId.equals(operationId)) {
+            int result = currentId.compareTo(operationId);
+            if (result == 0) {
                 return true;
             }
-            if (currentId.compareTo(operationId) > 0) {
+            if (result > 0) {
                 return false;
             }
         }

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedEntityBinding.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedEntityBinding.java
@@ -10,8 +10,10 @@ import java.util.List;
 import java.util.Set;
 import software.amazon.smithy.diff.ChangedShape;
 import software.amazon.smithy.diff.Differences;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.EntityShape;
+import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
 import software.amazon.smithy.model.validation.Severity;
@@ -33,35 +35,45 @@ public final class RemovedEntityBinding extends AbstractDiffEvaluator {
 
     @Override
     public List<ValidationEvent> evaluate(Differences differences) {
-        TopDownIndex topDownIndex = TopDownIndex.of(differences.getNewModel());
         List<ValidationEvent> events = new ArrayList<>();
-        differences.changedShapes(EntityShape.class).forEach(change -> validateBindings(change, events, topDownIndex));
+        differences.changedShapes(EntityShape.class)
+                .forEach(change -> validateBindings(change, events, differences.getNewModel()));
         return events;
     }
 
-    private void validateBindings(
-            ChangedShape<EntityShape> change,
-            List<ValidationEvent> events,
-            TopDownIndex topDownIndex
-    ) {
+    private void validateBindings(ChangedShape<EntityShape> change, List<ValidationEvent> events, Model newModel) {
+        TopDownIndex topDownIndex = TopDownIndex.of(newModel);
         EntityShape oldEntity = change.getOldShape();
         EntityShape newEntity = change.getNewShape();
 
         for (ShapeId removed : findRemoved(oldEntity.getOperations(), newEntity.getOperations())) {
-            Severity severity =
-                    isStillContainedInService(newEntity, removed, topDownIndex) ? Severity.WARNING : Severity.ERROR;
-            events.add(createRemovedEvent(REMOVED_OPERATION, newEntity, removed, severity));
+            if (isContainedInService(newEntity, removed, topDownIndex)) {
+                events.add(createMovedOperationEvent(newEntity, removed));
+            } else {
+                events.add(createRemovedEvent(REMOVED_OPERATION, newEntity, removed));
+            }
         }
 
         for (ShapeId removed : findRemoved(oldEntity.getResources(), newEntity.getResources())) {
-            events.add(createRemovedEvent(REMOVED_RESOURCE, newEntity, removed, Severity.ERROR));
+            events.add(createRemovedEvent(REMOVED_RESOURCE, newEntity, removed));
         }
     }
 
-    private boolean isStillContainedInService(EntityShape entity, ShapeId operationId, TopDownIndex topDownIndex) {
-        return entity.isServiceShape() && topDownIndex.getContainedOperations(entity)
-                .stream()
-                .anyMatch(operation -> operation.getId().equals(operationId));
+    private boolean isContainedInService(EntityShape entity, ShapeId operationId, TopDownIndex topDownIndex) {
+        if (!entity.isServiceShape()) {
+            return false;
+        }
+
+        for (OperationShape operation : topDownIndex.getContainedOperations(entity)) {
+            ShapeId currentId = operation.getId();
+            if (currentId.equals(operationId)) {
+                return true;
+            }
+            if (currentId.compareTo(operationId) > 0) {
+                return false;
+            }
+        }
+        return false;
     }
 
     private Set<ShapeId> findRemoved(Set<ShapeId> oldShapes, Set<ShapeId> newShapes) {
@@ -70,12 +82,21 @@ public final class RemovedEntityBinding extends AbstractDiffEvaluator {
         return removed;
     }
 
-    private ValidationEvent createRemovedEvent(
-            String typeOfRemoval,
-            EntityShape parentEntity,
-            ShapeId childShape,
-            Severity severity
-    ) {
+    private ValidationEvent createMovedOperationEvent(EntityShape service, ShapeId operationId) {
+        String message = String.format(
+                "Operation binding of `%s` was removed from service shape, `%s`, "
+                        + "but the operation remains in the service closure through a resource",
+                operationId,
+                service.getId());
+        return ValidationEvent.builder()
+                .id(REMOVED_OPERATION + FROM_SERVICE + operationId.getName())
+                .severity(Severity.WARNING)
+                .shape(service)
+                .message(message)
+                .build();
+    }
+
+    private ValidationEvent createRemovedEvent(String typeOfRemoval, EntityShape parentEntity, ShapeId childShape) {
         String childType = typeOfRemoval.equals(REMOVED_RESOURCE) ? "Resource" : "Operation";
         String typeOfParentShape = ShapeType.RESOURCE.equals(parentEntity.getType()) ? FROM_RESOURCE : FROM_SERVICE;
         String message = String.format(
@@ -86,7 +107,7 @@ public final class RemovedEntityBinding extends AbstractDiffEvaluator {
                 parentEntity.getId());
         return ValidationEvent.builder()
                 .id(typeOfRemoval + typeOfParentShape + childShape.getName())
-                .severity(severity)
+                .severity(Severity.ERROR)
                 .shape(parentEntity)
                 .message(message)
                 .build();

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedEntityBinding.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedEntityBinding.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Set;
 import software.amazon.smithy.diff.ChangedShape;
 import software.amazon.smithy.diff.Differences;
+import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.EntityShape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeType;
@@ -32,17 +33,35 @@ public final class RemovedEntityBinding extends AbstractDiffEvaluator {
 
     @Override
     public List<ValidationEvent> evaluate(Differences differences) {
+        TopDownIndex topDownIndex = TopDownIndex.of(differences.getNewModel());
         List<ValidationEvent> events = new ArrayList<>();
-        differences.changedShapes(EntityShape.class).forEach(change -> validateOperation(change, events));
+        differences.changedShapes(EntityShape.class).forEach(change -> validateBindings(change, events, topDownIndex));
         return events;
     }
 
-    private void validateOperation(ChangedShape<EntityShape> change, List<ValidationEvent> events) {
-        findRemoved(change.getOldShape().getOperations(), change.getNewShape().getOperations())
-                .forEach(removed -> events.add(createRemovedEvent(REMOVED_OPERATION, change.getNewShape(), removed)));
+    private void validateBindings(
+            ChangedShape<EntityShape> change,
+            List<ValidationEvent> events,
+            TopDownIndex topDownIndex
+    ) {
+        EntityShape oldEntity = change.getOldShape();
+        EntityShape newEntity = change.getNewShape();
 
-        findRemoved(change.getOldShape().getResources(), change.getNewShape().getResources())
-                .forEach(removed -> events.add(createRemovedEvent(REMOVED_RESOURCE, change.getNewShape(), removed)));
+        for (ShapeId removed : findRemoved(oldEntity.getOperations(), newEntity.getOperations())) {
+            Severity severity =
+                    isStillContainedInService(newEntity, removed, topDownIndex) ? Severity.WARNING : Severity.ERROR;
+            events.add(createRemovedEvent(REMOVED_OPERATION, newEntity, removed, severity));
+        }
+
+        for (ShapeId removed : findRemoved(oldEntity.getResources(), newEntity.getResources())) {
+            events.add(createRemovedEvent(REMOVED_RESOURCE, newEntity, removed, Severity.ERROR));
+        }
+    }
+
+    private boolean isStillContainedInService(EntityShape entity, ShapeId operationId, TopDownIndex topDownIndex) {
+        return entity.isServiceShape() && topDownIndex.getContainedOperations(entity)
+                .stream()
+                .anyMatch(operation -> operation.getId().equals(operationId));
     }
 
     private Set<ShapeId> findRemoved(Set<ShapeId> oldShapes, Set<ShapeId> newShapes) {
@@ -51,7 +70,12 @@ public final class RemovedEntityBinding extends AbstractDiffEvaluator {
         return removed;
     }
 
-    private ValidationEvent createRemovedEvent(String typeOfRemoval, EntityShape parentEntity, ShapeId childShape) {
+    private ValidationEvent createRemovedEvent(
+            String typeOfRemoval,
+            EntityShape parentEntity,
+            ShapeId childShape,
+            Severity severity
+    ) {
         String childType = typeOfRemoval.equals(REMOVED_RESOURCE) ? "Resource" : "Operation";
         String typeOfParentShape = ShapeType.RESOURCE.equals(parentEntity.getType()) ? FROM_RESOURCE : FROM_SERVICE;
         String message = String.format(
@@ -62,7 +86,7 @@ public final class RemovedEntityBinding extends AbstractDiffEvaluator {
                 parentEntity.getId());
         return ValidationEvent.builder()
                 .id(typeOfRemoval + typeOfParentShape + childShape.getName())
-                .severity(Severity.ERROR)
+                .severity(severity)
                 .shape(parentEntity)
                 .message(message)
                 .build();

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedEntityBinding.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/RemovedEntityBinding.java
@@ -91,7 +91,7 @@ public final class RemovedEntityBinding extends AbstractDiffEvaluator {
                 service.getId());
         return ValidationEvent.builder()
                 .id(REMOVED_OPERATION + FROM_SERVICE + operationId.getName())
-                .severity(Severity.WARNING)
+                .severity(Severity.NOTE)
                 .shape(service)
                 .message(message)
                 .build();

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
@@ -66,7 +66,7 @@ public class RemovedEntityBindingTest {
     }
 
     @Test
-    public void warnsWhenOperationMovesFromServiceToNestedResource() {
+    public void emitsNoteWhenOperationMovesFromServiceToNestedResource() {
         OperationShape op = OperationShape.builder().id("foo.baz#Operation").build();
         ResourceShape child = ResourceShape.builder()
                 .id("foo.baz#Child")

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
@@ -61,12 +61,17 @@ public class RemovedEntityBindingTest {
         Model modelA = Model.assembler().addShapes(service1, op).assemble().unwrap();
         Model modelB = Model.assembler().addShapes(service2, parent, child, op).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
-        List<ValidationEvent> removedEvents = TestHelper.findEvents(
+        List<ValidationEvent> movedEvents = TestHelper.findEvents(
                 events,
                 "RemovedOperationBinding.FromService.Operation");
 
-        assertThat(removedEvents.size(), equalTo(1));
-        assertThat(removedEvents.get(0).getSeverity(), equalTo(Severity.WARNING));
+        assertThat(movedEvents.size(), equalTo(1));
+        assertThat(movedEvents.get(0).getSeverity(), equalTo(Severity.WARNING));
+        assertThat(
+                movedEvents.get(0).getMessage(),
+                equalTo(
+                        "Operation binding of `foo.baz#Operation` was removed from service shape, `foo.baz#Service`, "
+                                + "but the operation remains in the service closure through a resource"));
     }
 
     @Test

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
@@ -15,6 +15,7 @@ import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ResourceShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
 public class RemovedEntityBindingTest {
@@ -35,6 +36,31 @@ public class RemovedEntityBindingTest {
 
         assertThat(TestHelper.findEvents(events, "RemovedOperationBinding.FromService.Operation").size(), equalTo(1));
         assertThat(events.get(0).getSourceLocation(), equalTo(source));
+    }
+
+    @Test
+    public void warnsWhenOperationMovesFromServiceToContainedResource() {
+        OperationShape o = OperationShape.builder().id("foo.baz#Operation").build();
+        ResourceShape r1 = ResourceShape.builder().id("foo.baz#Resource").build();
+        ResourceShape r2 = r1.toBuilder().addOperation(o.getId()).build();
+        ServiceShape service1 = ServiceShape.builder()
+                .version("1")
+                .id("foo.baz#Service")
+                .addOperation(o.getId())
+                .build();
+        ServiceShape service2 = service1.toBuilder()
+                .clearOperations()
+                .addResource(r2.getId())
+                .build();
+        Model modelA = Model.assembler().addShapes(service1, r1, o).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(service2, r2, o).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+        List<ValidationEvent> removedEvents = TestHelper.findEvents(
+                events,
+                "RemovedOperationBinding.FromService.Operation");
+
+        assertThat(removedEvents.size(), equalTo(1));
+        assertThat(removedEvents.get(0).getSeverity(), equalTo(Severity.WARNING));
     }
 
     @Test

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
@@ -93,7 +93,7 @@ public class RemovedEntityBindingTest {
                 "RemovedOperationBinding.FromService.Operation");
 
         assertThat(movedEvents.size(), equalTo(1));
-        assertThat(movedEvents.get(0).getSeverity(), equalTo(Severity.WARNING));
+        assertThat(movedEvents.get(0).getSeverity(), equalTo(Severity.NOTE));
         assertThat(
                 movedEvents.get(0).getMessage(),
                 equalTo(

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
@@ -39,21 +39,27 @@ public class RemovedEntityBindingTest {
     }
 
     @Test
-    public void warnsWhenOperationMovesFromServiceToContainedResource() {
-        OperationShape o = OperationShape.builder().id("foo.baz#Operation").build();
-        ResourceShape r1 = ResourceShape.builder().id("foo.baz#Resource").build();
-        ResourceShape r2 = r1.toBuilder().addOperation(o.getId()).build();
+    public void warnsWhenOperationMovesFromServiceToNestedResource() {
+        OperationShape op = OperationShape.builder().id("foo.baz#Operation").build();
+        ResourceShape child = ResourceShape.builder()
+                .id("foo.baz#Child")
+                .addOperation(op.getId())
+                .build();
+        ResourceShape parent = ResourceShape.builder()
+                .id("foo.baz#Parent")
+                .addResource(child.getId())
+                .build();
         ServiceShape service1 = ServiceShape.builder()
                 .version("1")
                 .id("foo.baz#Service")
-                .addOperation(o.getId())
+                .addOperation(op.getId())
                 .build();
         ServiceShape service2 = service1.toBuilder()
                 .clearOperations()
-                .addResource(r2.getId())
+                .addResource(parent.getId())
                 .build();
-        Model modelA = Model.assembler().addShapes(service1, r1, o).assemble().unwrap();
-        Model modelB = Model.assembler().addShapes(service2, r2, o).assemble().unwrap();
+        Model modelA = Model.assembler().addShapes(service1, op).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(service2, parent, child, op).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
         List<ValidationEvent> removedEvents = TestHelper.findEvents(
                 events,
@@ -61,6 +67,33 @@ public class RemovedEntityBindingTest {
 
         assertThat(removedEvents.size(), equalTo(1));
         assertThat(removedEvents.get(0).getSeverity(), equalTo(Severity.WARNING));
+    }
+
+    @Test
+    public void detectsWhenOperationMovesFromResourceToService() {
+        OperationShape op = OperationShape.builder().id("foo.baz#Operation").build();
+        ResourceShape resourceWithOperation = ResourceShape.builder()
+                .id("foo.baz#Resource")
+                .addOperation(op.getId())
+                .build();
+        ResourceShape resourceWithoutOperation = resourceWithOperation.toBuilder().clearOperations().build();
+        ServiceShape serviceWithResource = ServiceShape.builder()
+                .version("1")
+                .id("foo.baz#Service")
+                .addResource(resourceWithOperation.getId())
+                .build();
+        ServiceShape serviceWithOperation = serviceWithResource.toBuilder()
+                .addOperation(op.getId())
+                .build();
+        Model modelA = Model.assembler().addShapes(serviceWithResource, resourceWithOperation, op).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(serviceWithOperation, resourceWithoutOperation, op).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+        List<ValidationEvent> removedEvents = TestHelper.findEvents(
+                events,
+                "RemovedOperationBinding.FromResource.Operation");
+
+        assertThat(removedEvents.size(), equalTo(1));
+        assertThat(removedEvents.get(0).getSeverity(), equalTo(Severity.ERROR));
     }
 
     @Test

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
@@ -39,6 +39,33 @@ public class RemovedEntityBindingTest {
     }
 
     @Test
+    public void detectsRemovedOperationsBeforeAndAfterContainedOperation() {
+        // The retained middle ID exercises both early-exit and exhausted searches of the sorted closure.
+        OperationShape first = OperationShape.builder().id("foo.baz#AOperation").build();
+        OperationShape retained = OperationShape.builder().id("foo.baz#MOperation").build();
+        OperationShape last = OperationShape.builder().id("foo.baz#ZOperation").build();
+        ServiceShape service1 = ServiceShape.builder()
+                .version("1")
+                .id("foo.baz#Service")
+                .addOperation(first.getId())
+                .addOperation(retained.getId())
+                .addOperation(last.getId())
+                .build();
+        ServiceShape service2 = service1.toBuilder()
+                .clearOperations()
+                .addOperation(retained.getId())
+                .build();
+        Model modelA = Model.assembler().addShapes(service1, first, retained, last).assemble().unwrap();
+        Model modelB = Model.assembler().addShapes(service2, first, retained, last).assemble().unwrap();
+        List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
+        List<ValidationEvent> removedEvents =
+                TestHelper.findEvents(events, "RemovedOperationBinding.FromService");
+
+        assertThat(removedEvents.size(), equalTo(2));
+        assertThat(TestHelper.findEvents(removedEvents, Severity.ERROR).size(), equalTo(2));
+    }
+
+    @Test
     public void warnsWhenOperationMovesFromServiceToNestedResource() {
         OperationShape op = OperationShape.builder().id("foo.baz#Operation").build();
         ResourceShape child = ResourceShape.builder()

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/RemovedEntityBindingTest.java
@@ -86,7 +86,8 @@ public class RemovedEntityBindingTest {
                 .addOperation(op.getId())
                 .build();
         Model modelA = Model.assembler().addShapes(serviceWithResource, resourceWithOperation, op).assemble().unwrap();
-        Model modelB = Model.assembler().addShapes(serviceWithOperation, resourceWithoutOperation, op).assemble().unwrap();
+        Model modelB =
+                Model.assembler().addShapes(serviceWithOperation, resourceWithoutOperation, op).assemble().unwrap();
         List<ValidationEvent> events = ModelDiff.compare(modelA, modelB);
         List<ValidationEvent> removedEvents = TestHelper.findEvents(
                 events,

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-from-resource-to-service.a.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-from-resource-to-service.a.smithy
@@ -1,0 +1,14 @@
+$version: "2.0"
+
+namespace ns.foo
+
+service Service {
+    version: "1"
+    resources: [Resource]
+}
+
+resource Resource {
+    operations: [Operation]
+}
+
+operation Operation {}

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-from-resource-to-service.b.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-from-resource-to-service.b.smithy
@@ -1,0 +1,13 @@
+$version: "2.0"
+
+namespace ns.foo
+
+service Service {
+    version: "1"
+    operations: [Operation]
+    resources: [Resource]
+}
+
+resource Resource {}
+
+operation Operation {}

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-from-resource-to-service.events
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-from-resource-to-service.events
@@ -1,0 +1,3 @@
+[ERROR] ns.foo#Resource: Operation binding of `ns.foo#Operation` was removed from resource shape, `ns.foo#Resource` | RemovedOperationBinding.FromResource.Operation
+-----
+[NOTE] ns.foo#Service: Operation binding of `ns.foo#Operation` was added to the service shape, `ns.foo#Service` | AddedOperationBinding.ToService.Operation

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-to-nested-resource.a.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-to-nested-resource.a.smithy
@@ -1,0 +1,17 @@
+$version: "2.0"
+
+namespace ns.foo
+
+service Service {
+    version: "1"
+    operations: [Operation]
+    resources: [Parent]
+}
+
+resource Parent {
+    resources: [Child]
+}
+
+resource Child {}
+
+operation Operation {}

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-to-nested-resource.b.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-to-nested-resource.b.smithy
@@ -1,0 +1,18 @@
+$version: "2.0"
+
+namespace ns.foo
+
+service Service {
+    version: "1"
+    resources: [Parent]
+}
+
+resource Parent {
+    resources: [Child]
+}
+
+resource Child {
+    operations: [Operation]
+}
+
+operation Operation {}

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-to-nested-resource.events
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-to-nested-resource.events
@@ -1,3 +1,3 @@
-[WARNING] ns.foo#Service: Operation binding of `ns.foo#Operation` was removed from service shape, `ns.foo#Service`, but the operation remains in the service closure through a resource | RemovedOperationBinding.FromService.Operation
+[NOTE] ns.foo#Service: Operation binding of `ns.foo#Operation` was removed from service shape, `ns.foo#Service`, but the operation remains in the service closure through a resource | RemovedOperationBinding.FromService.Operation
 -----
 [NOTE] ns.foo#Child: Operation binding of `ns.foo#Operation` was added to the resource shape, `ns.foo#Child` | AddedOperationBinding.ToResource.Operation

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-to-nested-resource.events
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-to-nested-resource.events
@@ -1,0 +1,3 @@
+[WARNING] ns.foo#Service: Operation binding of `ns.foo#Operation` was removed from service shape, `ns.foo#Service`, but the operation remains in the service closure through a resource | RemovedOperationBinding.FromService.Operation
+-----
+[NOTE] ns.foo#Child: Operation binding of `ns.foo#Operation` was added to the resource shape, `ns.foo#Child` | AddedOperationBinding.ToResource.Operation

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-to-resource.a.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-to-resource.a.smithy
@@ -1,0 +1,13 @@
+$version: "2.0"
+
+namespace ns.foo
+
+service Service {
+    version: "1"
+    operations: [Operation]
+    resources: [Resource]
+}
+
+resource Resource {}
+
+operation Operation {}

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-to-resource.b.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-to-resource.b.smithy
@@ -1,0 +1,14 @@
+$version: "2.0"
+
+namespace ns.foo
+
+service Service {
+    version: "1"
+    resources: [Resource]
+}
+
+resource Resource {
+    operations: [Operation]
+}
+
+operation Operation {}

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-to-resource.events
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-to-resource.events
@@ -1,0 +1,3 @@
+[WARNING] ns.foo#Service: Operation binding of `ns.foo#Operation` was removed from service shape, `ns.foo#Service`, but the operation remains in the service closure through a resource | RemovedOperationBinding.FromService.Operation
+-----
+[NOTE] ns.foo#Resource: Operation binding of `ns.foo#Operation` was added to the resource shape, `ns.foo#Resource` | AddedOperationBinding.ToResource.Operation

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-to-resource.events
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/move-operation-to-resource.events
@@ -1,3 +1,3 @@
-[WARNING] ns.foo#Service: Operation binding of `ns.foo#Operation` was removed from service shape, `ns.foo#Service`, but the operation remains in the service closure through a resource | RemovedOperationBinding.FromService.Operation
+[NOTE] ns.foo#Service: Operation binding of `ns.foo#Operation` was removed from service shape, `ns.foo#Service`, but the operation remains in the service closure through a resource | RemovedOperationBinding.FromService.Operation
 -----
 [NOTE] ns.foo#Resource: Operation binding of `ns.foo#Operation` was added to the resource shape, `ns.foo#Resource` | AddedOperationBinding.ToResource.Operation

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-operation-from-service.a.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-operation-from-service.a.smithy
@@ -1,0 +1,10 @@
+$version: "2.0"
+
+namespace ns.foo
+
+service Service {
+    version: "1"
+    operations: [Operation]
+}
+
+operation Operation {}

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-operation-from-service.b.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-operation-from-service.b.smithy
@@ -1,0 +1,9 @@
+$version: "2.0"
+
+namespace ns.foo
+
+service Service {
+    version: "1"
+}
+
+operation Operation {}

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-operation-from-service.events
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-operation-from-service.events
@@ -1,0 +1,1 @@
+[ERROR] ns.foo#Service: Operation binding of `ns.foo#Operation` was removed from service shape, `ns.foo#Service` | RemovedOperationBinding.FromService.Operation

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-resource-from-resource.a.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-resource-from-resource.a.smithy
@@ -1,0 +1,14 @@
+$version: "2.0"
+
+namespace ns.foo
+
+service Service {
+    version: "1"
+    resources: [Parent]
+}
+
+resource Parent {
+    resources: [Child]
+}
+
+resource Child {}

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-resource-from-resource.b.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-resource-from-resource.b.smithy
@@ -1,0 +1,12 @@
+$version: "2.0"
+
+namespace ns.foo
+
+service Service {
+    version: "1"
+    resources: [Parent]
+}
+
+resource Parent {}
+
+resource Child {}

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-resource-from-resource.events
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-resource-from-resource.events
@@ -1,0 +1,1 @@
+[ERROR] ns.foo#Parent: Resource binding of `ns.foo#Child` was removed from resource shape, `ns.foo#Parent` | RemovedResourceBinding.FromResource.Child

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-resource-from-service.a.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-resource-from-service.a.smithy
@@ -1,0 +1,10 @@
+$version: "2.0"
+
+namespace ns.foo
+
+service Service {
+    version: "1"
+    resources: [Resource]
+}
+
+resource Resource {}

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-resource-from-service.b.smithy
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-resource-from-service.b.smithy
@@ -1,0 +1,9 @@
+$version: "2.0"
+
+namespace ns.foo
+
+service Service {
+    version: "1"
+}
+
+resource Resource {}

--- a/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-resource-from-service.events
+++ b/smithy-diff/src/test/resources/software/amazon/smithy/diff/diffs/removedEntityBinding/remove-resource-from-service.events
@@ -1,0 +1,1 @@
+[ERROR] ns.foo#Service: Resource binding of `ns.foo#Resource` was removed from service shape, `ns.foo#Service` | RemovedResourceBinding.FromService.Resource


### PR DESCRIPTION
Adds coverage for moving an operation out of direct service.operations while keeping it reachable through the same service closure, ensuring the diff emits a warning instead of treating it like a hard removal.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
