### PR TITLE
Fix duplicate search box in smithy doc page

### DIFF
--- a/.changes/next-release/bugfix-af2990c8128e481fc65fea16d4b1c1054147f5f2.json
+++ b/.changes/next-release/bugfix-af2990c8128e481fc65fea16d4b1c1054147f5f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Fix duplicate search box in smithy doc page",
+  "pull_requests": [
+    "[#3245](https://github.com/smithy-lang/smithy/pull/3245)"
+  ]
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,7 @@ html_theme_options = {
     # so we show just those three rather than the whole doc toctree.
     "navbar_start": ["navbar-logo"],
     "navbar_center": ["components/smithy-navbar-nav.html"],
-    "navbar_end": ["search-button-field", "theme-switcher", "navbar-icon-links"],
+    "navbar_end": ["theme-switcher", "navbar-icon-links"],
     "navbar_align": "left",
     # sphinx-book-theme puts a "toggle primary sidebar" button in the article
     # header, but with our restored pydata top header there are now two


### PR DESCRIPTION
#### Background

Pydata sphinx theme injects a search box in the nav bar and the current setting injects another search box. This PR removed the duplicate search box by altering the `navbar_end` setting in conf.py.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
