### PR TITLE
skip additional validation for null nodes in a nullable context

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/validation/NodeValidationVisitor.java
@@ -408,10 +408,17 @@ public final class NodeValidationVisitor implements ShapeVisitor<List<Validation
 
     @Override
     public List<ValidationEvent> memberShape(MemberShape shape) {
-        List<ValidationEvent> events = applyPlugins(shape);
+        List<ValidationEvent> events = new ArrayList<>();
         if (value.isNullNode()) {
             events.addAll(checkNullMember(shape));
+            if (events.isEmpty()) {
+                // It's null in a place where it's allowed to be, nothing more to validate.
+                return events;
+            }
         }
+
+        events.addAll(applyPlugins(shape));
+
         model.getShape(shape.getTarget()).ifPresent(target -> {
             // We only need to keep track of a single referring member, so a stack of members or anything like that
             // isn't needed here.

--- a/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/validation/NodeValidationVisitorTest.java
@@ -656,6 +656,41 @@ public class NodeValidationVisitorTest {
     }
 
     @Test
+    public void nullSparseTimestampListMember() {
+        ArrayNode list = ArrayNode.builder()
+                .withValue(Node.nullNode())
+                .build();
+        NodeValidationVisitor visitor = NodeValidationVisitor.builder()
+                .value(list)
+                .model(MODEL)
+                .allowOptionalNull(true)
+                .build();
+        List<ValidationEvent> events = MODEL
+                .expectShape(ShapeId.from("ns.foo#SparseTimestampList"))
+                .accept(visitor);
+
+        assertThat(events, empty());
+    }
+
+    @Test
+    public void nullSparseTimestampListMemberWithEpochSecondsStrategy() {
+        ArrayNode list = ArrayNode.builder()
+                .withValue(Node.nullNode())
+                .build();
+        NodeValidationVisitor visitor = NodeValidationVisitor.builder()
+                .value(list)
+                .model(MODEL)
+                .allowOptionalNull(true)
+                .timestampValidationStrategy(TimestampValidationStrategy.EPOCH_SECONDS)
+                .build();
+        List<ValidationEvent> events = MODEL
+                .expectShape(ShapeId.from("ns.foo#SparseTimestampList"))
+                .accept(visitor);
+
+        assertThat(events, empty());
+    }
+
+    @Test
     public void nullNonSparseMapValue() {
         ObjectNode map = ObjectNode.builder()
                 .withMember("a", Node.nullNode())

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/validation/node-validator.json
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/validation/node-validator.json
@@ -271,6 +271,15 @@
                 "target": "ns.foo#Timestamp"
             }
         },
+        "ns.foo#SparseTimestampList": {
+            "type": "list",
+            "member": {
+                "target": "ns.foo#Timestamp"
+            },
+            "traits": {
+                "smithy.api#sparse": {}
+            }
+        },
         "ns.foo#Structure2": {
             "type": "structure",
             "members": {


### PR DESCRIPTION
A null timestamp in a sparse collection (or even a struct member) would fail validation because of the extra timestamp validation plugins.

```
$version: "2"

namespace example.sparse

operation Foo {
    input: Bar
}

structure Bar {
    values: SparseTimestampList
}

@sparse
list SparseTimestampList {
    member: Timestamp
}

apply Foo @examples([
    {
        title: "foo"
        input: {
            values: ["2020-01-01T00:00:00Z", null, "2020-01-02T00:00:00Z"]
        }
    }
])
```

failed with

```
──  ERROR  ─────────────────────────────────────────────────────── ExamplesTrait
Shape: example.sparse#Foo
File:  model.smithy:22:46

22|             values: ["2020-01-01T00:00:00Z", null, "2020-01-02T00:00:00Z"]
  |                                              ^

Example input of foo.values.1: Invalid null value provided for timestamp,
smithy.api#Timestamp. Expected a number that contains epoch seconds with
optional millisecond precision, or a string that contains an RFC 3339 formatted
timestamp (e.g., "1985-04-12T23:20:50.52Z")

FAILURE: Validated 242 shapes (ERROR: 1)
```

This patch just short-circuits any time a null node is in a place where it's "allowed" to be.

**This has a minor side of effect of no longer running any external plugins for valid null nodes.** Whether or not that's a problem I don't know. The alternative would be to patch the two timestamp plugins individually to check the null node.

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
