### PR TITLE
add recorpused rpcv2json protocol tests

### DIFF
--- a/smithy-aws-protocol-tests/model/v2/query-compat.smithy
+++ b/smithy-aws-protocol-tests/model/v2/query-compat.smithy
@@ -1,0 +1,38 @@
+$version: "2.0"
+
+namespace aws.protocoltests.corpus
+
+use aws.protocols#awsQueryError
+
+// Shapes for @awsQueryCompatible coverage: services that migrated off awsQuery and
+// have to keep exposing awsQuery error codes to old callers. The service itself is
+// declared per protocol, since the trait is service-level and only some protocols
+// accept it; this file holds the operation they share. Its two errors cover the code
+// being derived from the shape name and the code being overridden by @awsQueryError.
+//
+// Note @awsQueryError's httpResponseCode is NOT applied by the RPC v2 family: it
+// records what awsQuery itself would have returned, and the status still comes from
+// the @error trait.
+operation QueryCompatErrorOp {
+    input: QueryCompatErrorOpInput
+    output: QueryCompatErrorOpOutput
+    errors: [
+        QueryCompatError
+        QueryCompatCustomCodeError
+    ]
+}
+
+structure QueryCompatErrorOpInput {}
+
+structure QueryCompatErrorOpOutput {}
+
+@error("client")
+structure QueryCompatError {
+    message: String
+}
+
+@awsQueryError(code: "CustomCode", httpResponseCode: 402)
+@error("client")
+structure QueryCompatCustomCodeError {
+    message: String
+}

--- a/smithy-aws-protocol-tests/model/v2/rpcv2jsonquerycompatible/main.smithy
+++ b/smithy-aws-protocol-tests/model/v2/rpcv2jsonquerycompatible/main.smithy
@@ -1,0 +1,16 @@
+$version: "2.0"
+
+namespace aws.protocoltests.corpus
+
+use aws.protocols#awsQueryCompatible
+use smithy.protocols#rpcv2Json
+
+@rpcv2Json
+@awsQueryCompatible
+@aws.api#service(sdkId: "RpcV2JsonQueryCompatCorpus", arnNamespace: "rpcv2jsonquerycompatcorpus")
+@aws.auth#sigv4(name: "rpcv2jsonquerycompatcorpus")
+service RpcV2JsonQueryCompatCorpusTests {
+    operations: [
+        QueryCompatErrorOp
+    ]
+}

--- a/smithy-aws-protocol-tests/model/v2/rpcv2jsonquerycompatible/querycompat-test.smithy
+++ b/smithy-aws-protocol-tests/model/v2/rpcv2jsonquerycompatible/querycompat-test.smithy
@@ -1,0 +1,73 @@
+$version: "2.0"
+
+namespace aws.protocoltests.corpus
+
+use aws.protocoltests.config#ErrorCodeParams
+use smithy.protocols#rpcv2Json
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+apply QueryCompatErrorOp @httpRequestTests([
+    {
+        id: "RpcV2JsonQueryCompatSendsQueryModeHeader"
+        documentation: "Clients for query-compatible services MUST send the x-amzn-query-mode header"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonQueryCompatCorpusTests/operation/QueryCompatErrorOp"
+        body: """
+            {}"""
+        bodyMediaType: "application/json"
+        headers: {
+            "smithy-protocol": "rpc-v2-json"
+            "Content-Type": "application/json"
+            Accept: "application/json"
+            "x-amzn-query-mode": "true"
+        }
+        forbidHeaders: ["X-Amz-Target"]
+        params: {}
+    }
+])
+
+apply QueryCompatError @httpResponseTests([
+    {
+        id: "RpcV2JsonQueryCompatNoCustomCodeError"
+        documentation: """
+            Parses an error that declares no @awsQueryError, so no
+            x-amzn-query-error header is sent and the code exposed to the caller
+            is the error shape's own name"""
+        protocol: rpcv2Json
+        code: 400
+        body: """
+            {
+                "__type": "aws.protocoltests.corpus#QueryCompatError",
+                "message": "query compatible failure"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { message: "query compatible failure" }
+        vendorParamsShape: ErrorCodeParams
+        vendorParams: { code: "QueryCompatError" }
+    }
+])
+
+apply QueryCompatCustomCodeError @httpResponseTests([
+    {
+        id: "RpcV2JsonQueryCompatCustomCodeError"
+        documentation: """
+            Parses an error whose @awsQueryError code is surfaced through the
+            x-amzn-query-error header, and exposes that customized code rather
+            than the shape name"""
+        protocol: rpcv2Json
+        code: 400
+        body: """
+            {
+                "__type": "aws.protocoltests.corpus#QueryCompatCustomCodeError",
+                "message": "customized query error code"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", "x-amzn-query-error": "CustomCode;Sender" }
+        params: { message: "customized query error code" }
+        vendorParamsShape: ErrorCodeParams
+        vendorParams: { code: "CustomCode", type: "Sender" }
+    }
+])

--- a/smithy-protocol-tests/model/v2/core.smithy
+++ b/smithy-protocol-tests/model/v2/core.smithy
@@ -1,0 +1,931 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.corpus
+
+// CoreProtocolTestService exercises the fundamental state transitions between
+// different shape types within (de)serialization.
+//
+// A deserializer is a state machine: at any point it's inside a container
+// (struct, list, map, union) and reads the next element, which is a scalar or
+// another container. Every container x element pair is a transition, and this
+// layer covers all 20 of them, plus sparse variants, errors, and the empty and
+// absent body edge cases. Every protocol mixes this in.
+//
+// Each operation tests all scalar types at once so the "matrix" stays linear
+// instead of scalar x container.
+//
+// The Document type is _excluded_ from this corpus due to its limited support
+// across protocols, it is covered separately.
+@mixin
+service CoreProtocolTestService {
+    operations: [
+        ScalarMembers
+        ListOfScalars
+        MapOfScalars
+        UnionOfScalars
+        UnionOfStruct
+        UnionOfList
+        UnionOfMap
+        UnionOfUnion
+        StructOfScalars
+        ListOfStructs
+        ListOfMaps
+        ListOfLists
+        ListOfUnions
+        MapOfStructs
+        MapOfMaps
+        MapOfLists
+        MapOfUnions
+        SparseListOfScalars
+        SparseMapOfScalars
+        SparseListOfStructs
+        SparseMapOfStructs
+        RecursiveStruct
+        RecursiveUnion
+        EmptyInputOutput
+        NoInputOutput
+        ErrorOperation
+    ]
+}
+
+operation ScalarMembers {
+    input: ScalarMembersInputOutput
+    output: ScalarMembersInputOutput
+}
+
+structure ScalarMembersInputOutput {
+    booleanMember: Boolean
+    byteMember: Byte
+    shortMember: Short
+    integerMember: Integer
+    longMember: Long
+    floatMember: Float
+    doubleMember: Double
+    bigIntegerMember: BigInteger
+    bigDecimalMember: BigDecimal
+    stringMember: String
+    blobMember: Blob
+    dateTimeMember: DateTimeTimestamp
+    epochSecondsMember: EpochSecondsTimestamp
+    httpDateMember: HttpDateTimestamp
+    stringEnum: CorpusStringEnum
+    intEnum: CorpusIntEnum
+}
+
+operation ListOfScalars {
+    input: ListOfScalarsInputOutput
+    output: ListOfScalarsInputOutput
+}
+
+structure ListOfScalarsInputOutput {
+    booleans: BooleanList
+    bytes: ByteList
+    shorts: ShortList
+    integers: IntegerList
+    longs: LongList
+    floats: FloatList
+    doubles: DoubleList
+    bigIntegers: BigIntegerList
+    bigDecimals: BigDecimalList
+    strings: StringList
+    blobs: BlobList
+    timestamps: TimestampList
+    enums: CorpusStringEnumList
+    intEnums: CorpusIntEnumList
+}
+
+operation SparseListOfScalars {
+    input: SparseListOfScalarsInputOutput
+    output: SparseListOfScalarsInputOutput
+}
+
+structure SparseListOfScalarsInputOutput {
+    booleans: SparseBooleanList
+    bytes: SparseByteList
+    shorts: SparseShortList
+    integers: SparseIntegerList
+    longs: SparseLongList
+    floats: SparseFloatList
+    doubles: SparseDoubleList
+    bigIntegers: SparseBigIntegerList
+    bigDecimals: SparseBigDecimalList
+    strings: SparseStringList
+    blobs: SparseBlobList
+    timestamps: SparseTimestampList
+    enums: SparseCorpusStringEnumList
+    intEnums: SparseCorpusIntEnumList
+}
+
+operation MapOfScalars {
+    input: MapOfScalarsInputOutput
+    output: MapOfScalarsInputOutput
+}
+
+structure MapOfScalarsInputOutput {
+    booleans: BooleanMap
+    bytes: ByteMap
+    shorts: ShortMap
+    integers: IntegerMap
+    longs: LongMap
+    floats: FloatMap
+    doubles: DoubleMap
+    bigIntegers: BigIntegerMap
+    bigDecimals: BigDecimalMap
+    strings: StringMap
+    blobs: BlobMap
+    timestamps: TimestampMap
+    enums: CorpusStringEnumMap
+    intEnums: CorpusIntEnumMap
+}
+
+operation SparseMapOfScalars {
+    input: SparseMapOfScalarsInputOutput
+    output: SparseMapOfScalarsInputOutput
+}
+
+structure SparseMapOfScalarsInputOutput {
+    booleans: SparseBooleanMap
+    bytes: SparseByteMap
+    shorts: SparseShortMap
+    integers: SparseIntegerMap
+    longs: SparseLongMap
+    floats: SparseFloatMap
+    doubles: SparseDoubleMap
+    bigIntegers: SparseBigIntegerMap
+    bigDecimals: SparseBigDecimalMap
+    strings: SparseStringMap
+    blobs: SparseBlobMap
+    timestamps: SparseTimestampMap
+    enums: SparseCorpusStringEnumMap
+    intEnums: SparseCorpusIntEnumMap
+}
+
+operation UnionOfScalars {
+    input: UnionOfScalarsInputOutput
+    output: UnionOfScalarsInputOutput
+}
+
+structure UnionOfScalarsInputOutput {
+    value: CorpusUnion
+}
+
+operation UnionOfStruct {
+    input: UnionOfStructInputOutput
+    output: UnionOfStructInputOutput
+}
+
+structure UnionOfStructInputOutput {
+    value: CorpusUnion
+}
+
+operation UnionOfList {
+    input: UnionOfListInputOutput
+    output: UnionOfListInputOutput
+}
+
+structure UnionOfListInputOutput {
+    value: CorpusUnion
+}
+
+operation UnionOfMap {
+    input: UnionOfMapInputOutput
+    output: UnionOfMapInputOutput
+}
+
+structure UnionOfMapInputOutput {
+    value: CorpusUnion
+}
+
+operation UnionOfUnion {
+    input: UnionOfUnionInputOutput
+    output: UnionOfUnionInputOutput
+}
+
+structure UnionOfUnionInputOutput {
+    value: CorpusUnion
+}
+
+union CorpusUnion {
+    booleanValue: Boolean
+    byteValue: Byte
+    shortValue: Short
+    integerValue: Integer
+    longValue: Long
+    floatValue: Float
+    doubleValue: Double
+    bigIntegerValue: BigInteger
+    bigDecimalValue: BigDecimal
+    stringValue: String
+    blobValue: Blob
+    timestampValue: NoFormatTimestamp
+    enumValue: CorpusStringEnum
+    intEnumValue: CorpusIntEnum
+    listValue: StringList
+    mapValue: StringMap
+    structValue: SimpleStruct
+    unionValue: CorpusSubUnion
+}
+
+union CorpusSubUnion {
+    stringValue: String
+    integerValue: Integer
+}
+
+operation StructOfScalars {
+    input: StructOfScalarsInputOutput
+    output: StructOfScalarsInputOutput
+}
+
+structure StructOfScalarsInputOutput {
+    value: ScalarStruct
+}
+
+structure ScalarStruct {
+    booleanMember: Boolean
+    byteMember: Byte
+    shortMember: Short
+    integerMember: Integer
+    longMember: Long
+    floatMember: Float
+    doubleMember: Double
+    bigIntegerMember: BigInteger
+    bigDecimalMember: BigDecimal
+    stringMember: String
+    blobMember: Blob
+    dateTimeMember: DateTimeTimestamp
+    epochSecondsMember: EpochSecondsTimestamp
+    httpDateMember: HttpDateTimestamp
+    stringEnum: CorpusStringEnum
+    intEnum: CorpusIntEnum
+}
+
+operation ListOfStructs {
+    input: ListOfStructsInputOutput
+    output: ListOfStructsInputOutput
+}
+
+structure ListOfStructsInputOutput {
+    values: SimpleStructList
+}
+
+operation ListOfMaps {
+    input: ListOfMapsInputOutput
+    output: ListOfMapsInputOutput
+}
+
+structure ListOfMapsInputOutput {
+    booleans: ListOfBooleanMap
+    integers: ListOfIntegerMap
+    strings: ListOfStringMap
+    blobs: ListOfBlobMap
+    timestamps: ListOfTimestampMap
+    enums: ListOfCorpusStringEnumMap
+    intEnums: ListOfCorpusIntEnumMap
+}
+
+operation ListOfLists {
+    input: ListOfListsInputOutput
+    output: ListOfListsInputOutput
+}
+
+structure ListOfListsInputOutput {
+    booleans: ListOfBooleanList
+    integers: ListOfIntegerList
+    strings: ListOfStringList
+    blobs: ListOfBlobList
+    timestamps: ListOfTimestampList
+    enums: ListOfCorpusStringEnumList
+    intEnums: ListOfCorpusIntEnumList
+}
+
+operation ListOfUnions {
+    input: ListOfUnionsInputOutput
+    output: ListOfUnionsInputOutput
+}
+
+structure ListOfUnionsInputOutput {
+    values: CorpusUnionList
+}
+
+operation MapOfStructs {
+    input: MapOfStructsInputOutput
+    output: MapOfStructsInputOutput
+}
+
+structure MapOfStructsInputOutput {
+    values: SimpleStructMap
+}
+
+operation MapOfMaps {
+    input: MapOfMapsInputOutput
+    output: MapOfMapsInputOutput
+}
+
+structure MapOfMapsInputOutput {
+    booleans: MapOfBooleanMap
+    integers: MapOfIntegerMap
+    strings: MapOfStringMap
+    blobs: MapOfBlobMap
+    timestamps: MapOfTimestampMap
+    enums: MapOfCorpusStringEnumMap
+    intEnums: MapOfCorpusIntEnumMap
+}
+
+operation MapOfLists {
+    input: MapOfListsInputOutput
+    output: MapOfListsInputOutput
+}
+
+structure MapOfListsInputOutput {
+    booleans: MapOfBooleanList
+    integers: MapOfIntegerList
+    strings: MapOfStringList
+    blobs: MapOfBlobList
+    timestamps: MapOfTimestampList
+    enums: MapOfCorpusStringEnumList
+    intEnums: MapOfCorpusIntEnumList
+}
+
+operation MapOfUnions {
+    input: MapOfUnionsInputOutput
+    output: MapOfUnionsInputOutput
+}
+
+structure MapOfUnionsInputOutput {
+    values: CorpusUnionMap
+}
+
+operation SparseListOfStructs {
+    input: SparseListOfStructsInputOutput
+    output: SparseListOfStructsInputOutput
+}
+
+structure SparseListOfStructsInputOutput {
+    values: SparseSimpleStructList
+}
+
+operation SparseMapOfStructs {
+    input: SparseMapOfStructsInputOutput
+    output: SparseMapOfStructsInputOutput
+}
+
+structure SparseMapOfStructsInputOutput {
+    values: SparseSimpleStructMap
+}
+
+operation RecursiveStruct {
+    input: RecursiveStructInputOutput
+    output: RecursiveStructInputOutput
+}
+
+structure RecursiveStructInputOutput {
+    value: RecursiveStructShape
+}
+
+structure RecursiveStructShape {
+    stringMember: String
+    recursiveMember: RecursiveStructShape
+    recursiveList: RecursiveStructList
+    recursiveMap: RecursiveStructMap
+}
+
+list RecursiveStructList {
+    member: RecursiveStructShape
+}
+
+map RecursiveStructMap {
+    key: String
+    value: RecursiveStructShape
+}
+
+operation RecursiveUnion {
+    input: RecursiveUnionInputOutput
+    output: RecursiveUnionInputOutput
+}
+
+structure RecursiveUnionInputOutput {
+    value: RecursiveUnionShape
+}
+
+union RecursiveUnionShape {
+    stringValue: String
+    recursiveValue: RecursiveUnionShape
+    structValue: RecursiveUnionStruct
+}
+
+structure RecursiveUnionStruct {
+    value: RecursiveUnionShape
+}
+
+operation EmptyInputOutput {
+    input: EmptyInputOutputInput
+    output: EmptyInputOutputOutput
+}
+
+structure EmptyInputOutputInput {}
+
+structure EmptyInputOutputOutput {}
+
+operation NoInputOutput {}
+
+operation ErrorOperation {
+    input: ErrorOperationInput
+    output: ErrorOperationOutput
+    errors: [
+        SimpleError
+        ComplexError
+    ]
+}
+
+structure ErrorOperationInput {}
+
+structure ErrorOperationOutput {}
+
+@error("client")
+structure SimpleError {
+    message: String
+}
+
+@error("server")
+structure ComplexError {
+    message: String
+    code: Integer
+    nested: ComplexNestedError
+}
+
+structure ComplexNestedError {
+    stringMember: String
+    integerMember: Integer
+}
+
+structure SimpleStruct {
+    stringMember: String
+    integerMember: Integer
+    booleanMember: Boolean
+}
+
+list BooleanList {
+    member: Boolean
+}
+
+list ByteList {
+    member: Byte
+}
+
+list ShortList {
+    member: Short
+}
+
+list IntegerList {
+    member: Integer
+}
+
+list LongList {
+    member: Long
+}
+
+list FloatList {
+    member: Float
+}
+
+list DoubleList {
+    member: Double
+}
+
+list BigIntegerList {
+    member: BigInteger
+}
+
+list BigDecimalList {
+    member: BigDecimal
+}
+
+list StringList {
+    member: String
+}
+
+list BlobList {
+    member: Blob
+}
+
+list TimestampList {
+    member: NoFormatTimestamp
+}
+
+list DateTimeTimestampList {
+    member: DateTimeTimestamp
+}
+
+list HttpDateTimestampList {
+    member: HttpDateTimestamp
+}
+
+timestamp NoFormatTimestamp
+
+@timestampFormat("date-time")
+timestamp DateTimeTimestamp
+
+@timestampFormat("epoch-seconds")
+timestamp EpochSecondsTimestamp
+
+@timestampFormat("http-date")
+timestamp HttpDateTimestamp
+
+list CorpusStringEnumList {
+    member: CorpusStringEnum
+}
+
+list CorpusIntEnumList {
+    member: CorpusIntEnum
+}
+
+list SimpleStructList {
+    member: SimpleStruct
+}
+
+list ListOfBooleanList {
+    member: BooleanList
+}
+
+list ListOfIntegerList {
+    member: IntegerList
+}
+
+list ListOfStringList {
+    member: StringList
+}
+
+list ListOfBlobList {
+    member: BlobList
+}
+
+list ListOfTimestampList {
+    member: TimestampList
+}
+
+list ListOfCorpusStringEnumList {
+    member: CorpusStringEnumList
+}
+
+list ListOfCorpusIntEnumList {
+    member: CorpusIntEnumList
+}
+
+list ListOfBooleanMap {
+    member: BooleanMap
+}
+
+list ListOfIntegerMap {
+    member: IntegerMap
+}
+
+list ListOfStringMap {
+    member: StringMap
+}
+
+list ListOfBlobMap {
+    member: BlobMap
+}
+
+list ListOfTimestampMap {
+    member: TimestampMap
+}
+
+list ListOfCorpusStringEnumMap {
+    member: CorpusStringEnumMap
+}
+
+list ListOfCorpusIntEnumMap {
+    member: CorpusIntEnumMap
+}
+
+list CorpusUnionList {
+    member: CorpusUnion
+}
+
+@sparse
+list SparseBooleanList {
+    member: Boolean
+}
+
+@sparse
+list SparseByteList {
+    member: Byte
+}
+
+@sparse
+list SparseShortList {
+    member: Short
+}
+
+@sparse
+list SparseIntegerList {
+    member: Integer
+}
+
+@sparse
+list SparseLongList {
+    member: Long
+}
+
+@sparse
+list SparseFloatList {
+    member: Float
+}
+
+@sparse
+list SparseDoubleList {
+    member: Double
+}
+
+@sparse
+list SparseBigIntegerList {
+    member: BigInteger
+}
+
+@sparse
+list SparseBigDecimalList {
+    member: BigDecimal
+}
+
+@sparse
+list SparseStringList {
+    member: String
+}
+
+@sparse
+list SparseBlobList {
+    member: Blob
+}
+
+@sparse
+list SparseTimestampList {
+    member: NoFormatTimestamp
+}
+
+@sparse
+list SparseCorpusStringEnumList {
+    member: CorpusStringEnum
+}
+
+@sparse
+list SparseCorpusIntEnumList {
+    member: CorpusIntEnum
+}
+
+@sparse
+list SparseSimpleStructList {
+    member: SimpleStruct
+}
+
+map BooleanMap {
+    key: String
+    value: Boolean
+}
+
+map ByteMap {
+    key: String
+    value: Byte
+}
+
+map ShortMap {
+    key: String
+    value: Short
+}
+
+map IntegerMap {
+    key: String
+    value: Integer
+}
+
+map LongMap {
+    key: String
+    value: Long
+}
+
+map FloatMap {
+    key: String
+    value: Float
+}
+
+map DoubleMap {
+    key: String
+    value: Double
+}
+
+map BigIntegerMap {
+    key: String
+    value: BigInteger
+}
+
+map BigDecimalMap {
+    key: String
+    value: BigDecimal
+}
+
+map StringMap {
+    key: String
+    value: String
+}
+
+map BlobMap {
+    key: String
+    value: Blob
+}
+
+map TimestampMap {
+    key: String
+    value: NoFormatTimestamp
+}
+
+map CorpusStringEnumMap {
+    key: String
+    value: CorpusStringEnum
+}
+
+map CorpusIntEnumMap {
+    key: String
+    value: CorpusIntEnum
+}
+
+map SimpleStructMap {
+    key: String
+    value: SimpleStruct
+}
+
+map MapOfBooleanList {
+    key: String
+    value: BooleanList
+}
+
+map MapOfIntegerList {
+    key: String
+    value: IntegerList
+}
+
+map MapOfStringList {
+    key: String
+    value: StringList
+}
+
+map MapOfBlobList {
+    key: String
+    value: BlobList
+}
+
+map MapOfTimestampList {
+    key: String
+    value: TimestampList
+}
+
+map MapOfCorpusStringEnumList {
+    key: String
+    value: CorpusStringEnumList
+}
+
+map MapOfCorpusIntEnumList {
+    key: String
+    value: CorpusIntEnumList
+}
+
+map MapOfBooleanMap {
+    key: String
+    value: BooleanMap
+}
+
+map MapOfIntegerMap {
+    key: String
+    value: IntegerMap
+}
+
+map MapOfStringMap {
+    key: String
+    value: StringMap
+}
+
+map MapOfBlobMap {
+    key: String
+    value: BlobMap
+}
+
+map MapOfTimestampMap {
+    key: String
+    value: TimestampMap
+}
+
+map MapOfCorpusStringEnumMap {
+    key: String
+    value: CorpusStringEnumMap
+}
+
+map MapOfCorpusIntEnumMap {
+    key: String
+    value: CorpusIntEnumMap
+}
+
+map CorpusUnionMap {
+    key: String
+    value: CorpusUnion
+}
+
+@sparse
+map SparseBooleanMap {
+    key: String
+    value: Boolean
+}
+
+@sparse
+map SparseByteMap {
+    key: String
+    value: Byte
+}
+
+@sparse
+map SparseShortMap {
+    key: String
+    value: Short
+}
+
+@sparse
+map SparseIntegerMap {
+    key: String
+    value: Integer
+}
+
+@sparse
+map SparseLongMap {
+    key: String
+    value: Long
+}
+
+@sparse
+map SparseFloatMap {
+    key: String
+    value: Float
+}
+
+@sparse
+map SparseDoubleMap {
+    key: String
+    value: Double
+}
+
+@sparse
+map SparseBigIntegerMap {
+    key: String
+    value: BigInteger
+}
+
+@sparse
+map SparseBigDecimalMap {
+    key: String
+    value: BigDecimal
+}
+
+@sparse
+map SparseStringMap {
+    key: String
+    value: String
+}
+
+@sparse
+map SparseBlobMap {
+    key: String
+    value: Blob
+}
+
+@sparse
+map SparseTimestampMap {
+    key: String
+    value: NoFormatTimestamp
+}
+
+@sparse
+map SparseCorpusStringEnumMap {
+    key: String
+    value: CorpusStringEnum
+}
+
+@sparse
+map SparseCorpusIntEnumMap {
+    key: String
+    value: CorpusIntEnum
+}
+
+@sparse
+map SparseSimpleStructMap {
+    key: String
+    value: SimpleStruct
+}
+
+enum CorpusStringEnum {
+    FOO = "Foo"
+    BAR = "Bar"
+    BAZ = "Baz"
+}
+
+intEnum CorpusIntEnum {
+    ONE = 1
+    TWO = 2
+    THREE = 3
+}

--- a/smithy-protocol-tests/model/v2/document.smithy
+++ b/smithy-protocol-tests/model/v2/document.smithy
@@ -1,0 +1,88 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.corpus
+
+// DocumentProtocolTestService tests document scalars.
+@mixin
+service DocumentProtocolTestService {
+    operations: [
+        DocumentMembers
+        ListOfDocuments
+        MapOfDocuments
+        DocumentUnion
+    ]
+}
+
+operation DocumentMembers {
+    input: DocumentMembersInput
+    output: DocumentMembersOutput
+}
+
+structure DocumentMembersInput {
+    documentValue: Document
+    nestedStruct: DocumentStruct
+}
+
+structure DocumentMembersOutput {
+    documentValue: Document
+    nestedStruct: DocumentStruct
+}
+
+structure DocumentStruct {
+    documentMember: Document
+    stringMember: String
+}
+
+operation ListOfDocuments {
+    input: ListOfDocumentsInput
+    output: ListOfDocumentsOutput
+}
+
+structure ListOfDocumentsInput {
+    values: DocumentList
+}
+
+structure ListOfDocumentsOutput {
+    values: DocumentList
+}
+
+list DocumentList {
+    member: Document
+}
+
+operation MapOfDocuments {
+    input: MapOfDocumentsInput
+    output: MapOfDocumentsOutput
+}
+
+structure MapOfDocumentsInput {
+    values: DocumentMap
+}
+
+structure MapOfDocumentsOutput {
+    values: DocumentMap
+}
+
+map DocumentMap {
+    key: String
+    value: Document
+}
+
+operation DocumentUnion {
+    input: DocumentUnionInput
+    output: DocumentUnionOutput
+}
+
+structure DocumentUnionInput {
+    value: DocumentUnionShape
+}
+
+structure DocumentUnionOutput {
+    value: DocumentUnionShape
+}
+
+union DocumentUnionShape {
+    documentValue: Document
+    stringValue: String
+    integerValue: Integer
+}

--- a/smithy-protocol-tests/model/v2/event-stream.smithy
+++ b/smithy-protocol-tests/model/v2/event-stream.smithy
@@ -1,0 +1,292 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.corpus
+
+// EventStreamProtocolTestService covers event stream framing.
+//
+// Its operations and shape combinations are largely meant to mimic that of
+// CoreProtocolTestService.
+@mixin
+service EventStreamProtocolTestService {
+    operations: [
+        EventStreamResponse
+        EventStreamResponseBlobPayload
+        EventStreamResponseHeaders
+        EventStreamResponseImplicitPayload
+        EventStreamError
+        EventStreamRequest
+        EventStreamInitialRequest
+        EventStreamInitialResponse
+        EventStreamDuplex
+    ]
+}
+
+operation EventStreamResponse {
+    input: EventStreamResponseInput
+    output: EventStreamResponseOutput
+}
+
+structure EventStreamResponseInput {}
+
+structure EventStreamResponseOutput {
+    @httpPayload
+    @required
+    events: ResponseEventStream
+}
+
+@streaming
+union ResponseEventStream {
+    scalarsEvent: ScalarsEvent
+    listEvent: ListEvent
+    mapEvent: MapEvent
+    structEvent: StructEvent
+    unionEvent: UnionEvent
+    heartbeatEvent: HeartbeatEvent
+}
+
+structure ScalarsEvent {
+    booleanMember: Boolean
+    byteMember: Byte
+    shortMember: Short
+    integerMember: Integer
+    longMember: Long
+    floatMember: Float
+    doubleMember: Double
+    bigIntegerMember: BigInteger
+    bigDecimalMember: BigDecimal
+    stringMember: String
+    blobMember: Blob
+    timestampMember: NoFormatTimestamp
+    stringEnum: CorpusStringEnum
+    intEnum: CorpusIntEnum
+}
+
+structure ListEvent {
+    strings: StringList
+    integers: IntegerList
+    timestamps: TimestampList
+}
+
+structure MapEvent {
+    strings: StringMap
+    integers: IntegerMap
+    timestamps: TimestampMap
+}
+
+structure StructEvent {
+    value: SimpleStruct
+}
+
+structure UnionEvent {
+    value: CorpusUnion
+}
+
+structure MessageEvent {
+    content: String
+    sequence: Integer
+}
+
+structure HeartbeatEvent {}
+
+operation EventStreamResponseBlobPayload {
+    input: EventStreamResponseBlobPayloadInput
+    output: EventStreamResponseBlobPayloadOutput
+}
+
+structure EventStreamResponseBlobPayloadInput {}
+
+structure EventStreamResponseBlobPayloadOutput {
+    @httpPayload
+    @required
+    events: BlobPayloadEventStream
+}
+
+@streaming
+union BlobPayloadEventStream {
+    blobEvent: BlobPayloadEvent
+}
+
+structure BlobPayloadEvent {
+    @eventHeader
+    contentType: String
+
+    @eventPayload
+    data: Blob
+}
+
+operation EventStreamResponseHeaders {
+    input: EventStreamResponseHeadersInput
+    output: EventStreamResponseHeadersOutput
+}
+
+structure EventStreamResponseHeadersInput {}
+
+structure EventStreamResponseHeadersOutput {
+    @httpPayload
+    @required
+    events: HeaderEventStream
+}
+
+@streaming
+union HeaderEventStream {
+    headerEvent: HeaderEvent
+}
+
+structure HeaderEvent {
+    @eventHeader
+    stringHeader: String
+
+    @eventHeader
+    integerHeader: Integer
+
+    @eventHeader
+    booleanHeader: Boolean
+
+    @eventHeader
+    longHeader: Long
+
+    @eventHeader
+    timestampHeader: NoFormatTimestamp
+
+    @eventHeader
+    blobHeader: Blob
+
+    @eventPayload
+    body: String
+}
+
+operation EventStreamResponseImplicitPayload {
+    input: EventStreamResponseImplicitPayloadInput
+    output: EventStreamResponseImplicitPayloadOutput
+}
+
+structure EventStreamResponseImplicitPayloadInput {}
+
+structure EventStreamResponseImplicitPayloadOutput {
+    @httpPayload
+    @required
+    events: ImplicitPayloadEventStream
+}
+
+@streaming
+union ImplicitPayloadEventStream {
+    dataEvent: ImplicitPayloadEvent
+}
+
+structure ImplicitPayloadEvent {
+    @eventHeader
+    requestId: String
+
+    content: String
+
+    count: Integer
+
+    nested: SimpleStruct
+}
+
+operation EventStreamError {
+    input: EventStreamErrorInput
+    output: EventStreamErrorOutput
+}
+
+structure EventStreamErrorInput {}
+
+structure EventStreamErrorOutput {
+    @httpPayload
+    @required
+    events: ErrorEventStream
+}
+
+@streaming
+union ErrorEventStream {
+    messageEvent: MessageEvent
+    streamError: StreamError
+}
+
+@error("server")
+structure StreamError {
+    message: String
+    code: Integer
+}
+
+operation EventStreamRequest {
+    input: EventStreamRequestInput
+    output: EventStreamRequestOutput
+}
+
+structure EventStreamRequestInput {
+    @httpPayload
+    @required
+    events: RequestEventStream
+}
+
+structure EventStreamRequestOutput {}
+
+@streaming
+union RequestEventStream {
+    sendMessage: SendMessageEvent
+    endStream: EndStreamEvent
+}
+
+structure SendMessageEvent {
+    content: String
+}
+
+structure EndStreamEvent {}
+
+operation EventStreamInitialResponse {
+    input: EventStreamInitialResponseInput
+    output: EventStreamInitialResponseOutput
+}
+
+structure EventStreamInitialResponseInput {}
+
+structure EventStreamInitialResponseOutput {
+    @httpHeader("X-Session-Id")
+    sessionId: String
+
+    @httpHeader("X-Timeout")
+    timeout: Integer
+
+    @httpPayload
+    events: ResponseEventStream
+}
+
+operation EventStreamInitialRequest {
+    input: EventStreamInitialRequestInput
+    output: EventStreamInitialRequestOutput
+}
+
+structure EventStreamInitialRequestInput {
+    @httpHeader("X-Request-Id")
+    requestId: String
+
+    @httpHeader("X-Priority")
+    priority: Integer
+
+    @httpPayload
+    events: RequestEventStream
+}
+
+structure EventStreamInitialRequestOutput {}
+
+operation EventStreamDuplex {
+    input: EventStreamDuplexInput
+    output: EventStreamDuplexOutput
+}
+
+structure EventStreamDuplexInput {
+    @httpHeader("X-Request-Id")
+    requestId: String
+
+    @httpPayload
+    events: RequestEventStream
+}
+
+structure EventStreamDuplexOutput {
+    @httpHeader("X-Session-Id")
+    sessionId: String
+
+    @httpPayload
+    events: ResponseEventStream
+}

--- a/smithy-protocol-tests/model/v2/http-error.smithy
+++ b/smithy-protocol-tests/model/v2/http-error.smithy
@@ -1,0 +1,48 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.corpus
+
+// HttpErrorProtocolTestServices exercises @httpError, which overrides the
+// status code that @error("client"|"server") would otherwise imply, in its own
+// layer because some protocol families support @httpError without supporting
+// the HTTP binding traits.
+@mixin
+service HttpErrorProtocolTestService {
+    operations: [
+        HttpErrorOperation
+    ]
+}
+
+operation HttpErrorOperation {
+    input: HttpErrorOperationInput
+    output: HttpErrorOperationOutput
+    errors: [
+        HttpErrorConflict
+        HttpErrorGone
+        HttpErrorServiceUnavailable
+    ]
+}
+
+structure HttpErrorOperationInput {}
+
+structure HttpErrorOperationOutput {}
+
+@error("client")
+@httpError(409)
+structure HttpErrorConflict {
+    message: String
+}
+
+@error("client")
+@httpError(410)
+structure HttpErrorGone {
+    message: String
+    details: String
+}
+
+@error("server")
+@httpError(503)
+structure HttpErrorServiceUnavailable {
+    message: String
+    retryAfterSeconds: Integer
+}

--- a/smithy-protocol-tests/model/v2/misc-serde-traits.smithy
+++ b/smithy-protocol-tests/model/v2/misc-serde-traits.smithy
@@ -1,0 +1,79 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.corpus
+
+// MiscSerdeTraitProtocolTestService tests serialization traits that affect the
+// request or response envelope rather than the shape of the body, and that
+// every protocol supports.
+@mixin
+service MiscSerdeTraitProtocolTestService {
+    operations: [
+        EndpointHostPrefix
+        EndpointHostLabel
+        IdempotencyTokenOp
+        RequestCompressionOp
+        MediaTypeOp
+    ]
+}
+
+@endpoint(hostPrefix: "data.")
+operation EndpointHostPrefix {
+    input: EndpointHostPrefixInput
+    output: EndpointHostPrefixOutput
+}
+
+structure EndpointHostPrefixInput {}
+
+structure EndpointHostPrefixOutput {}
+
+@endpoint(hostPrefix: "data.{label}.")
+operation EndpointHostLabel {
+    input: EndpointHostLabelInput
+    output: EndpointHostLabelOutput
+}
+
+structure EndpointHostLabelInput {
+    @required
+    @hostLabel
+    label: String
+}
+
+structure EndpointHostLabelOutput {}
+
+operation IdempotencyTokenOp {
+    input: IdempotencyTokenOpInput
+    output: IdempotencyTokenOpOutput
+}
+
+structure IdempotencyTokenOpInput {
+    @idempotencyToken
+    token: String
+}
+
+structure IdempotencyTokenOpOutput {}
+
+@requestCompression(
+    encodings: ["gzip"]
+)
+operation RequestCompressionOp {
+    input: RequestCompressionOpInput
+    output: RequestCompressionOpOutput
+}
+
+structure RequestCompressionOpInput {
+    data: String
+}
+
+structure RequestCompressionOpOutput {}
+
+operation MediaTypeOp {
+    input: MediaTypeOpInputOutput
+    output: MediaTypeOpInputOutput
+}
+
+structure MediaTypeOpInputOutput {
+    mediaTypeMember: MediaTypeJsonString
+}
+
+@mediaType("application/json")
+string MediaTypeJsonString

--- a/smithy-protocol-tests/model/v2/naming.smithy
+++ b/smithy-protocol-tests/model/v2/naming.smithy
@@ -1,0 +1,230 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.corpus
+
+// NamingProtocolTestService tests wire-name override traits.
+//
+// Every member here carries every naming trait, so a protocol either honors
+// the one that belongs to it (restJson1 -> @jsonName, restXml -> @xmlName) or
+// ignores all of them (awsJson, rpcv2Cbor, rpcv2Json). Each protocol writes
+// cases for whichever behavior applies to it.
+//
+// The operations are a subset of the Core transition matrix, enough to reach a
+// name in every position it can appear.
+@mixin
+service NamingProtocolTestService {
+    operations: [
+        NamedScalarMembers
+        NamedStructOfScalars
+        NamedListOfScalars
+        NamedMapOfScalars
+        NamedUnionMembers
+    ]
+}
+
+operation NamedScalarMembers {
+    input: NamedScalarStruct
+    output: NamedScalarStruct
+}
+
+structure NamedScalarStruct {
+    @jsonName("jsonBooleanMember")
+    @xmlName("xmlBooleanMember")
+    booleanMember: Boolean
+
+    @jsonName("jsonByteMember")
+    @xmlName("xmlByteMember")
+    byteMember: Byte
+
+    @jsonName("jsonShortMember")
+    @xmlName("xmlShortMember")
+    shortMember: Short
+
+    @jsonName("jsonIntegerMember")
+    @xmlName("xmlIntegerMember")
+    integerMember: Integer
+
+    @jsonName("jsonLongMember")
+    @xmlName("xmlLongMember")
+    longMember: Long
+
+    @jsonName("jsonFloatMember")
+    @xmlName("xmlFloatMember")
+    floatMember: Float
+
+    @jsonName("jsonDoubleMember")
+    @xmlName("xmlDoubleMember")
+    doubleMember: Double
+
+    @jsonName("jsonBigIntegerMember")
+    @xmlName("xmlBigIntegerMember")
+    bigIntegerMember: BigInteger
+
+    @jsonName("jsonBigDecimalMember")
+    @xmlName("xmlBigDecimalMember")
+    bigDecimalMember: BigDecimal
+
+    @jsonName("jsonStringMember")
+    @xmlName("xmlStringMember")
+    stringMember: String
+
+    @jsonName("jsonBlobMember")
+    @xmlName("xmlBlobMember")
+    blobMember: Blob
+
+    @jsonName("jsonTimestampMember")
+    @xmlName("xmlTimestampMember")
+    timestampMember: NoFormatTimestamp
+
+    @jsonName("jsonEnumMember")
+    @xmlName("xmlEnumMember")
+    enumMember: CorpusStringEnum
+
+    @jsonName("jsonIntEnumMember")
+    @xmlName("xmlIntEnumMember")
+    intEnumMember: CorpusIntEnum
+}
+
+operation NamedStructOfScalars {
+    input: NamedStructOfScalarsInput
+    output: NamedStructOfScalarsOutput
+}
+
+structure NamedStructOfScalarsInput {
+    @jsonName("jsonNested")
+    @xmlName("xmlNested")
+    nested: NamedSimpleStruct
+}
+
+structure NamedStructOfScalarsOutput {
+    @jsonName("jsonNested")
+    @xmlName("xmlNested")
+    nested: NamedSimpleStruct
+}
+
+structure NamedSimpleStruct {
+    @jsonName("jsonStringMember")
+    @xmlName("xmlStringMember")
+    stringMember: String
+
+    @jsonName("jsonIntegerMember")
+    @xmlName("xmlIntegerMember")
+    integerMember: Integer
+
+    @jsonName("jsonBooleanMember")
+    @xmlName("xmlBooleanMember")
+    booleanMember: Boolean
+
+    @jsonName("jsonTimestampMember")
+    @xmlName("xmlTimestampMember")
+    timestampMember: NoFormatTimestamp
+}
+
+operation NamedListOfScalars {
+    input: NamedListOfScalarsInput
+    output: NamedListOfScalarsOutput
+}
+
+structure NamedListOfScalarsInput {
+    @jsonName("jsonStrings")
+    @xmlName("xmlStrings")
+    strings: StringList
+
+    @jsonName("jsonIntegers")
+    @xmlName("xmlIntegers")
+    integers: IntegerList
+
+    @jsonName("jsonTimestamps")
+    @xmlName("xmlTimestamps")
+    timestamps: TimestampList
+}
+
+structure NamedListOfScalarsOutput {
+    @jsonName("jsonStrings")
+    @xmlName("xmlStrings")
+    strings: StringList
+
+    @jsonName("jsonIntegers")
+    @xmlName("xmlIntegers")
+    integers: IntegerList
+
+    @jsonName("jsonTimestamps")
+    @xmlName("xmlTimestamps")
+    timestamps: TimestampList
+}
+
+operation NamedMapOfScalars {
+    input: NamedMapOfScalarsInput
+    output: NamedMapOfScalarsOutput
+}
+
+structure NamedMapOfScalarsInput {
+    @jsonName("jsonStrings")
+    @xmlName("xmlStrings")
+    strings: StringMap
+
+    @jsonName("jsonIntegers")
+    @xmlName("xmlIntegers")
+    integers: IntegerMap
+
+    @jsonName("jsonTimestamps")
+    @xmlName("xmlTimestamps")
+    timestamps: TimestampMap
+}
+
+structure NamedMapOfScalarsOutput {
+    @jsonName("jsonStrings")
+    @xmlName("xmlStrings")
+    strings: StringMap
+
+    @jsonName("jsonIntegers")
+    @xmlName("xmlIntegers")
+    integers: IntegerMap
+
+    @jsonName("jsonTimestamps")
+    @xmlName("xmlTimestamps")
+    timestamps: TimestampMap
+}
+
+operation NamedUnionMembers {
+    input: NamedUnionMembersInput
+    output: NamedUnionMembersOutput
+}
+
+structure NamedUnionMembersInput {
+    @jsonName("jsonValue")
+    @xmlName("xmlValue")
+    value: NamedUnion
+}
+
+structure NamedUnionMembersOutput {
+    @jsonName("jsonValue")
+    @xmlName("xmlValue")
+    value: NamedUnion
+}
+
+union NamedUnion {
+    @jsonName("jsonStringMember")
+    @xmlName("xmlStringMember")
+    stringMember: String
+
+    @jsonName("jsonIntegerMember")
+    @xmlName("xmlIntegerMember")
+    integerMember: Integer
+
+    @jsonName("jsonBooleanMember")
+    @xmlName("xmlBooleanMember")
+    booleanMember: Boolean
+
+    @jsonName("jsonListMember")
+    @xmlName("xmlListMember")
+    listMember: StringList
+
+    @jsonName("jsonMapMember")
+    @xmlName("xmlMapMember")
+    mapMember: StringMap
+
+    @jsonName("jsonStructMember")
+    @xmlName("xmlStructMember")
+    structMember: NamedSimpleStruct
+}

--- a/smithy-protocol-tests/model/v2/optionality.smithy
+++ b/smithy-protocol-tests/model/v2/optionality.smithy
@@ -1,0 +1,188 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.corpus
+
+// OptionalityProtocolTestService tests @required, @default, and
+// @clientOptional semantics.
+@mixin
+service OptionalityProtocolTestService {
+    operations: [
+        DefaultScalars
+        DefaultCollections
+        NestedDefaults
+        RequiredMembers
+        NullSparseMembers
+        ClientOptionalDefaults
+    ]
+}
+
+operation DefaultScalars {
+    input: DefaultScalarsInput
+    output: DefaultScalarsOutput
+}
+
+structure DefaultScalarsInput with [DefaultScalarsMixin] {}
+
+structure DefaultScalarsOutput with [DefaultScalarsMixin] {}
+
+@mixin
+structure DefaultScalarsMixin {
+    defaultBoolean: Boolean = false
+    defaultByte: Byte = 0
+    defaultShort: Short = 0
+    defaultInteger: Integer = 0
+    defaultLong: Long = 0
+    defaultFloat: Float = 0
+    defaultDouble: Double = 0
+    defaultString: String = ""
+    defaultBlob: Blob = ""
+    defaultEnum: CorpusStringEnum = "Foo"
+    defaultIntEnum: CorpusIntEnum = 1
+    zeroBoolean: Boolean = false
+    zeroByte: Byte = 0
+    zeroShort: Short = 0
+    zeroInteger: Integer = 0
+    zeroLong: Long = 0
+    zeroFloat: Float = 0
+    zeroDouble: Double = 0
+    emptyString: String = ""
+    emptyBlob: Blob = ""
+}
+
+operation DefaultCollections {
+    input: DefaultCollectionsInput
+    output: DefaultCollectionsOutput
+}
+
+structure DefaultCollectionsInput with [DefaultCollectionsMixin] {}
+
+structure DefaultCollectionsOutput with [DefaultCollectionsMixin] {}
+
+@mixin
+structure DefaultCollectionsMixin {
+    defaultList: StringList = []
+    defaultMap: StringMap = {}
+}
+
+operation NestedDefaults {
+    input: NestedDefaultsInput
+    output: NestedDefaultsOutput
+}
+
+structure NestedDefaultsInput {
+    topLevel: TopLevelWithDefaults
+}
+
+structure NestedDefaultsOutput {
+    topLevel: TopLevelWithDefaults
+}
+
+structure TopLevelWithDefaults {
+    @required
+    nested: NestedWithDefaults
+
+    nestedList: NestedWithDefaultsList
+
+    nestedMap: NestedWithDefaultsMap
+}
+
+structure NestedWithDefaults {
+    greeting: String = "hello"
+    count: Integer = 0
+    inner: InnerWithDefaults
+}
+
+structure InnerWithDefaults {
+    farewell: String = "goodbye"
+}
+
+list NestedWithDefaultsList {
+    member: NestedWithDefaults
+}
+
+map NestedWithDefaultsMap {
+    key: String
+    value: NestedWithDefaults
+}
+
+operation RequiredMembers {
+    input: RequiredMembersInput
+    output: RequiredMembersOutput
+}
+
+structure RequiredMembersInput with [RequiredMembersMixin] {}
+
+structure RequiredMembersOutput with [RequiredMembersMixin] {}
+
+@mixin
+structure RequiredMembersMixin {
+    @required
+    requiredString: String
+
+    @required
+    requiredInteger: Integer
+
+    @required
+    requiredBoolean: Boolean
+
+    @required
+    requiredList: StringList
+
+    @required
+    requiredMap: StringMap
+
+    @required
+    requiredStringWithDefault: String = "default"
+
+    @required
+    requiredIntegerWithDefault: Integer = 0
+
+    @required
+    requiredBooleanWithDefault: Boolean = false
+
+    @required
+    requiredListWithDefault: StringList = []
+
+    @required
+    requiredMapWithDefault: StringMap = {}
+}
+
+operation NullSparseMembers {
+    input: NullSparseMembersInput
+    output: NullSparseMembersOutput
+}
+
+structure NullSparseMembersInput {
+    sparseStringList: SparseStringList
+    sparseStringMap: SparseStringMap
+    sparseStructList: SparseSimpleStructList
+    sparseStructMap: SparseSimpleStructMap
+}
+
+structure NullSparseMembersOutput {
+    sparseStringList: SparseStringList
+    sparseStringMap: SparseStringMap
+    sparseStructList: SparseSimpleStructList
+    sparseStructMap: SparseSimpleStructMap
+}
+
+operation ClientOptionalDefaults {
+    input: ClientOptionalDefaultsInput
+    output: ClientOptionalDefaultsOutput
+}
+
+structure ClientOptionalDefaultsInput with [ClientOptionalMixin] {}
+
+structure ClientOptionalDefaultsOutput with [ClientOptionalMixin] {}
+
+@mixin
+structure ClientOptionalMixin {
+    @clientOptional
+    optionalInteger: Integer = 0
+
+    @clientOptional
+    optionalString: String = ""
+
+    @clientOptional
+    optionalBoolean: Boolean = false
+}

--- a/smithy-protocol-tests/model/v2/rpcv2json/core-test.smithy
+++ b/smithy-protocol-tests/model/v2/rpcv2json/core-test.smithy
@@ -1,0 +1,3353 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.corpus
+
+use smithy.protocols#rpcv2Json
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+apply ScalarMembers @httpRequestTests([
+    {
+        id: "RpcV2JsonScalarMembersSerialize"
+        documentation: "Serializes all scalar members"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ScalarMembers"
+        body: """
+            {
+                "booleanMember": true,
+                "byteMember": 5,
+                "shortMember": 256,
+                "integerMember": 1234,
+                "longMember": 999999999999,
+                "floatMember": 1.5,
+                "doubleMember": 2.5,
+                "stringMember": "hello",
+                "blobMember": "Zm9v",
+                "dateTimeMember": 1609504496,
+                "epochSecondsMember": 1612325106,
+                "httpDateMember": 1614834367,
+                "stringEnum": "Foo",
+                "intEnum": 1
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleanMember: true
+            byteMember: 5
+            shortMember: 256
+            integerMember: 1234
+            longMember: 999999999999
+            floatMember: 1.5
+            doubleMember: 2.5
+            stringMember: "hello"
+            blobMember: "foo"
+            dateTimeMember: 1609504496
+            epochSecondsMember: 1612325106
+            httpDateMember: 1614834367
+            stringEnum: "Foo"
+            intEnum: 1
+        }
+    }
+    {
+        id: "RpcV2JsonScalarMembersSerializeZeroValues"
+        documentation: "Serializes zero/false/empty scalar values"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ScalarMembers"
+        body: """
+            {
+                "booleanMember": false,
+                "byteMember": 0,
+                "shortMember": 0,
+                "integerMember": 0,
+                "longMember": 0,
+                "floatMember": 0,
+                "doubleMember": 0,
+                "stringMember": ""
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleanMember: false
+            byteMember: 0
+            shortMember: 0
+            integerMember: 0
+            longMember: 0
+            floatMember: 0
+            doubleMember: 0
+            stringMember: ""
+        }
+    }
+    {
+        id: "RpcV2JsonScalarMembersNaN"
+        tags: ["non-finite-floats"]
+        documentation: "Serializes NaN float values"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ScalarMembers"
+        body: """
+            {
+                "floatMember": "NaN",
+                "doubleMember": "NaN"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: { floatMember: "NaN", doubleMember: "NaN" }
+    }
+    {
+        id: "RpcV2JsonScalarMembersInfinity"
+        tags: ["non-finite-floats"]
+        documentation: "Serializes Infinity float values"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ScalarMembers"
+        body: """
+            {
+                "floatMember": "Infinity",
+                "doubleMember": "Infinity"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: { floatMember: "Infinity", doubleMember: "Infinity" }
+    }
+    {
+        id: "RpcV2JsonScalarMembersNegativeInfinity"
+        tags: ["non-finite-floats"]
+        documentation: "Serializes -Infinity float values"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ScalarMembers"
+        body: """
+            {
+                "floatMember": "-Infinity",
+                "doubleMember": "-Infinity"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: { floatMember: "-Infinity", doubleMember: "-Infinity" }
+    }
+    {
+        id: "RpcV2JsonScalarMembersOmitsNullValues"
+        tags: ["null-on-wire"]
+        documentation: "Non-sparse struct members that are null are omitted"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ScalarMembers"
+        body: """
+            {
+                "stringMember": "only this"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: { stringMember: "only this" }
+    }
+])
+
+apply ScalarMembers @httpResponseTests([
+    {
+        id: "RpcV2JsonScalarMembersDeserialize"
+        documentation: "Deserializes all scalar members"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleanMember": true,
+                "byteMember": 5,
+                "shortMember": 256,
+                "integerMember": 1234,
+                "longMember": 999999999999,
+                "floatMember": 1.5,
+                "doubleMember": 2.5,
+                "stringMember": "hello",
+                "blobMember": "Zm9v",
+                "dateTimeMember": 1609504496,
+                "epochSecondsMember": 1612325106,
+                "httpDateMember": 1614834367,
+                "stringEnum": "Foo",
+                "intEnum": 1
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleanMember: true
+            byteMember: 5
+            shortMember: 256
+            integerMember: 1234
+            longMember: 999999999999
+            floatMember: 1.5
+            doubleMember: 2.5
+            stringMember: "hello"
+            blobMember: "foo"
+            dateTimeMember: 1609504496
+            epochSecondsMember: 1612325106
+            httpDateMember: 1614834367
+            stringEnum: "Foo"
+            intEnum: 1
+        }
+    }
+    {
+        id: "RpcV2JsonScalarMembersDeserializeNaN"
+        tags: ["non-finite-floats"]
+        documentation: "Deserializes NaN float values"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "floatMember": "NaN",
+                "doubleMember": "NaN"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { floatMember: "NaN", doubleMember: "NaN" }
+    }
+    {
+        id: "RpcV2JsonScalarMembersDeserializeZeroValues"
+        documentation: "Deserializes zero/false/empty scalar values"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleanMember": false,
+                "byteMember": 0,
+                "shortMember": 0,
+                "integerMember": 0,
+                "longMember": 0,
+                "floatMember": 0,
+                "doubleMember": 0,
+                "stringMember": ""
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleanMember: false
+            byteMember: 0
+            shortMember: 0
+            integerMember: 0
+            longMember: 0
+            floatMember: 0
+            doubleMember: 0
+            stringMember: ""
+        }
+    }
+    {
+        id: "RpcV2JsonScalarMembersDeserializeInfinity"
+        tags: ["non-finite-floats"]
+        documentation: "Deserializes Infinity float values"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "floatMember": "Infinity",
+                "doubleMember": "Infinity"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { floatMember: "Infinity", doubleMember: "Infinity" }
+    }
+    {
+        id: "RpcV2JsonScalarMembersDeserializeNegativeInfinity"
+        tags: ["non-finite-floats"]
+        documentation: "Deserializes -Infinity float values"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "floatMember": "-Infinity",
+                "doubleMember": "-Infinity"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { floatMember: "-Infinity", doubleMember: "-Infinity" }
+    }
+    {
+        id: "RpcV2JsonScalarMembersDeserializeIgnoresNullValues"
+        tags: ["null-on-wire"]
+        documentation: "Client drops a wire null for a dense struct member"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "stringMember": "only this",
+                "integerMember": null,
+                "booleanMember": null
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        appliesTo: "client"
+        params: { stringMember: "only this" }
+    }
+    {
+        id: "RpcV2JsonScalarMembersDeserializeIgnoresUnknownFields"
+        tags: ["unknown-fields"]
+        documentation: "Client ignores unrecognized fields in the response"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "stringMember": "hello",
+                "unknownField": "ignored",
+                "anotherUnknown": 42
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        appliesTo: "client"
+        params: { stringMember: "hello" }
+    }
+])
+
+apply ListOfScalars @httpRequestTests([
+    {
+        id: "RpcV2JsonListOfScalarsPopulated"
+        documentation: "Serializes all scalar list types"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ListOfScalars"
+        body: """
+            {
+                "booleans": [true, false],
+                "bytes": [5, 6],
+                "shorts": [256, 257],
+                "integers": [1, 2, 3],
+                "longs": [999999999999, 999999999998],
+                "floats": [1.5, 2.5],
+                "doubles": [3.5, 4.5],
+                "strings": ["foo", "bar"],
+                "blobs": ["Zm9v", "YmFy"],
+                "timestamps": [1609459200, 1609545600],
+                "enums": ["Foo", "Bar"],
+                "intEnums": [1, 2]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleans: [true, false]
+            bytes: [5, 6]
+            shorts: [256, 257]
+            integers: [1, 2, 3]
+            longs: [999999999999, 999999999998]
+            floats: [1.5, 2.5]
+            doubles: [3.5, 4.5]
+            strings: ["foo", "bar"]
+            blobs: ["foo", "bar"]
+            timestamps: [1609459200, 1609545600]
+            enums: ["Foo", "Bar"]
+            intEnums: [1, 2]
+        }
+    }
+    {
+        id: "RpcV2JsonListOfScalarsEmpty"
+        tags: ["empty"]
+        documentation: "Serializes empty lists"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ListOfScalars"
+        body: """
+            {
+                "booleans": [],
+                "bytes": [],
+                "shorts": [],
+                "integers": [],
+                "longs": [],
+                "floats": [],
+                "doubles": [],
+                "strings": [],
+                "blobs": [],
+                "timestamps": [],
+                "enums": [],
+                "intEnums": []
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleans: []
+            bytes: []
+            shorts: []
+            integers: []
+            longs: []
+            floats: []
+            doubles: []
+            strings: []
+            blobs: []
+            timestamps: []
+            enums: []
+            intEnums: []
+        }
+    }
+])
+
+apply ListOfScalars @httpResponseTests([
+    {
+        id: "RpcV2JsonListOfScalarsPopulatedResponse"
+        documentation: "Deserializes all scalar list types"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleans": [true, false],
+                "bytes": [5, 6],
+                "shorts": [256, 257],
+                "integers": [1, 2, 3],
+                "longs": [999999999999, 999999999998],
+                "floats": [1.5, 2.5],
+                "doubles": [3.5, 4.5],
+                "strings": ["foo", "bar"],
+                "blobs": ["Zm9v", "YmFy"],
+                "timestamps": [1609459200, 1609545600],
+                "enums": ["Foo", "Bar"],
+                "intEnums": [1, 2]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleans: [true, false]
+            bytes: [5, 6]
+            shorts: [256, 257]
+            integers: [1, 2, 3]
+            longs: [999999999999, 999999999998]
+            floats: [1.5, 2.5]
+            doubles: [3.5, 4.5]
+            strings: ["foo", "bar"]
+            blobs: ["foo", "bar"]
+            timestamps: [1609459200, 1609545600]
+            enums: ["Foo", "Bar"]
+            intEnums: [1, 2]
+        }
+    }
+    {
+        id: "RpcV2JsonListOfScalarsEmptyResponse"
+        tags: ["empty"]
+        documentation: "Deserializes empty lists"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleans": [],
+                "bytes": [],
+                "shorts": [],
+                "integers": [],
+                "longs": [],
+                "floats": [],
+                "doubles": [],
+                "strings": [],
+                "blobs": [],
+                "timestamps": [],
+                "enums": [],
+                "intEnums": []
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleans: []
+            bytes: []
+            shorts: []
+            integers: []
+            longs: []
+            floats: []
+            doubles: []
+            strings: []
+            blobs: []
+            timestamps: []
+            enums: []
+            intEnums: []
+        }
+    }
+])
+
+apply SparseListOfScalars @httpRequestTests([
+    {
+        id: "RpcV2JsonSparseListOfScalarsNullAtStart"
+        documentation: "Serializes sparse lists with a null as the first element"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/SparseListOfScalars"
+        body: """
+            {
+                "booleans": [null, true, false],
+                "bytes": [null, 5, 6],
+                "shorts": [null, 256, 257],
+                "integers": [null, 1, 2],
+                "longs": [null, 999999999999, 999999999998],
+                "floats": [null, 1.5, 2.5],
+                "doubles": [null, 3.5, 4.5],
+                "strings": [null, "foo", "bar"],
+                "blobs": [null, "Zm9v", "YmFy"],
+                "timestamps": [null, 1609459200, 1609545600],
+                "enums": [null, "Foo", "Bar"],
+                "intEnums": [null, 1, 2]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleans: [null, true, false]
+            bytes: [null, 5, 6]
+            shorts: [null, 256, 257]
+            integers: [null, 1, 2]
+            longs: [null, 999999999999, 999999999998]
+            floats: [null, 1.5, 2.5]
+            doubles: [null, 3.5, 4.5]
+            strings: [null, "foo", "bar"]
+            blobs: [null, "foo", "bar"]
+            timestamps: [null, 1609459200, 1609545600]
+            enums: [null, "Foo", "Bar"]
+            intEnums: [null, 1, 2]
+        }
+    }
+    {
+        id: "RpcV2JsonSparseListOfScalarsNullInMiddle"
+        documentation: "Serializes sparse lists with a null as the middle element"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/SparseListOfScalars"
+        body: """
+            {
+                "booleans": [true, null, false],
+                "bytes": [5, null, 6],
+                "shorts": [256, null, 257],
+                "integers": [1, null, 2],
+                "longs": [999999999999, null, 999999999998],
+                "floats": [1.5, null, 2.5],
+                "doubles": [3.5, null, 4.5],
+                "strings": ["foo", null, "bar"],
+                "blobs": ["Zm9v", null, "YmFy"],
+                "timestamps": [1609459200, null, 1609545600],
+                "enums": ["Foo", null, "Bar"],
+                "intEnums": [1, null, 2]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleans: [true, null, false]
+            bytes: [5, null, 6]
+            shorts: [256, null, 257]
+            integers: [1, null, 2]
+            longs: [999999999999, null, 999999999998]
+            floats: [1.5, null, 2.5]
+            doubles: [3.5, null, 4.5]
+            strings: ["foo", null, "bar"]
+            blobs: ["foo", null, "bar"]
+            timestamps: [1609459200, null, 1609545600]
+            enums: ["Foo", null, "Bar"]
+            intEnums: [1, null, 2]
+        }
+    }
+    {
+        id: "RpcV2JsonSparseListOfScalarsNullAtEnd"
+        documentation: "Serializes sparse lists with a null as the last element"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/SparseListOfScalars"
+        body: """
+            {
+                "booleans": [true, false, null],
+                "bytes": [5, 6, null],
+                "shorts": [256, 257, null],
+                "integers": [1, 2, null],
+                "longs": [999999999999, 999999999998, null],
+                "floats": [1.5, 2.5, null],
+                "doubles": [3.5, 4.5, null],
+                "strings": ["foo", "bar", null],
+                "blobs": ["Zm9v", "YmFy", null],
+                "timestamps": [1609459200, 1609545600, null],
+                "enums": ["Foo", "Bar", null],
+                "intEnums": [1, 2, null]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleans: [true, false, null]
+            bytes: [5, 6, null]
+            shorts: [256, 257, null]
+            integers: [1, 2, null]
+            longs: [999999999999, 999999999998, null]
+            floats: [1.5, 2.5, null]
+            doubles: [3.5, 4.5, null]
+            strings: ["foo", "bar", null]
+            blobs: ["foo", "bar", null]
+            timestamps: [1609459200, 1609545600, null]
+            enums: ["Foo", "Bar", null]
+            intEnums: [1, 2, null]
+        }
+    }
+])
+
+apply SparseListOfScalars @httpResponseTests([
+    {
+        id: "RpcV2JsonSparseListOfScalarsNullAtStartResponse"
+        documentation: "Deserializes sparse lists with a null as the first element"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleans": [null, true, false],
+                "bytes": [null, 5, 6],
+                "shorts": [null, 256, 257],
+                "integers": [null, 1, 2],
+                "longs": [null, 999999999999, 999999999998],
+                "floats": [null, 1.5, 2.5],
+                "doubles": [null, 3.5, 4.5],
+                "strings": [null, "foo", "bar"],
+                "blobs": [null, "Zm9v", "YmFy"],
+                "timestamps": [null, 1609459200, 1609545600],
+                "enums": [null, "Foo", "Bar"],
+                "intEnums": [null, 1, 2]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleans: [null, true, false]
+            bytes: [null, 5, 6]
+            shorts: [null, 256, 257]
+            integers: [null, 1, 2]
+            longs: [null, 999999999999, 999999999998]
+            floats: [null, 1.5, 2.5]
+            doubles: [null, 3.5, 4.5]
+            strings: [null, "foo", "bar"]
+            blobs: [null, "foo", "bar"]
+            timestamps: [null, 1609459200, 1609545600]
+            enums: [null, "Foo", "Bar"]
+            intEnums: [null, 1, 2]
+        }
+    }
+    {
+        id: "RpcV2JsonSparseListOfScalarsNullInMiddleResponse"
+        documentation: "Deserializes sparse lists with a null as the middle element"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleans": [true, null, false],
+                "bytes": [5, null, 6],
+                "shorts": [256, null, 257],
+                "integers": [1, null, 2],
+                "longs": [999999999999, null, 999999999998],
+                "floats": [1.5, null, 2.5],
+                "doubles": [3.5, null, 4.5],
+                "strings": ["foo", null, "bar"],
+                "blobs": ["Zm9v", null, "YmFy"],
+                "timestamps": [1609459200, null, 1609545600],
+                "enums": ["Foo", null, "Bar"],
+                "intEnums": [1, null, 2]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleans: [true, null, false]
+            bytes: [5, null, 6]
+            shorts: [256, null, 257]
+            integers: [1, null, 2]
+            longs: [999999999999, null, 999999999998]
+            floats: [1.5, null, 2.5]
+            doubles: [3.5, null, 4.5]
+            strings: ["foo", null, "bar"]
+            blobs: ["foo", null, "bar"]
+            timestamps: [1609459200, null, 1609545600]
+            enums: ["Foo", null, "Bar"]
+            intEnums: [1, null, 2]
+        }
+    }
+    {
+        id: "RpcV2JsonSparseListOfScalarsNullAtEndResponse"
+        documentation: "Deserializes sparse lists with a null as the last element"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleans": [true, false, null],
+                "bytes": [5, 6, null],
+                "shorts": [256, 257, null],
+                "integers": [1, 2, null],
+                "longs": [999999999999, 999999999998, null],
+                "floats": [1.5, 2.5, null],
+                "doubles": [3.5, 4.5, null],
+                "strings": ["foo", "bar", null],
+                "blobs": ["Zm9v", "YmFy", null],
+                "timestamps": [1609459200, 1609545600, null],
+                "enums": ["Foo", "Bar", null],
+                "intEnums": [1, 2, null]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleans: [true, false, null]
+            bytes: [5, 6, null]
+            shorts: [256, 257, null]
+            integers: [1, 2, null]
+            longs: [999999999999, 999999999998, null]
+            floats: [1.5, 2.5, null]
+            doubles: [3.5, 4.5, null]
+            strings: ["foo", "bar", null]
+            blobs: ["foo", "bar", null]
+            timestamps: [1609459200, 1609545600, null]
+            enums: ["Foo", "Bar", null]
+            intEnums: [1, 2, null]
+        }
+    }
+])
+
+apply MapOfScalars @httpRequestTests([
+    {
+        id: "RpcV2JsonMapOfScalarsPopulated"
+        documentation: "Serializes all scalar map types"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/MapOfScalars"
+        body: """
+            {
+                "booleans": {"a": true, "b": false},
+                "bytes": {"a": 5, "b": 6},
+                "shorts": {"a": 256, "b": 257},
+                "integers": {"a": 1, "b": 2},
+                "longs": {"a": 999999999999, "b": 999999999998},
+                "floats": {"a": 1.5, "b": 2.5},
+                "doubles": {"a": 3.5, "b": 4.5},
+                "strings": {"a": "foo", "b": "bar"},
+                "blobs": {"a": "Zm9v", "b": "YmFy"},
+                "timestamps": {"a": 1609459200, "b": 1609545600},
+                "enums": {"a": "Foo", "b": "Bar"},
+                "intEnums": {"a": 1, "b": 2}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleans: { a: true, b: false }
+            bytes: { a: 5, b: 6 }
+            shorts: { a: 256, b: 257 }
+            integers: { a: 1, b: 2 }
+            longs: { a: 999999999999, b: 999999999998 }
+            floats: { a: 1.5, b: 2.5 }
+            doubles: { a: 3.5, b: 4.5 }
+            strings: { a: "foo", b: "bar" }
+            blobs: { a: "foo", b: "bar" }
+            timestamps: { a: 1609459200, b: 1609545600 }
+            enums: { a: "Foo", b: "Bar" }
+            intEnums: { a: 1, b: 2 }
+        }
+    }
+    {
+        id: "RpcV2JsonMapOfScalarsEmpty"
+        tags: ["empty"]
+        documentation: "Serializes empty maps"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/MapOfScalars"
+        body: """
+            {
+                "booleans": {},
+                "bytes": {},
+                "shorts": {},
+                "integers": {},
+                "longs": {},
+                "floats": {},
+                "doubles": {},
+                "strings": {},
+                "blobs": {},
+                "timestamps": {},
+                "enums": {},
+                "intEnums": {}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleans: {}
+            bytes: {}
+            shorts: {}
+            integers: {}
+            longs: {}
+            floats: {}
+            doubles: {}
+            strings: {}
+            blobs: {}
+            timestamps: {}
+            enums: {}
+            intEnums: {}
+        }
+    }
+])
+
+apply MapOfScalars @httpResponseTests([
+    {
+        id: "RpcV2JsonMapOfScalarsPopulatedResponse"
+        documentation: "Deserializes all scalar map types"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleans": {"a": true, "b": false},
+                "bytes": {"a": 5, "b": 6},
+                "shorts": {"a": 256, "b": 257},
+                "integers": {"a": 1, "b": 2},
+                "longs": {"a": 999999999999, "b": 999999999998},
+                "floats": {"a": 1.5, "b": 2.5},
+                "doubles": {"a": 3.5, "b": 4.5},
+                "strings": {"a": "foo", "b": "bar"},
+                "blobs": {"a": "Zm9v", "b": "YmFy"},
+                "timestamps": {"a": 1609459200, "b": 1609545600},
+                "enums": {"a": "Foo", "b": "Bar"},
+                "intEnums": {"a": 1, "b": 2}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleans: { a: true, b: false }
+            bytes: { a: 5, b: 6 }
+            shorts: { a: 256, b: 257 }
+            integers: { a: 1, b: 2 }
+            longs: { a: 999999999999, b: 999999999998 }
+            floats: { a: 1.5, b: 2.5 }
+            doubles: { a: 3.5, b: 4.5 }
+            strings: { a: "foo", b: "bar" }
+            blobs: { a: "foo", b: "bar" }
+            timestamps: { a: 1609459200, b: 1609545600 }
+            enums: { a: "Foo", b: "Bar" }
+            intEnums: { a: 1, b: 2 }
+        }
+    }
+    {
+        id: "RpcV2JsonMapOfScalarsEmptyResponse"
+        tags: ["empty"]
+        documentation: "Deserializes empty maps"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleans": {},
+                "bytes": {},
+                "shorts": {},
+                "integers": {},
+                "longs": {},
+                "floats": {},
+                "doubles": {},
+                "strings": {},
+                "blobs": {},
+                "timestamps": {},
+                "enums": {},
+                "intEnums": {}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleans: {}
+            bytes: {}
+            shorts: {}
+            integers: {}
+            longs: {}
+            floats: {}
+            doubles: {}
+            strings: {}
+            blobs: {}
+            timestamps: {}
+            enums: {}
+            intEnums: {}
+        }
+    }
+])
+
+apply SparseMapOfScalars @httpRequestTests([
+    {
+        id: "RpcV2JsonSparseMapOfScalarsNullAtStart"
+        documentation: "Serializes sparse maps with a null as the first entry"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/SparseMapOfScalars"
+        body: """
+            {
+                "booleans": {"a": null, "b": true, "c": false},
+                "bytes": {"a": null, "b": 5, "c": 6},
+                "shorts": {"a": null, "b": 256, "c": 257},
+                "integers": {"a": null, "b": 1, "c": 2},
+                "longs": {"a": null, "b": 999999999999, "c": 999999999998},
+                "floats": {"a": null, "b": 1.5, "c": 2.5},
+                "doubles": {"a": null, "b": 3.5, "c": 4.5},
+                "strings": {"a": null, "b": "foo", "c": "bar"},
+                "blobs": {"a": null, "b": "Zm9v", "c": "YmFy"},
+                "timestamps": {"a": null, "b": 1609459200, "c": 1609545600},
+                "enums": {"a": null, "b": "Foo", "c": "Bar"},
+                "intEnums": {"a": null, "b": 1, "c": 2}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleans: { a: null, b: true, c: false }
+            bytes: { a: null, b: 5, c: 6 }
+            shorts: { a: null, b: 256, c: 257 }
+            integers: { a: null, b: 1, c: 2 }
+            longs: { a: null, b: 999999999999, c: 999999999998 }
+            floats: { a: null, b: 1.5, c: 2.5 }
+            doubles: { a: null, b: 3.5, c: 4.5 }
+            strings: { a: null, b: "foo", c: "bar" }
+            blobs: { a: null, b: "foo", c: "bar" }
+            timestamps: { a: null, b: 1609459200, c: 1609545600 }
+            enums: { a: null, b: "Foo", c: "Bar" }
+            intEnums: { a: null, b: 1, c: 2 }
+        }
+    }
+    {
+        id: "RpcV2JsonSparseMapOfScalarsNullInMiddle"
+        documentation: "Serializes sparse maps with a null as the middle entry"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/SparseMapOfScalars"
+        body: """
+            {
+                "booleans": {"a": true, "b": null, "c": false},
+                "bytes": {"a": 5, "b": null, "c": 6},
+                "shorts": {"a": 256, "b": null, "c": 257},
+                "integers": {"a": 1, "b": null, "c": 2},
+                "longs": {"a": 999999999999, "b": null, "c": 999999999998},
+                "floats": {"a": 1.5, "b": null, "c": 2.5},
+                "doubles": {"a": 3.5, "b": null, "c": 4.5},
+                "strings": {"a": "foo", "b": null, "c": "bar"},
+                "blobs": {"a": "Zm9v", "b": null, "c": "YmFy"},
+                "timestamps": {"a": 1609459200, "b": null, "c": 1609545600},
+                "enums": {"a": "Foo", "b": null, "c": "Bar"},
+                "intEnums": {"a": 1, "b": null, "c": 2}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleans: { a: true, b: null, c: false }
+            bytes: { a: 5, b: null, c: 6 }
+            shorts: { a: 256, b: null, c: 257 }
+            integers: { a: 1, b: null, c: 2 }
+            longs: { a: 999999999999, b: null, c: 999999999998 }
+            floats: { a: 1.5, b: null, c: 2.5 }
+            doubles: { a: 3.5, b: null, c: 4.5 }
+            strings: { a: "foo", b: null, c: "bar" }
+            blobs: { a: "foo", b: null, c: "bar" }
+            timestamps: { a: 1609459200, b: null, c: 1609545600 }
+            enums: { a: "Foo", b: null, c: "Bar" }
+            intEnums: { a: 1, b: null, c: 2 }
+        }
+    }
+    {
+        id: "RpcV2JsonSparseMapOfScalarsNullAtEnd"
+        documentation: "Serializes sparse maps with a null as the last entry"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/SparseMapOfScalars"
+        body: """
+            {
+                "booleans": {"a": true, "b": false, "c": null},
+                "bytes": {"a": 5, "b": 6, "c": null},
+                "shorts": {"a": 256, "b": 257, "c": null},
+                "integers": {"a": 1, "b": 2, "c": null},
+                "longs": {"a": 999999999999, "b": 999999999998, "c": null},
+                "floats": {"a": 1.5, "b": 2.5, "c": null},
+                "doubles": {"a": 3.5, "b": 4.5, "c": null},
+                "strings": {"a": "foo", "b": "bar", "c": null},
+                "blobs": {"a": "Zm9v", "b": "YmFy", "c": null},
+                "timestamps": {"a": 1609459200, "b": 1609545600, "c": null},
+                "enums": {"a": "Foo", "b": "Bar", "c": null},
+                "intEnums": {"a": 1, "b": 2, "c": null}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleans: { a: true, b: false, c: null }
+            bytes: { a: 5, b: 6, c: null }
+            shorts: { a: 256, b: 257, c: null }
+            integers: { a: 1, b: 2, c: null }
+            longs: { a: 999999999999, b: 999999999998, c: null }
+            floats: { a: 1.5, b: 2.5, c: null }
+            doubles: { a: 3.5, b: 4.5, c: null }
+            strings: { a: "foo", b: "bar", c: null }
+            blobs: { a: "foo", b: "bar", c: null }
+            timestamps: { a: 1609459200, b: 1609545600, c: null }
+            enums: { a: "Foo", b: "Bar", c: null }
+            intEnums: { a: 1, b: 2, c: null }
+        }
+    }
+])
+
+apply SparseMapOfScalars @httpResponseTests([
+    {
+        id: "RpcV2JsonSparseMapOfScalarsNullAtStartResponse"
+        documentation: "Deserializes sparse maps with a null as the first entry"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleans": {"a": null, "b": true, "c": false},
+                "bytes": {"a": null, "b": 5, "c": 6},
+                "shorts": {"a": null, "b": 256, "c": 257},
+                "integers": {"a": null, "b": 1, "c": 2},
+                "longs": {"a": null, "b": 999999999999, "c": 999999999998},
+                "floats": {"a": null, "b": 1.5, "c": 2.5},
+                "doubles": {"a": null, "b": 3.5, "c": 4.5},
+                "strings": {"a": null, "b": "foo", "c": "bar"},
+                "blobs": {"a": null, "b": "Zm9v", "c": "YmFy"},
+                "timestamps": {"a": null, "b": 1609459200, "c": 1609545600},
+                "enums": {"a": null, "b": "Foo", "c": "Bar"},
+                "intEnums": {"a": null, "b": 1, "c": 2}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleans: { a: null, b: true, c: false }
+            bytes: { a: null, b: 5, c: 6 }
+            shorts: { a: null, b: 256, c: 257 }
+            integers: { a: null, b: 1, c: 2 }
+            longs: { a: null, b: 999999999999, c: 999999999998 }
+            floats: { a: null, b: 1.5, c: 2.5 }
+            doubles: { a: null, b: 3.5, c: 4.5 }
+            strings: { a: null, b: "foo", c: "bar" }
+            blobs: { a: null, b: "foo", c: "bar" }
+            timestamps: { a: null, b: 1609459200, c: 1609545600 }
+            enums: { a: null, b: "Foo", c: "Bar" }
+            intEnums: { a: null, b: 1, c: 2 }
+        }
+    }
+    {
+        id: "RpcV2JsonSparseMapOfScalarsNullInMiddleResponse"
+        documentation: "Deserializes sparse maps with a null as the middle entry"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleans": {"a": true, "b": null, "c": false},
+                "bytes": {"a": 5, "b": null, "c": 6},
+                "shorts": {"a": 256, "b": null, "c": 257},
+                "integers": {"a": 1, "b": null, "c": 2},
+                "longs": {"a": 999999999999, "b": null, "c": 999999999998},
+                "floats": {"a": 1.5, "b": null, "c": 2.5},
+                "doubles": {"a": 3.5, "b": null, "c": 4.5},
+                "strings": {"a": "foo", "b": null, "c": "bar"},
+                "blobs": {"a": "Zm9v", "b": null, "c": "YmFy"},
+                "timestamps": {"a": 1609459200, "b": null, "c": 1609545600},
+                "enums": {"a": "Foo", "b": null, "c": "Bar"},
+                "intEnums": {"a": 1, "b": null, "c": 2}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleans: { a: true, b: null, c: false }
+            bytes: { a: 5, b: null, c: 6 }
+            shorts: { a: 256, b: null, c: 257 }
+            integers: { a: 1, b: null, c: 2 }
+            longs: { a: 999999999999, b: null, c: 999999999998 }
+            floats: { a: 1.5, b: null, c: 2.5 }
+            doubles: { a: 3.5, b: null, c: 4.5 }
+            strings: { a: "foo", b: null, c: "bar" }
+            blobs: { a: "foo", b: null, c: "bar" }
+            timestamps: { a: 1609459200, b: null, c: 1609545600 }
+            enums: { a: "Foo", b: null, c: "Bar" }
+            intEnums: { a: 1, b: null, c: 2 }
+        }
+    }
+    {
+        id: "RpcV2JsonSparseMapOfScalarsNullAtEndResponse"
+        documentation: "Deserializes sparse maps with a null as the last entry"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleans": {"a": true, "b": false, "c": null},
+                "bytes": {"a": 5, "b": 6, "c": null},
+                "shorts": {"a": 256, "b": 257, "c": null},
+                "integers": {"a": 1, "b": 2, "c": null},
+                "longs": {"a": 999999999999, "b": 999999999998, "c": null},
+                "floats": {"a": 1.5, "b": 2.5, "c": null},
+                "doubles": {"a": 3.5, "b": 4.5, "c": null},
+                "strings": {"a": "foo", "b": "bar", "c": null},
+                "blobs": {"a": "Zm9v", "b": "YmFy", "c": null},
+                "timestamps": {"a": 1609459200, "b": 1609545600, "c": null},
+                "enums": {"a": "Foo", "b": "Bar", "c": null},
+                "intEnums": {"a": 1, "b": 2, "c": null}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleans: { a: true, b: false, c: null }
+            bytes: { a: 5, b: 6, c: null }
+            shorts: { a: 256, b: 257, c: null }
+            integers: { a: 1, b: 2, c: null }
+            longs: { a: 999999999999, b: 999999999998, c: null }
+            floats: { a: 1.5, b: 2.5, c: null }
+            doubles: { a: 3.5, b: 4.5, c: null }
+            strings: { a: "foo", b: "bar", c: null }
+            blobs: { a: "foo", b: "bar", c: null }
+            timestamps: { a: 1609459200, b: 1609545600, c: null }
+            enums: { a: "Foo", b: "Bar", c: null }
+            intEnums: { a: 1, b: 2, c: null }
+        }
+    }
+])
+
+apply StructOfScalars @httpRequestTests([
+    {
+        id: "RpcV2JsonStructOfScalarsPopulated"
+        documentation: "Serializes a fully populated nested struct"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/StructOfScalars"
+        body: """
+            {
+                "value": {
+                    "booleanMember": true,
+                    "byteMember": 5,
+                    "shortMember": 256,
+                    "integerMember": 1234,
+                    "longMember": 999999999999,
+                    "floatMember": 1.5,
+                    "doubleMember": 2.5,
+                    "stringMember": "hello",
+                    "blobMember": "Zm9v",
+                    "dateTimeMember": 1609504496,
+                    "epochSecondsMember": 1612325106,
+                    "httpDateMember": 1614834367,
+                    "stringEnum": "Foo",
+                    "intEnum": 1
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: {
+                booleanMember: true
+                byteMember: 5
+                shortMember: 256
+                integerMember: 1234
+                longMember: 999999999999
+                floatMember: 1.5
+                doubleMember: 2.5
+                stringMember: "hello"
+                blobMember: "foo"
+                dateTimeMember: 1609504496
+                epochSecondsMember: 1612325106
+                httpDateMember: 1614834367
+                stringEnum: "Foo"
+                intEnum: 1
+            }
+        }
+    }
+])
+
+apply StructOfScalars @httpResponseTests([
+    {
+        id: "RpcV2JsonStructOfScalarsPopulatedResponse"
+        documentation: "Deserializes a fully populated nested struct"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "booleanMember": true,
+                    "byteMember": 5,
+                    "shortMember": 256,
+                    "integerMember": 1234,
+                    "longMember": 999999999999,
+                    "floatMember": 1.5,
+                    "doubleMember": 2.5,
+                    "stringMember": "hello",
+                    "blobMember": "Zm9v",
+                    "dateTimeMember": 1609504496,
+                    "epochSecondsMember": 1612325106,
+                    "httpDateMember": 1614834367,
+                    "stringEnum": "Foo",
+                    "intEnum": 1
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: {
+                booleanMember: true
+                byteMember: 5
+                shortMember: 256
+                integerMember: 1234
+                longMember: 999999999999
+                floatMember: 1.5
+                doubleMember: 2.5
+                stringMember: "hello"
+                blobMember: "foo"
+                dateTimeMember: 1609504496
+                epochSecondsMember: 1612325106
+                httpDateMember: 1614834367
+                stringEnum: "Foo"
+                intEnum: 1
+            }
+        }
+    }
+])
+
+apply UnionOfScalars @httpRequestTests([
+    {
+        id: "RpcV2JsonUnionOfScalarsStringSerialize"
+        documentation: "Serializes union string variant"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/UnionOfScalars"
+        body: """
+            {
+                "value": {
+                    "stringValue": "hello"
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: { stringValue: "hello" }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsBooleanSerialize"
+        documentation: "Serializes union boolean variant"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/UnionOfScalars"
+        body: """
+            {
+                "value": {
+                    "booleanValue": true
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: { booleanValue: true }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsByteSerialize"
+        documentation: "Serializes union byte variant"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/UnionOfScalars"
+        body: """
+            {
+                "value": {
+                    "byteValue": 9
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: { byteValue: 9 }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsShortSerialize"
+        documentation: "Serializes union short variant"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/UnionOfScalars"
+        body: """
+            {
+                "value": {
+                    "shortValue": 512
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: { shortValue: 512 }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsIntegerSerialize"
+        documentation: "Serializes union integer variant"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/UnionOfScalars"
+        body: """
+            {
+                "value": {
+                    "integerValue": 42
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: { integerValue: 42 }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsLongSerialize"
+        documentation: "Serializes union long variant"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/UnionOfScalars"
+        body: """
+            {
+                "value": {
+                    "longValue": 999999999999
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: { longValue: 999999999999 }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsFloatSerialize"
+        documentation: "Serializes union float variant"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/UnionOfScalars"
+        body: """
+            {
+                "value": {
+                    "floatValue": 1.5
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: { floatValue: 1.5 }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsDoubleSerialize"
+        documentation: "Serializes union double variant"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/UnionOfScalars"
+        body: """
+            {
+                "value": {
+                    "doubleValue": 2.5
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: { doubleValue: 2.5 }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsBlobSerialize"
+        documentation: "Serializes union blob variant (base64 on wire)"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/UnionOfScalars"
+        body: """
+            {
+                "value": {
+                    "blobValue": "Zm9v"
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: { blobValue: "foo" }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsTimestampSerialize"
+        documentation: "Serializes union timestamp variant (epoch seconds on wire)"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/UnionOfScalars"
+        body: """
+            {
+                "value": {
+                    "timestampValue": 1609459200
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: { timestampValue: 1609459200 }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsEnumSerialize"
+        documentation: "Serializes union enum variant"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/UnionOfScalars"
+        body: """
+            {
+                "value": {
+                    "enumValue": "Foo"
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: { enumValue: "Foo" }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsIntEnumSerialize"
+        documentation: "Serializes union intEnum variant"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/UnionOfScalars"
+        body: """
+            {
+                "value": {
+                    "intEnumValue": 1
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: { intEnumValue: 1 }
+        }
+    }
+])
+
+apply UnionOfScalars @httpResponseTests([
+    {
+        id: "RpcV2JsonUnionOfScalarsStringDeserialize"
+        documentation: "Deserializes union string variant"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "stringValue": "hello"
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: { stringValue: "hello" }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsBooleanDeserialize"
+        documentation: "Deserializes union boolean variant"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "booleanValue": true
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: { booleanValue: true }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsByteDeserialize"
+        documentation: "Deserializes union byte variant"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "byteValue": 9
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: { byteValue: 9 }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsShortDeserialize"
+        documentation: "Deserializes union short variant"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "shortValue": 512
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: { shortValue: 512 }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsIntegerDeserialize"
+        documentation: "Deserializes union integer variant"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "integerValue": 42
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: { integerValue: 42 }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsLongDeserialize"
+        documentation: "Deserializes union long variant"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "longValue": 999999999999
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: { longValue: 999999999999 }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsFloatDeserialize"
+        documentation: "Deserializes union float variant"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "floatValue": 1.5
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: { floatValue: 1.5 }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsDoubleDeserialize"
+        documentation: "Deserializes union double variant"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "doubleValue": 2.5
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: { doubleValue: 2.5 }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsBlobDeserialize"
+        documentation: "Deserializes union blob variant (base64 on wire)"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "blobValue": "Zm9v"
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: { blobValue: "foo" }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsTimestampDeserialize"
+        documentation: "Deserializes union timestamp variant (epoch seconds on wire)"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "timestampValue": 1609459200
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: { timestampValue: 1609459200 }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsEnumDeserialize"
+        documentation: "Deserializes union enum variant"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "enumValue": "Foo"
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: { enumValue: "Foo" }
+        }
+    }
+    {
+        id: "RpcV2JsonUnionOfScalarsIntEnumDeserialize"
+        documentation: "Deserializes union intEnum variant"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "intEnumValue": 1
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: { intEnumValue: 1 }
+        }
+    }
+])
+
+apply UnionOfStruct @httpRequestTests([
+    {
+        id: "RpcV2JsonUnionOfStructSerialize"
+        documentation: "Serializes union struct variant"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/UnionOfStruct"
+        body: """
+            {
+                "value": {
+                    "structValue": {
+                        "stringMember": "hello",
+                        "integerMember": 42,
+                        "booleanMember": true
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: {
+                structValue: { stringMember: "hello", integerMember: 42, booleanMember: true }
+            }
+        }
+    }
+])
+
+apply UnionOfStruct @httpResponseTests([
+    {
+        id: "RpcV2JsonUnionOfStructDeserialize"
+        documentation: "Deserializes union struct variant"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "structValue": {
+                        "stringMember": "hello",
+                        "integerMember": 42,
+                        "booleanMember": true
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: {
+                structValue: { stringMember: "hello", integerMember: 42, booleanMember: true }
+            }
+        }
+    }
+])
+
+apply UnionOfList @httpRequestTests([
+    {
+        id: "RpcV2JsonUnionOfListSerialize"
+        documentation: "Serializes union list variant"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/UnionOfList"
+        body: """
+            {
+                "value": {
+                    "listValue": ["a", "b", "c"]
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: {
+                listValue: ["a", "b", "c"]
+            }
+        }
+    }
+])
+
+apply UnionOfList @httpResponseTests([
+    {
+        id: "RpcV2JsonUnionOfListDeserialize"
+        documentation: "Deserializes union list variant"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "listValue": ["a", "b", "c"]
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: {
+                listValue: ["a", "b", "c"]
+            }
+        }
+    }
+])
+
+apply UnionOfMap @httpRequestTests([
+    {
+        id: "RpcV2JsonUnionOfMapSerialize"
+        documentation: "Serializes union map variant"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/UnionOfMap"
+        body: """
+            {
+                "value": {
+                    "mapValue": {
+                        "k1": "v1",
+                        "k2": "v2"
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: {
+                mapValue: { k1: "v1", k2: "v2" }
+            }
+        }
+    }
+])
+
+apply UnionOfMap @httpResponseTests([
+    {
+        id: "RpcV2JsonUnionOfMapDeserialize"
+        documentation: "Deserializes union map variant"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "mapValue": {
+                        "k1": "v1",
+                        "k2": "v2"
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: {
+                mapValue: { k1: "v1", k2: "v2" }
+            }
+        }
+    }
+])
+
+apply UnionOfUnion @httpRequestTests([
+    {
+        id: "RpcV2JsonUnionOfUnionSerialize"
+        documentation: "Serializes union containing another union"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/UnionOfUnion"
+        body: """
+            {
+                "value": {
+                    "unionValue": {
+                        "stringValue": "nested"
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: {
+                unionValue: { stringValue: "nested" }
+            }
+        }
+    }
+])
+
+apply UnionOfUnion @httpResponseTests([
+    {
+        id: "RpcV2JsonUnionOfUnionDeserialize"
+        documentation: "Deserializes union containing another union"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "unionValue": {
+                        "stringValue": "nested"
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: {
+                unionValue: { stringValue: "nested" }
+            }
+        }
+    }
+])
+
+apply ListOfStructs @httpRequestTests([
+    {
+        id: "RpcV2JsonListOfStructsSerialize"
+        documentation: "Serializes a list of structs"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ListOfStructs"
+        body: """
+            {
+                "values": [
+                    {"stringMember": "foo", "integerMember": 1, "booleanMember": true},
+                    {"stringMember": "bar", "integerMember": 2, "booleanMember": false}
+                ]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            values: [
+                {
+                    stringMember: "foo"
+                    integerMember: 1
+                    booleanMember: true
+                }
+                {
+                    stringMember: "bar"
+                    integerMember: 2
+                    booleanMember: false
+                }
+            ]
+        }
+    }
+])
+
+apply ListOfStructs @httpResponseTests([
+    {
+        id: "RpcV2JsonListOfStructsDeserialize"
+        documentation: "Deserializes a list of structs"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "values": [
+                    {"stringMember": "foo", "integerMember": 1, "booleanMember": true},
+                    {"stringMember": "bar", "integerMember": 2, "booleanMember": false}
+                ]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            values: [
+                {
+                    stringMember: "foo"
+                    integerMember: 1
+                    booleanMember: true
+                }
+                {
+                    stringMember: "bar"
+                    integerMember: 2
+                    booleanMember: false
+                }
+            ]
+        }
+    }
+])
+
+apply ListOfMaps @httpRequestTests([
+    {
+        id: "RpcV2JsonListOfMapsSerialize"
+        documentation: "Serializes lists of maps for all scalar leaf types"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ListOfMaps"
+        body: """
+            {
+                "booleans": [{"k1": true, "k2": false}, {"k3": false, "k4": true, "k5": true}],
+                "integers": [{"k1": 1, "k2": 2}, {"k3": 3, "k4": 4, "k5": 5}],
+                "strings": [{"k1": "a", "k2": "b"}, {"k3": "c", "k4": "d", "k5": "e"}],
+                "blobs": [{"k1": "Zm9v", "k2": "YmFy"}, {"k3": "YmF6", "k4": "cXV4", "k5": "cXV1eA=="}],
+                "timestamps": [{"k1": 1609502096, "k2": 1609588496}, {"k3": 1609674896, "k4": 1609761296, "k5": 1609847696}],
+                "enums": [{"k1": "Foo", "k2": "Bar"}, {"k3": "Baz", "k4": "Foo", "k5": "Bar"}],
+                "intEnums": [{"k1": 1, "k2": 2}, {"k3": 3, "k4": 1, "k5": 2}]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleans: [
+                {
+                    k1: true
+                    k2: false
+                }
+                {
+                    k3: false
+                    k4: true
+                    k5: true
+                }
+            ]
+            integers: [
+                {
+                    k1: 1
+                    k2: 2
+                }
+                {
+                    k3: 3
+                    k4: 4
+                    k5: 5
+                }
+            ]
+            strings: [
+                {
+                    k1: "a"
+                    k2: "b"
+                }
+                {
+                    k3: "c"
+                    k4: "d"
+                    k5: "e"
+                }
+            ]
+            blobs: [
+                {
+                    k1: "foo"
+                    k2: "bar"
+                }
+                {
+                    k3: "baz"
+                    k4: "qux"
+                    k5: "quux"
+                }
+            ]
+            timestamps: [
+                {
+                    k1: 1609502096
+                    k2: 1609588496
+                }
+                {
+                    k3: 1609674896
+                    k4: 1609761296
+                    k5: 1609847696
+                }
+            ]
+            enums: [
+                {
+                    k1: "Foo"
+                    k2: "Bar"
+                }
+                {
+                    k3: "Baz"
+                    k4: "Foo"
+                    k5: "Bar"
+                }
+            ]
+            intEnums: [
+                {
+                    k1: 1
+                    k2: 2
+                }
+                {
+                    k3: 3
+                    k4: 1
+                    k5: 2
+                }
+            ]
+        }
+    }
+])
+
+apply ListOfMaps @httpResponseTests([
+    {
+        id: "RpcV2JsonListOfMapsDeserialize"
+        documentation: "Deserializes lists of maps for all scalar leaf types"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleans": [{"k1": true, "k2": false}, {"k3": false, "k4": true, "k5": true}],
+                "integers": [{"k1": 1, "k2": 2}, {"k3": 3, "k4": 4, "k5": 5}],
+                "strings": [{"k1": "a", "k2": "b"}, {"k3": "c", "k4": "d", "k5": "e"}],
+                "blobs": [{"k1": "Zm9v", "k2": "YmFy"}, {"k3": "YmF6", "k4": "cXV4", "k5": "cXV1eA=="}],
+                "timestamps": [{"k1": 1609502096, "k2": 1609588496}, {"k3": 1609674896, "k4": 1609761296, "k5": 1609847696}],
+                "enums": [{"k1": "Foo", "k2": "Bar"}, {"k3": "Baz", "k4": "Foo", "k5": "Bar"}],
+                "intEnums": [{"k1": 1, "k2": 2}, {"k3": 3, "k4": 1, "k5": 2}]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleans: [
+                {
+                    k1: true
+                    k2: false
+                }
+                {
+                    k3: false
+                    k4: true
+                    k5: true
+                }
+            ]
+            integers: [
+                {
+                    k1: 1
+                    k2: 2
+                }
+                {
+                    k3: 3
+                    k4: 4
+                    k5: 5
+                }
+            ]
+            strings: [
+                {
+                    k1: "a"
+                    k2: "b"
+                }
+                {
+                    k3: "c"
+                    k4: "d"
+                    k5: "e"
+                }
+            ]
+            blobs: [
+                {
+                    k1: "foo"
+                    k2: "bar"
+                }
+                {
+                    k3: "baz"
+                    k4: "qux"
+                    k5: "quux"
+                }
+            ]
+            timestamps: [
+                {
+                    k1: 1609502096
+                    k2: 1609588496
+                }
+                {
+                    k3: 1609674896
+                    k4: 1609761296
+                    k5: 1609847696
+                }
+            ]
+            enums: [
+                {
+                    k1: "Foo"
+                    k2: "Bar"
+                }
+                {
+                    k3: "Baz"
+                    k4: "Foo"
+                    k5: "Bar"
+                }
+            ]
+            intEnums: [
+                {
+                    k1: 1
+                    k2: 2
+                }
+                {
+                    k3: 3
+                    k4: 1
+                    k5: 2
+                }
+            ]
+        }
+    }
+])
+
+apply ListOfLists @httpRequestTests([
+    {
+        id: "RpcV2JsonListOfListsSerialize"
+        documentation: "Serializes lists of lists for all scalar leaf types"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ListOfLists"
+        body: """
+            {
+                "booleans": [[true, false], [false, true, true]],
+                "integers": [[1, 2], [3, 4, 5]],
+                "strings": [["a", "b"], ["c", "d", "e"]],
+                "blobs": [["Zm9v", "YmFy"], ["YmF6", "cXV4", "cXV1eA=="]],
+                "timestamps": [[1609502096, 1609588496], [1609674896, 1609761296, 1609847696]],
+                "enums": [["Foo", "Bar"], ["Baz", "Foo", "Bar"]],
+                "intEnums": [[1, 2], [3, 1, 2]]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleans: [
+                [true, false]
+                [false, true, true]
+            ]
+            integers: [
+                [1, 2]
+                [3, 4, 5]
+            ]
+            strings: [
+                ["a", "b"]
+                ["c", "d", "e"]
+            ]
+            blobs: [
+                ["foo", "bar"]
+                ["baz", "qux", "quux"]
+            ]
+            timestamps: [
+                [1609502096, 1609588496]
+                [1609674896, 1609761296, 1609847696]
+            ]
+            enums: [
+                ["Foo", "Bar"]
+                ["Baz", "Foo", "Bar"]
+            ]
+            intEnums: [
+                [1, 2]
+                [3, 1, 2]
+            ]
+        }
+    }
+])
+
+apply ListOfLists @httpResponseTests([
+    {
+        id: "RpcV2JsonListOfListsDeserialize"
+        documentation: "Deserializes lists of lists for all scalar leaf types"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleans": [[true, false], [false, true, true]],
+                "integers": [[1, 2], [3, 4, 5]],
+                "strings": [["a", "b"], ["c", "d", "e"]],
+                "blobs": [["Zm9v", "YmFy"], ["YmF6", "cXV4", "cXV1eA=="]],
+                "timestamps": [[1609502096, 1609588496], [1609674896, 1609761296, 1609847696]],
+                "enums": [["Foo", "Bar"], ["Baz", "Foo", "Bar"]],
+                "intEnums": [[1, 2], [3, 1, 2]]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleans: [
+                [true, false]
+                [false, true, true]
+            ]
+            integers: [
+                [1, 2]
+                [3, 4, 5]
+            ]
+            strings: [
+                ["a", "b"]
+                ["c", "d", "e"]
+            ]
+            blobs: [
+                ["foo", "bar"]
+                ["baz", "qux", "quux"]
+            ]
+            timestamps: [
+                [1609502096, 1609588496]
+                [1609674896, 1609761296, 1609847696]
+            ]
+            enums: [
+                ["Foo", "Bar"]
+                ["Baz", "Foo", "Bar"]
+            ]
+            intEnums: [
+                [1, 2]
+                [3, 1, 2]
+            ]
+        }
+    }
+])
+
+apply ListOfUnions @httpRequestTests([
+    {
+        id: "RpcV2JsonListOfUnionsSerialize"
+        documentation: "Serializes a list of unions with different variants"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ListOfUnions"
+        body: """
+            {
+                "values": [
+                    {"stringValue": "hello"},
+                    {"integerValue": 42}
+                ]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            values: [
+                {
+                    stringValue: "hello"
+                }
+                {
+                    integerValue: 42
+                }
+            ]
+        }
+    }
+])
+
+apply ListOfUnions @httpResponseTests([
+    {
+        id: "RpcV2JsonListOfUnionsDeserialize"
+        documentation: "Deserializes a list of unions with different variants"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "values": [
+                    {"stringValue": "hello"},
+                    {"integerValue": 42}
+                ]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            values: [
+                {
+                    stringValue: "hello"
+                }
+                {
+                    integerValue: 42
+                }
+            ]
+        }
+    }
+])
+
+apply MapOfStructs @httpRequestTests([
+    {
+        id: "RpcV2JsonMapOfStructsSerialize"
+        documentation: "Serializes a map of structs"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/MapOfStructs"
+        body: """
+            {
+                "values": {
+                    "first": {"stringMember": "foo", "integerMember": 1, "booleanMember": true},
+                    "second": {"stringMember": "bar", "integerMember": 2, "booleanMember": false}
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            values: {
+                first: { stringMember: "foo", integerMember: 1, booleanMember: true }
+                second: { stringMember: "bar", integerMember: 2, booleanMember: false }
+            }
+        }
+    }
+])
+
+apply MapOfStructs @httpResponseTests([
+    {
+        id: "RpcV2JsonMapOfStructsDeserialize"
+        documentation: "Deserializes a map of structs"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "values": {
+                    "first": {"stringMember": "foo", "integerMember": 1, "booleanMember": true},
+                    "second": {"stringMember": "bar", "integerMember": 2, "booleanMember": false}
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            values: {
+                first: { stringMember: "foo", integerMember: 1, booleanMember: true }
+                second: { stringMember: "bar", integerMember: 2, booleanMember: false }
+            }
+        }
+    }
+])
+
+apply MapOfMaps @httpRequestTests([
+    {
+        id: "RpcV2JsonMapOfMapsSerialize"
+        documentation: "Serializes maps of maps for all scalar leaf types"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/MapOfMaps"
+        body: """
+            {
+                "booleans": {"first": {"k1": true, "k2": false}, "second": {"k3": false, "k4": true, "k5": true}},
+                "integers": {"first": {"k1": 1, "k2": 2}, "second": {"k3": 3, "k4": 4, "k5": 5}},
+                "strings": {"first": {"k1": "a", "k2": "b"}, "second": {"k3": "c", "k4": "d", "k5": "e"}},
+                "blobs": {"first": {"k1": "Zm9v", "k2": "YmFy"}, "second": {"k3": "YmF6", "k4": "cXV4", "k5": "cXV1eA=="}},
+                "timestamps": {"first": {"k1": 1609502096, "k2": 1609588496}, "second": {"k3": 1609674896, "k4": 1609761296, "k5": 1609847696}},
+                "enums": {"first": {"k1": "Foo", "k2": "Bar"}, "second": {"k3": "Baz", "k4": "Foo", "k5": "Bar"}},
+                "intEnums": {"first": {"k1": 1, "k2": 2}, "second": {"k3": 3, "k4": 1, "k5": 2}}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleans: {
+                first: { k1: true, k2: false }
+                second: { k3: false, k4: true, k5: true }
+            }
+            integers: {
+                first: { k1: 1, k2: 2 }
+                second: { k3: 3, k4: 4, k5: 5 }
+            }
+            strings: {
+                first: { k1: "a", k2: "b" }
+                second: { k3: "c", k4: "d", k5: "e" }
+            }
+            blobs: {
+                first: { k1: "foo", k2: "bar" }
+                second: { k3: "baz", k4: "qux", k5: "quux" }
+            }
+            timestamps: {
+                first: { k1: 1609502096, k2: 1609588496 }
+                second: { k3: 1609674896, k4: 1609761296, k5: 1609847696 }
+            }
+            enums: {
+                first: { k1: "Foo", k2: "Bar" }
+                second: { k3: "Baz", k4: "Foo", k5: "Bar" }
+            }
+            intEnums: {
+                first: { k1: 1, k2: 2 }
+                second: { k3: 3, k4: 1, k5: 2 }
+            }
+        }
+    }
+])
+
+apply MapOfMaps @httpResponseTests([
+    {
+        id: "RpcV2JsonMapOfMapsDeserialize"
+        documentation: "Deserializes maps of maps for all scalar leaf types"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleans": {"first": {"k1": true, "k2": false}, "second": {"k3": false, "k4": true, "k5": true}},
+                "integers": {"first": {"k1": 1, "k2": 2}, "second": {"k3": 3, "k4": 4, "k5": 5}},
+                "strings": {"first": {"k1": "a", "k2": "b"}, "second": {"k3": "c", "k4": "d", "k5": "e"}},
+                "blobs": {"first": {"k1": "Zm9v", "k2": "YmFy"}, "second": {"k3": "YmF6", "k4": "cXV4", "k5": "cXV1eA=="}},
+                "timestamps": {"first": {"k1": 1609502096, "k2": 1609588496}, "second": {"k3": 1609674896, "k4": 1609761296, "k5": 1609847696}},
+                "enums": {"first": {"k1": "Foo", "k2": "Bar"}, "second": {"k3": "Baz", "k4": "Foo", "k5": "Bar"}},
+                "intEnums": {"first": {"k1": 1, "k2": 2}, "second": {"k3": 3, "k4": 1, "k5": 2}}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleans: {
+                first: { k1: true, k2: false }
+                second: { k3: false, k4: true, k5: true }
+            }
+            integers: {
+                first: { k1: 1, k2: 2 }
+                second: { k3: 3, k4: 4, k5: 5 }
+            }
+            strings: {
+                first: { k1: "a", k2: "b" }
+                second: { k3: "c", k4: "d", k5: "e" }
+            }
+            blobs: {
+                first: { k1: "foo", k2: "bar" }
+                second: { k3: "baz", k4: "qux", k5: "quux" }
+            }
+            timestamps: {
+                first: { k1: 1609502096, k2: 1609588496 }
+                second: { k3: 1609674896, k4: 1609761296, k5: 1609847696 }
+            }
+            enums: {
+                first: { k1: "Foo", k2: "Bar" }
+                second: { k3: "Baz", k4: "Foo", k5: "Bar" }
+            }
+            intEnums: {
+                first: { k1: 1, k2: 2 }
+                second: { k3: 3, k4: 1, k5: 2 }
+            }
+        }
+    }
+])
+
+apply MapOfLists @httpRequestTests([
+    {
+        id: "RpcV2JsonMapOfListsSerialize"
+        documentation: "Serializes maps of lists for all scalar leaf types"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/MapOfLists"
+        body: """
+            {
+                "booleans": {"first": [true, false], "second": [false, true, true]},
+                "integers": {"first": [1, 2], "second": [3, 4, 5]},
+                "strings": {"first": ["a", "b"], "second": ["c", "d", "e"]},
+                "blobs": {"first": ["Zm9v", "YmFy"], "second": ["YmF6", "cXV4", "cXV1eA=="]},
+                "timestamps": {"first": [1609502096, 1609588496], "second": [1609674896, 1609761296, 1609847696]},
+                "enums": {"first": ["Foo", "Bar"], "second": ["Baz", "Foo", "Bar"]},
+                "intEnums": {"first": [1, 2], "second": [3, 1, 2]}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleans: {
+                first: [true, false]
+                second: [false, true, true]
+            }
+            integers: {
+                first: [1, 2]
+                second: [3, 4, 5]
+            }
+            strings: {
+                first: ["a", "b"]
+                second: ["c", "d", "e"]
+            }
+            blobs: {
+                first: ["foo", "bar"]
+                second: ["baz", "qux", "quux"]
+            }
+            timestamps: {
+                first: [1609502096, 1609588496]
+                second: [1609674896, 1609761296, 1609847696]
+            }
+            enums: {
+                first: ["Foo", "Bar"]
+                second: ["Baz", "Foo", "Bar"]
+            }
+            intEnums: {
+                first: [1, 2]
+                second: [3, 1, 2]
+            }
+        }
+    }
+])
+
+apply MapOfLists @httpResponseTests([
+    {
+        id: "RpcV2JsonMapOfListsDeserialize"
+        documentation: "Deserializes maps of lists for all scalar leaf types"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleans": {"first": [true, false], "second": [false, true, true]},
+                "integers": {"first": [1, 2], "second": [3, 4, 5]},
+                "strings": {"first": ["a", "b"], "second": ["c", "d", "e"]},
+                "blobs": {"first": ["Zm9v", "YmFy"], "second": ["YmF6", "cXV4", "cXV1eA=="]},
+                "timestamps": {"first": [1609502096, 1609588496], "second": [1609674896, 1609761296, 1609847696]},
+                "enums": {"first": ["Foo", "Bar"], "second": ["Baz", "Foo", "Bar"]},
+                "intEnums": {"first": [1, 2], "second": [3, 1, 2]}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleans: {
+                first: [true, false]
+                second: [false, true, true]
+            }
+            integers: {
+                first: [1, 2]
+                second: [3, 4, 5]
+            }
+            strings: {
+                first: ["a", "b"]
+                second: ["c", "d", "e"]
+            }
+            blobs: {
+                first: ["foo", "bar"]
+                second: ["baz", "qux", "quux"]
+            }
+            timestamps: {
+                first: [1609502096, 1609588496]
+                second: [1609674896, 1609761296, 1609847696]
+            }
+            enums: {
+                first: ["Foo", "Bar"]
+                second: ["Baz", "Foo", "Bar"]
+            }
+            intEnums: {
+                first: [1, 2]
+                second: [3, 1, 2]
+            }
+        }
+    }
+])
+
+apply MapOfUnions @httpRequestTests([
+    {
+        id: "RpcV2JsonMapOfUnionsSerialize"
+        documentation: "Serializes a map of unions with different variants"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/MapOfUnions"
+        body: """
+            {
+                "values": {
+                    "first": {"stringValue": "hello"},
+                    "second": {"integerValue": 42}
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            values: {
+                first: { stringValue: "hello" }
+                second: { integerValue: 42 }
+            }
+        }
+    }
+])
+
+apply MapOfUnions @httpResponseTests([
+    {
+        id: "RpcV2JsonMapOfUnionsDeserialize"
+        documentation: "Deserializes a map of unions with different variants"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "values": {
+                    "first": {"stringValue": "hello"},
+                    "second": {"integerValue": 42}
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            values: {
+                first: { stringValue: "hello" }
+                second: { integerValue: 42 }
+            }
+        }
+    }
+])
+
+apply SparseListOfStructs @httpRequestTests([
+    {
+        id: "RpcV2JsonSparseListOfStructsNullAtStart"
+        documentation: "Serializes a sparse list with a null as the first element"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/SparseListOfStructs"
+        body: """
+            {
+                "values": [
+                    null,
+                    {"stringMember": "foo", "integerMember": 1, "booleanMember": true},
+                    {"stringMember": "bar", "integerMember": 2, "booleanMember": false}
+                ]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            values: [
+                null
+                {
+                    stringMember: "foo"
+                    integerMember: 1
+                    booleanMember: true
+                }
+                {
+                    stringMember: "bar"
+                    integerMember: 2
+                    booleanMember: false
+                }
+            ]
+        }
+    }
+    {
+        id: "RpcV2JsonSparseListOfStructsNullInMiddle"
+        documentation: "Serializes a sparse list with a null as the middle element"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/SparseListOfStructs"
+        body: """
+            {
+                "values": [
+                    {"stringMember": "foo", "integerMember": 1, "booleanMember": true},
+                    null,
+                    {"stringMember": "bar", "integerMember": 2, "booleanMember": false}
+                ]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            values: [
+                {
+                    stringMember: "foo"
+                    integerMember: 1
+                    booleanMember: true
+                }
+                null
+                {
+                    stringMember: "bar"
+                    integerMember: 2
+                    booleanMember: false
+                }
+            ]
+        }
+    }
+    {
+        id: "RpcV2JsonSparseListOfStructsNullAtEnd"
+        documentation: "Serializes a sparse list with a null as the last element"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/SparseListOfStructs"
+        body: """
+            {
+                "values": [
+                    {"stringMember": "foo", "integerMember": 1, "booleanMember": true},
+                    {"stringMember": "bar", "integerMember": 2, "booleanMember": false},
+                    null
+                ]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            values: [
+                {
+                    stringMember: "foo"
+                    integerMember: 1
+                    booleanMember: true
+                }
+                {
+                    stringMember: "bar"
+                    integerMember: 2
+                    booleanMember: false
+                }
+                null
+            ]
+        }
+    }
+])
+
+apply SparseListOfStructs @httpResponseTests([
+    {
+        id: "RpcV2JsonSparseListOfStructsNullAtStartResponse"
+        documentation: "Deserializes a sparse list with a null as the first element"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "values": [
+                    null,
+                    {"stringMember": "foo", "integerMember": 1, "booleanMember": true},
+                    {"stringMember": "bar", "integerMember": 2, "booleanMember": false}
+                ]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            values: [
+                null
+                {
+                    stringMember: "foo"
+                    integerMember: 1
+                    booleanMember: true
+                }
+                {
+                    stringMember: "bar"
+                    integerMember: 2
+                    booleanMember: false
+                }
+            ]
+        }
+    }
+    {
+        id: "RpcV2JsonSparseListOfStructsNullInMiddleResponse"
+        documentation: "Deserializes a sparse list with a null as the middle element"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "values": [
+                    {"stringMember": "foo", "integerMember": 1, "booleanMember": true},
+                    null,
+                    {"stringMember": "bar", "integerMember": 2, "booleanMember": false}
+                ]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            values: [
+                {
+                    stringMember: "foo"
+                    integerMember: 1
+                    booleanMember: true
+                }
+                null
+                {
+                    stringMember: "bar"
+                    integerMember: 2
+                    booleanMember: false
+                }
+            ]
+        }
+    }
+    {
+        id: "RpcV2JsonSparseListOfStructsNullAtEndResponse"
+        documentation: "Deserializes a sparse list with a null as the last element"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "values": [
+                    {"stringMember": "foo", "integerMember": 1, "booleanMember": true},
+                    {"stringMember": "bar", "integerMember": 2, "booleanMember": false},
+                    null
+                ]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            values: [
+                {
+                    stringMember: "foo"
+                    integerMember: 1
+                    booleanMember: true
+                }
+                {
+                    stringMember: "bar"
+                    integerMember: 2
+                    booleanMember: false
+                }
+                null
+            ]
+        }
+    }
+])
+
+apply SparseMapOfStructs @httpRequestTests([
+    {
+        id: "RpcV2JsonSparseMapOfStructsNullAtStart"
+        documentation: "Serializes a sparse map with a null as the first entry"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/SparseMapOfStructs"
+        body: """
+            {
+                "values": {
+                    "a": null,
+                    "b": {"stringMember": "foo", "integerMember": 1, "booleanMember": true},
+                    "c": {"stringMember": "bar", "integerMember": 2, "booleanMember": false}
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            values: {
+                a: null
+                b: { stringMember: "foo", integerMember: 1, booleanMember: true }
+                c: { stringMember: "bar", integerMember: 2, booleanMember: false }
+            }
+        }
+    }
+    {
+        id: "RpcV2JsonSparseMapOfStructsNullInMiddle"
+        documentation: "Serializes a sparse map with a null as the middle entry"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/SparseMapOfStructs"
+        body: """
+            {
+                "values": {
+                    "a": {"stringMember": "foo", "integerMember": 1, "booleanMember": true},
+                    "b": null,
+                    "c": {"stringMember": "bar", "integerMember": 2, "booleanMember": false}
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            values: {
+                a: { stringMember: "foo", integerMember: 1, booleanMember: true }
+                b: null
+                c: { stringMember: "bar", integerMember: 2, booleanMember: false }
+            }
+        }
+    }
+    {
+        id: "RpcV2JsonSparseMapOfStructsNullAtEnd"
+        documentation: "Serializes a sparse map with a null as the last entry"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/SparseMapOfStructs"
+        body: """
+            {
+                "values": {
+                    "a": {"stringMember": "foo", "integerMember": 1, "booleanMember": true},
+                    "b": {"stringMember": "bar", "integerMember": 2, "booleanMember": false},
+                    "c": null
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            values: {
+                a: { stringMember: "foo", integerMember: 1, booleanMember: true }
+                b: { stringMember: "bar", integerMember: 2, booleanMember: false }
+                c: null
+            }
+        }
+    }
+])
+
+apply SparseMapOfStructs @httpResponseTests([
+    {
+        id: "RpcV2JsonSparseMapOfStructsNullAtStartResponse"
+        documentation: "Deserializes a sparse map with a null as the first entry"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "values": {
+                    "a": null,
+                    "b": {"stringMember": "foo", "integerMember": 1, "booleanMember": true},
+                    "c": {"stringMember": "bar", "integerMember": 2, "booleanMember": false}
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            values: {
+                a: null
+                b: { stringMember: "foo", integerMember: 1, booleanMember: true }
+                c: { stringMember: "bar", integerMember: 2, booleanMember: false }
+            }
+        }
+    }
+    {
+        id: "RpcV2JsonSparseMapOfStructsNullInMiddleResponse"
+        documentation: "Deserializes a sparse map with a null as the middle entry"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "values": {
+                    "a": {"stringMember": "foo", "integerMember": 1, "booleanMember": true},
+                    "b": null,
+                    "c": {"stringMember": "bar", "integerMember": 2, "booleanMember": false}
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            values: {
+                a: { stringMember: "foo", integerMember: 1, booleanMember: true }
+                b: null
+                c: { stringMember: "bar", integerMember: 2, booleanMember: false }
+            }
+        }
+    }
+    {
+        id: "RpcV2JsonSparseMapOfStructsNullAtEndResponse"
+        documentation: "Deserializes a sparse map with a null as the last entry"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "values": {
+                    "a": {"stringMember": "foo", "integerMember": 1, "booleanMember": true},
+                    "b": {"stringMember": "bar", "integerMember": 2, "booleanMember": false},
+                    "c": null
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            values: {
+                a: { stringMember: "foo", integerMember: 1, booleanMember: true }
+                b: { stringMember: "bar", integerMember: 2, booleanMember: false }
+                c: null
+            }
+        }
+    }
+])
+
+apply RecursiveStruct @httpRequestTests([
+    {
+        id: "RpcV2JsonRecursiveStructTwoLevelsDeep"
+        documentation: "Serializes recursive struct two levels deep via recursiveMember"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/RecursiveStruct"
+        body: """
+            {
+                "value": {
+                    "stringMember": "level1",
+                    "recursiveMember": {
+                        "stringMember": "level2"
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: {
+                stringMember: "level1"
+                recursiveMember: { stringMember: "level2" }
+            }
+        }
+    }
+    {
+        id: "RpcV2JsonRecursiveStructViaList"
+        documentation: "Serializes recursive struct via list"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/RecursiveStruct"
+        body: """
+            {
+                "value": {
+                    "recursiveList": [
+                        {
+                            "stringMember": "inList1"
+                        },
+                        {
+                            "stringMember": "inList2"
+                        }
+                    ]
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: {
+                recursiveList: [
+                    {
+                        stringMember: "inList1"
+                    }
+                    {
+                        stringMember: "inList2"
+                    }
+                ]
+            }
+        }
+    }
+    {
+        id: "RpcV2JsonRecursiveStructViaMap"
+        documentation: "Serializes recursive struct via map"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/RecursiveStruct"
+        body: """
+            {
+                "value": {
+                    "recursiveMap": {
+                        "key1": {
+                            "stringMember": "inMap1"
+                        },
+                        "key2": {
+                            "stringMember": "inMap2"
+                        }
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: {
+                recursiveMap: {
+                    key1: { stringMember: "inMap1" }
+                    key2: { stringMember: "inMap2" }
+                }
+            }
+        }
+    }
+])
+
+apply RecursiveStruct @httpResponseTests([
+    {
+        id: "RpcV2JsonRecursiveStructTwoLevelsDeepDeserialize"
+        documentation: "Deserializes recursive struct two levels deep via recursiveMember"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "stringMember": "level1",
+                    "recursiveMember": {
+                        "stringMember": "level2"
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: {
+                stringMember: "level1"
+                recursiveMember: { stringMember: "level2" }
+            }
+        }
+    }
+    {
+        id: "RpcV2JsonRecursiveStructViaListDeserialize"
+        documentation: "Deserializes recursive struct via list"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "recursiveList": [
+                        {
+                            "stringMember": "inList1"
+                        },
+                        {
+                            "stringMember": "inList2"
+                        }
+                    ]
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: {
+                recursiveList: [
+                    {
+                        stringMember: "inList1"
+                    }
+                    {
+                        stringMember: "inList2"
+                    }
+                ]
+            }
+        }
+    }
+    {
+        id: "RpcV2JsonRecursiveStructViaMapDeserialize"
+        documentation: "Deserializes recursive struct via map"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "recursiveMap": {
+                        "key1": {
+                            "stringMember": "inMap1"
+                        },
+                        "key2": {
+                            "stringMember": "inMap2"
+                        }
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: {
+                recursiveMap: {
+                    key1: { stringMember: "inMap1" }
+                    key2: { stringMember: "inMap2" }
+                }
+            }
+        }
+    }
+])
+
+apply RecursiveUnion @httpRequestTests([
+    {
+        id: "RpcV2JsonRecursiveUnionDirectRecursion"
+        documentation: "Serializes recursive union two levels deep"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/RecursiveUnion"
+        body: """
+            {
+                "value": {
+                    "recursiveValue": {
+                        "stringValue": "nested"
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: {
+                recursiveValue: { stringValue: "nested" }
+            }
+        }
+    }
+    {
+        id: "RpcV2JsonRecursiveUnionThroughStruct"
+        documentation: "Serializes recursive union through struct"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/RecursiveUnion"
+        body: """
+            {
+                "value": {
+                    "structValue": {
+                        "value": {
+                            "stringValue": "deep"
+                        }
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: {
+                structValue: {
+                    value: { stringValue: "deep" }
+                }
+            }
+        }
+    }
+])
+
+apply RecursiveUnion @httpResponseTests([
+    {
+        id: "RpcV2JsonRecursiveUnionDirectRecursionDeserialize"
+        documentation: "Deserializes recursive union two levels deep"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "recursiveValue": {
+                        "stringValue": "nested"
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: {
+                recursiveValue: { stringValue: "nested" }
+            }
+        }
+    }
+    {
+        id: "RpcV2JsonRecursiveUnionThroughStructDeserialize"
+        documentation: "Deserializes recursive union through struct"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "structValue": {
+                        "value": {
+                            "stringValue": "deep"
+                        }
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: {
+                structValue: {
+                    value: { stringValue: "deep" }
+                }
+            }
+        }
+    }
+])
+
+apply EmptyInputOutput @httpRequestTests([
+    {
+        id: "RpcV2JsonEmptyInputOutputSerialize"
+        documentation: "Serializes empty input as empty JSON object"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/EmptyInputOutput"
+        body: """
+            {}"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {}
+    }
+])
+
+apply EmptyInputOutput @httpResponseTests([
+    {
+        id: "RpcV2JsonEmptyInputOutputDeserialize"
+        documentation: "Deserializes empty JSON object body"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {}"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {}
+    }
+    {
+        id: "RpcV2JsonEmptyInputOutputDeserializeEmptyBody"
+        tags: ["absent-response-body"]
+        documentation: "Deserializes empty string body as valid empty output"
+        protocol: rpcv2Json
+        code: 200
+        body: ""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        appliesTo: "client"
+        params: {}
+    }
+])
+
+apply NoInputOutput @httpRequestTests([
+    {
+        id: "RpcV2JsonNoInputOutputSerialize"
+        documentation: """
+            Sends no body at all for an operation whose input targets the Unit
+            shape, and omits Content-Type accordingly"""
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/NoInputOutput"
+        body: ""
+        headers: { "smithy-protocol": "rpc-v2-json", Accept: "application/json" }
+        forbidHeaders: ["Content-Type", "X-Amz-Target"]
+        params: {}
+    }
+])
+
+apply SimpleError @httpResponseTests([
+    {
+        id: "RpcV2JsonSimpleErrorDeserialize"
+        documentation: "Deserializes simple client error with __type discrimination"
+        protocol: rpcv2Json
+        code: 400
+        body: """
+            {
+                "__type": "smithy.protocoltests.corpus#SimpleError",
+                "message": "oops"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { message: "oops" }
+    }
+])
+
+apply ComplexError @httpResponseTests([
+    {
+        id: "RpcV2JsonComplexErrorDeserialize"
+        documentation: "Deserializes complex server error with nested struct"
+        protocol: rpcv2Json
+        code: 500
+        body: """
+            {
+                "__type": "smithy.protocoltests.corpus#ComplexError",
+                "message": "something went wrong",
+                "code": 42,
+                "nested": {
+                    "stringMember": "nestedValue",
+                    "integerMember": 99
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            message: "something went wrong"
+            code: 42
+            nested: { stringMember: "nestedValue", integerMember: 99 }
+        }
+    }
+])

--- a/smithy-protocol-tests/model/v2/rpcv2json/document-test.smithy
+++ b/smithy-protocol-tests/model/v2/rpcv2json/document-test.smithy
@@ -1,0 +1,405 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.corpus
+
+use smithy.protocols#rpcv2Json
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+apply DocumentMembers @httpRequestTests([
+    {
+        id: "RpcV2JsonDocumentMembersJsonObject"
+        documentation: "Serializes document as a JSON object"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/DocumentMembers"
+        body: """
+            {
+                "documentValue": {"key": "value"}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            documentValue: { key: "value" }
+        }
+    }
+    {
+        id: "RpcV2JsonDocumentMembersString"
+        documentation: "Serializes document as a string"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/DocumentMembers"
+        body: """
+            {
+                "documentValue": "hello"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: { documentValue: "hello" }
+    }
+    {
+        id: "RpcV2JsonDocumentMembersNumber"
+        documentation: "Serializes document as a number"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/DocumentMembers"
+        body: """
+            {
+                "documentValue": 42
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: { documentValue: 42 }
+    }
+    {
+        id: "RpcV2JsonDocumentMembersBoolean"
+        documentation: "Serializes document as a boolean"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/DocumentMembers"
+        body: """
+            {
+                "documentValue": true
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: { documentValue: true }
+    }
+    {
+        id: "RpcV2JsonDocumentMembersArray"
+        documentation: "Serializes document as an array"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/DocumentMembers"
+        body: """
+            {
+                "documentValue": [1, 2, 3]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            documentValue: [1, 2, 3]
+        }
+    }
+    {
+        id: "RpcV2JsonDocumentMembersNull"
+        documentation: "Serializes document as null"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/DocumentMembers"
+        body: """
+            {
+                "documentValue": null
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: { documentValue: null }
+    }
+    {
+        id: "RpcV2JsonDocumentMembersNestedStruct"
+        documentation: "Serializes nested struct containing a document"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/DocumentMembers"
+        body: """
+            {
+                "nestedStruct": {
+                    "documentMember": {"nested": true},
+                    "stringMember": "hello"
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            nestedStruct: {
+                documentMember: { nested: true }
+                stringMember: "hello"
+            }
+        }
+    }
+])
+
+apply DocumentMembers @httpResponseTests([
+    {
+        id: "RpcV2JsonDocumentMembersDeserializeJsonObject"
+        documentation: "Deserializes document as a JSON object"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "documentValue": {"key": "value"}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            documentValue: { key: "value" }
+        }
+    }
+    {
+        id: "RpcV2JsonDocumentMembersDeserializeString"
+        documentation: "Deserializes document as a string"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "documentValue": "hello"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { documentValue: "hello" }
+    }
+    {
+        id: "RpcV2JsonDocumentMembersDeserializeNumber"
+        documentation: "Deserializes document as a number"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "documentValue": 42
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { documentValue: 42 }
+    }
+    {
+        id: "RpcV2JsonDocumentMembersDeserializeBoolean"
+        documentation: "Deserializes document as a boolean"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "documentValue": true
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { documentValue: true }
+    }
+    {
+        id: "RpcV2JsonDocumentMembersDeserializeArray"
+        documentation: "Deserializes document as an array"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "documentValue": [1, 2, 3]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            documentValue: [1, 2, 3]
+        }
+    }
+    {
+        id: "RpcV2JsonDocumentMembersDeserializeNestedStruct"
+        documentation: "Deserializes nested struct containing a document"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "nestedStruct": {
+                    "documentMember": {"nested": true},
+                    "stringMember": "hello"
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            nestedStruct: {
+                documentMember: { nested: true }
+                stringMember: "hello"
+            }
+        }
+    }
+    {
+        id: "RpcV2JsonDocumentMembersDeserializeNull"
+        documentation: "Deserializes document as null"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "documentValue": null
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { documentValue: null }
+    }
+])
+
+apply ListOfDocuments @httpRequestTests([
+    {
+        id: "RpcV2JsonListOfDocumentsMixedTypes"
+        documentation: "Serializes a list of mixed document types"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ListOfDocuments"
+        body: """
+            {
+                "values": [42, "hello", true, [1, 2], {"key": "value"}]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            values: [
+                42
+                "hello"
+                true
+                [1, 2]
+                {
+                    key: "value"
+                }
+            ]
+        }
+    }
+])
+
+apply ListOfDocuments @httpResponseTests([
+    {
+        id: "RpcV2JsonListOfDocumentsDeserialize"
+        documentation: "Deserializes a list of mixed document types"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "values": [42, "hello", true, [1, 2], {"key": "value"}]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            values: [
+                42
+                "hello"
+                true
+                [1, 2]
+                {
+                    key: "value"
+                }
+            ]
+        }
+    }
+])
+
+apply MapOfDocuments @httpRequestTests([
+    {
+        id: "RpcV2JsonMapOfDocumentsMixedTypes"
+        documentation: "Serializes a map of mixed document types"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/MapOfDocuments"
+        body: """
+            {
+                "values": {
+                    "num": 42,
+                    "str": "hello",
+                    "bool": true,
+                    "list": [1, 2],
+                    "obj": {"key": "value"}
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            values: {
+                num: 42
+                str: "hello"
+                bool: true
+                list: [1, 2]
+                obj: { key: "value" }
+            }
+        }
+    }
+])
+
+apply MapOfDocuments @httpResponseTests([
+    {
+        id: "RpcV2JsonMapOfDocumentsDeserialize"
+        documentation: "Deserializes a map of mixed document types"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "values": {
+                    "num": 42,
+                    "str": "hello",
+                    "bool": true,
+                    "list": [1, 2],
+                    "obj": {"key": "value"}
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            values: {
+                num: 42
+                str: "hello"
+                bool: true
+                list: [1, 2]
+                obj: { key: "value" }
+            }
+        }
+    }
+])
+
+apply DocumentUnion @httpRequestTests([
+    {
+        id: "RpcV2JsonDocumentUnionDocumentValue"
+        documentation: "Serializes union with document value variant"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/DocumentUnion"
+        body: """
+            {
+                "value": {
+                    "documentValue": {"nested": "object", "count": 5}
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: {
+                documentValue: { nested: "object", count: 5 }
+            }
+        }
+    }
+])
+
+apply DocumentUnion @httpResponseTests([
+    {
+        id: "RpcV2JsonDocumentUnionDeserializeDocumentValue"
+        documentation: "Deserializes union with document value variant"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "documentValue": {"nested": "object", "count": 5}
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: {
+                documentValue: { nested: "object", count: 5 }
+            }
+        }
+    }
+])

--- a/smithy-protocol-tests/model/v2/rpcv2json/edges-test.smithy
+++ b/smithy-protocol-tests/model/v2/rpcv2json/edges-test.smithy
@@ -1,0 +1,427 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.corpus
+
+use smithy.protocols#rpcv2Json
+use smithy.test#InitialHttpRequest
+use smithy.test#eventStreamTests
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+apply ScalarMembers @httpRequestTests([
+    {
+        id: "RpcV2JsonScalarMembersArbitraryPrecision"
+        documentation: """
+            Serializes integers and decimals too large for int64/float64 as JSON
+            STRINGS, which is how this protocol keeps arbitrary precision intact
+            (a JSON number would be routed through a double by many parsers)"""
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ScalarMembers"
+        body: """
+            {
+                "bigIntegerMember": "1234567890123456789012345678901234567890",
+                "bigDecimalMember": "3.141592653589793238462643383279502884197"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        params: {
+            bigIntegerMember: 1234567890123456789012345678901234567890
+            bigDecimalMember: 3.141592653589793238462643383279502884197
+        }
+        tags: ["arbitrary-precision"]
+    }
+])
+
+apply ScalarMembers @httpResponseTests([
+    {
+        id: "RpcV2JsonScalarMembersArbitraryPrecisionDeserialize"
+        documentation: "Deserializes arbitrary-precision numbers without losing digits"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "bigIntegerMember": "1234567890123456789012345678901234567890",
+                "bigDecimalMember": "3.141592653589793238462643383279502884197"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            bigIntegerMember: 1234567890123456789012345678901234567890
+            bigDecimalMember: 3.141592653589793238462643383279502884197
+        }
+        tags: ["arbitrary-precision"]
+    }
+])
+
+apply ScalarMembers @httpRequestTests([
+    {
+        id: "RpcV2JsonScalarMembersNumericMinima"
+        documentation: "Serializes the minimum value of each integral type, including negatives"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ScalarMembers"
+        body: """
+            {
+                "byteMember": -128,
+                "shortMember": -32768,
+                "integerMember": -2147483648,
+                "longMember": -9007199254740993
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        params: { byteMember: -128, shortMember: -32768, integerMember: -2147483648, longMember: -9007199254740993 }
+        tags: ["numeric-boundaries"]
+    }
+    {
+        id: "RpcV2JsonScalarMembersNumericMaxima"
+        documentation: """
+            Serializes the maximum value of each integral type, plus a long above
+            2^53 and a double at full 17-significant-digit precision"""
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ScalarMembers"
+        body: """
+            {
+                "byteMember": 127,
+                "shortMember": 32767,
+                "integerMember": 2147483647,
+                "longMember": 9007199254740993,
+                "doubleMember": 123456789.12345679
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        params: {
+            byteMember: 127
+            shortMember: 32767
+            integerMember: 2147483647
+            longMember: 9007199254740993
+            doubleMember: 123456789.12345679
+        }
+        tags: ["numeric-boundaries"]
+    }
+])
+
+apply ScalarMembers @httpResponseTests([
+    {
+        id: "RpcV2JsonScalarMembersNumericMinimaDeserialize"
+        documentation: "Deserializes the minimum value of each integral type, including negatives"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "byteMember": -128,
+                "shortMember": -32768,
+                "integerMember": -2147483648,
+                "longMember": -9007199254740993
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { byteMember: -128, shortMember: -32768, integerMember: -2147483648, longMember: -9007199254740993 }
+        tags: ["numeric-boundaries"]
+    }
+    {
+        id: "RpcV2JsonScalarMembersNumericMaximaDeserialize"
+        documentation: "Deserializes maxima, a long above 2^53, and a full-precision double"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "byteMember": 127,
+                "shortMember": 32767,
+                "integerMember": 2147483647,
+                "longMember": 9007199254740993,
+                "doubleMember": 123456789.12345679
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            byteMember: 127
+            shortMember: 32767
+            integerMember: 2147483647
+            longMember: 9007199254740993
+            doubleMember: 123456789.12345679
+        }
+        tags: ["numeric-boundaries"]
+    }
+])
+
+apply ScalarMembers @httpRequestTests([
+    {
+        id: "RpcV2JsonScalarMembersStringEscaping"
+        documentation: "Escapes quotes, backslashes, control characters and preserves non-BMP text"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ScalarMembers"
+        body: """
+            {
+                "stringMember": "quote \\" backslash \\\\ newline \\n tab \\t control \\u0001 astral \\ud83d\\ude00"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        params: { stringMember: "quote \" backslash \\ newline \n tab \t control \u0001 astral \ud83d\ude00" }
+        tags: ["string-escaping"]
+    }
+])
+
+apply ScalarMembers @httpResponseTests([
+    {
+        id: "RpcV2JsonScalarMembersStringEscapingDeserialize"
+        documentation: "Unescapes quotes, backslashes, control characters and non-BMP text"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "stringMember": "quote \\" backslash \\\\ newline \\n tab \\t control \\u0001 astral \\ud83d\\ude00"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { stringMember: "quote \" backslash \\ newline \n tab \t control \u0001 astral \ud83d\ude00" }
+        tags: ["string-escaping"]
+    }
+])
+
+apply ScalarMembers @httpRequestTests([
+    {
+        id: "RpcV2JsonScalarMembersBlobPaddingOneByte"
+        documentation: "Base64-encodes a one-byte blob, which requires two padding characters"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ScalarMembers"
+        body: """
+            {
+                "blobMember": "Zg=="
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        params: { blobMember: "f" }
+        tags: ["blob-encoding"]
+    }
+    {
+        id: "RpcV2JsonScalarMembersBlobPaddingTwoBytes"
+        documentation: "Base64-encodes a two-byte blob, which requires one padding character"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ScalarMembers"
+        body: """
+            {
+                "blobMember": "Zm8="
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        params: { blobMember: "fo" }
+        tags: ["blob-encoding"]
+    }
+])
+
+apply ScalarMembers @httpResponseTests([
+    {
+        id: "RpcV2JsonScalarMembersBlobPaddingOneByteDeserialize"
+        documentation: "Decodes a base64 blob with two padding characters"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "blobMember": "Zg=="
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { blobMember: "f" }
+        tags: ["blob-encoding"]
+    }
+    {
+        id: "RpcV2JsonScalarMembersBlobPaddingTwoBytesDeserialize"
+        documentation: "Decodes a base64 blob with one padding character"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "blobMember": "Zm8="
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { blobMember: "fo" }
+        tags: ["blob-encoding"]
+    }
+])
+
+apply ScalarMembers @httpResponseTests([
+    {
+        id: "RpcV2JsonScalarMembersFractionalSecondsDeserialize"
+        documentation: "Preserves sub-second precision carried in the fraction of an epoch-seconds number"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "epochSecondsMember": 1609502096.123
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { epochSecondsMember: 1609502096.123 }
+        appliesTo: "client"
+        tags: ["timestamp-fractional-seconds"]
+    }
+])
+
+apply HttpErrorGone @httpResponseTests([
+    {
+        id: "RpcV2JsonErrorIgnoresErrorTypeHeader"
+        documentation: """
+            Resolves the error from the body's __type even when an
+            X-Amzn-ErrorType header names a different shape, because clients
+            MUST ignore that header under this protocol"""
+        protocol: rpcv2Json
+        code: 410
+        body: """
+            {
+                "__type": "smithy.protocoltests.corpus#HttpErrorGone",
+                "message": "resource was deleted",
+                "details": "deleted on 2021-01-01"
+            }"""
+        bodyMediaType: "application/json"
+        headers: {
+            "smithy-protocol": "rpc-v2-json"
+            "Content-Type": "application/json"
+            "X-Amzn-ErrorType": "smithy.protocoltests.corpus#HttpErrorConflict"
+        }
+        params: { message: "resource was deleted", details: "deleted on 2021-01-01" }
+        appliesTo: "client"
+        tags: ["error-discrimination"]
+    }
+    {
+        id: "RpcV2JsonErrorIgnoresCodeBodyField"
+        documentation: """
+            Resolves the error from __type even when Code and code body fields
+            name a different shape, because they MUST NOT be used to
+            distinguish which error is contained"""
+        protocol: rpcv2Json
+        code: 410
+        body: """
+            {
+                "__type": "smithy.protocoltests.corpus#HttpErrorGone",
+                "Code": "HttpErrorConflict",
+                "code": "HttpErrorServiceUnavailable",
+                "message": "resource was deleted",
+                "details": "deleted on 2021-01-01"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { message: "resource was deleted", details: "deleted on 2021-01-01" }
+        appliesTo: "client"
+        tags: ["error-discrimination"]
+    }
+])
+
+apply UnionOfScalars @httpResponseTests([
+    {
+        id: "RpcV2JsonUnionIgnoresUnrecognizedTypeMember"
+        documentation: "Ignores an unrecognized __type member alongside a union variant"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "__type": "smithy.protocoltests.corpus#NotARealShape",
+                    "stringValue": "union string"
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: { stringValue: "union string" }
+        }
+        appliesTo: "client"
+        tags: ["unknown-fields", "error-discrimination"]
+    }
+])
+
+apply EventStreamRequest @eventStreamTests([
+    {
+        id: "RpcV2JsonEventStreamRequestEnvelope"
+        documentation: """
+            A streaming request body uses the event stream media type, while
+            Accept stays application/json because this operation's response is
+            a buffered RPC response"""
+        protocol: rpcv2Json
+        initialRequest: {
+            method: "POST"
+            uri: "/service/RpcV2JsonCorpusTests/operation/EventStreamRequest"
+            headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/vnd.amazon.eventstream", Accept: "application/json" }
+        }
+        initialRequestShape: InitialHttpRequest
+    }
+])
+
+apply EventStreamResponse @eventStreamTests([
+    {
+        id: "RpcV2JsonEventStreamResponseEnvelope"
+        documentation: """
+            A buffered request that expects a streaming response sets Accept to
+            the event stream media type while its own Content-Type stays
+            application/json"""
+        protocol: rpcv2Json
+        initialRequest: {
+            method: "POST"
+            uri: "/service/RpcV2JsonCorpusTests/operation/EventStreamResponse"
+            headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/vnd.amazon.eventstream" }
+        }
+        initialRequestShape: InitialHttpRequest
+    }
+])
+
+apply NoInputOutput @httpRequestTests([
+    {
+        id: "RpcV2JsonNoInputServerAllowsEmptyJsonObject"
+        documentation: "Servers should accept an empty JSON object for an operation with no input"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/NoInputOutput"
+        body: "{}"
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        appliesTo: "server"
+    }
+    {
+        id: "RpcV2JsonNoInputServerAllowsEmptyBody"
+        documentation: """
+            Servers should accept an empty body for an operation with no input,
+            and must not fail merely because Accept is set"""
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/NoInputOutput"
+        body: ""
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        appliesTo: "server"
+    }
+])
+
+apply EventStreamResponse @eventStreamTests([
+    {
+        id: "RpcV2JsonEventStreamResponseArbitraryPrecision"
+        documentation: """
+            An event payload carries arbitrary-precision numbers as JSON STRINGS,
+            the same as a buffered body does, so the framing layer does not
+            reintroduce a double round-trip"""
+        protocol: rpcv2Json
+        events: [
+            {
+                type: "response"
+                params: {
+                    scalarsEvent: {
+                        bigIntegerMember: 1234567890123456789012345678901234567890
+                        bigDecimalMember: 3.141592653589793238462643383279502884197
+                    }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "scalarsEvent" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"bigIntegerMember":"1234567890123456789012345678901234567890","bigDecimalMember":"3.141592653589793238462643383279502884197"}"""
+                bodyMediaType: "application/json"
+            }
+        ]
+        tags: ["arbitrary-precision"]
+    }
+])

--- a/smithy-protocol-tests/model/v2/rpcv2json/eventstream-test.smithy
+++ b/smithy-protocol-tests/model/v2/rpcv2json/eventstream-test.smithy
@@ -1,0 +1,645 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.corpus
+
+use smithy.protocols#rpcv2Json
+use smithy.test#InitialHttpRequest
+use smithy.test#InitialHttpResponse
+use smithy.test#eventStreamTests
+
+apply EventStreamResponse @eventStreamTests([
+    {
+        id: "RpcV2JsonEventStreamResponseScalars"
+        documentation: "Deserializes an event whose implicit payload carries every scalar type"
+        protocol: rpcv2Json
+        events: [
+            {
+                type: "response"
+                params: {
+                    scalarsEvent: {
+                        booleanMember: true
+                        byteMember: 9
+                        shortMember: 512
+                        integerMember: 1234
+                        longMember: 9000000000
+                        floatMember: 1.5
+                        doubleMember: 2.25
+                        stringMember: "scalars event"
+                        blobMember: "foo"
+                        timestampMember: 1609502096
+                        stringEnum: "Foo"
+                        intEnum: 1
+                    }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "scalarsEvent" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"booleanMember":true,"byteMember":9,"shortMember":512,"integerMember":1234,"longMember":9000000000,"floatMember":1.5,"doubleMember":2.25,"stringMember":"scalars event","blobMember":"Zm9v","timestampMember":1609502096,"stringEnum":"Foo","intEnum":1}"""
+                bodyMediaType: "application/json"
+            }
+        ]
+    }
+    {
+        id: "RpcV2JsonEventStreamResponseList"
+        documentation: "Deserializes an event whose payload carries lists of scalars"
+        protocol: rpcv2Json
+        events: [
+            {
+                type: "response"
+                params: {
+                    listEvent: {
+                        strings: ["first", "second"]
+                        integers: [1, 2, 3]
+                        timestamps: [1609502096, 1609588496]
+                    }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "listEvent" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"strings":["first","second"],"integers":[1,2,3],"timestamps":[1609502096,1609588496]}"""
+                bodyMediaType: "application/json"
+            }
+        ]
+    }
+    {
+        id: "RpcV2JsonEventStreamResponseMap"
+        documentation: "Deserializes an event whose payload carries maps of scalars"
+        protocol: rpcv2Json
+        events: [
+            {
+                type: "response"
+                params: {
+                    mapEvent: {
+                        strings: { alpha: "first", beta: "second" }
+                        integers: { one: 1, two: 2 }
+                        timestamps: { start: 1609502096, end: 1609588496 }
+                    }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "mapEvent" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"strings":{"alpha":"first","beta":"second"},"integers":{"one":1,"two":2},"timestamps":{"start":1609502096,"end":1609588496}}"""
+                bodyMediaType: "application/json"
+            }
+        ]
+    }
+    {
+        id: "RpcV2JsonEventStreamResponseStruct"
+        documentation: "Deserializes an event whose payload nests a structure"
+        protocol: rpcv2Json
+        events: [
+            {
+                type: "response"
+                params: {
+                    structEvent: {
+                        value: { stringMember: "nestedString", integerMember: 55, booleanMember: true }
+                    }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "structEvent" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"value":{"stringMember":"nestedString","integerMember":55,"booleanMember":true}}"""
+                bodyMediaType: "application/json"
+            }
+        ]
+    }
+    {
+        id: "RpcV2JsonEventStreamResponseUnion"
+        documentation: "Deserializes an event whose payload nests a union"
+        protocol: rpcv2Json
+        events: [
+            {
+                type: "response"
+                params: {
+                    unionEvent: {
+                        value: { stringValue: "union event" }
+                    }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "unionEvent" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"value":{"stringValue":"union event"}}"""
+                bodyMediaType: "application/json"
+            }
+        ]
+    }
+    {
+        id: "RpcV2JsonEventStreamResponseMultipleEvents"
+        documentation: """
+            Dispatches a sequence of events to the correct union variants. The
+            heartbeat event models an empty structure, so it carries no payload
+            and therefore no :content-type header."""
+        protocol: rpcv2Json
+        events: [
+            {
+                type: "response"
+                params: {
+                    scalarsEvent: {
+                        booleanMember: true
+                        byteMember: 7
+                        shortMember: 300
+                        integerMember: 11
+                        longMember: 8000000001
+                        floatMember: 3.25
+                        doubleMember: 4.75
+                        stringMember: "first message"
+                        blobMember: "bar"
+                        timestampMember: 1609588496
+                        stringEnum: "Bar"
+                        intEnum: 2
+                    }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "scalarsEvent" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"booleanMember":true,"byteMember":7,"shortMember":300,"integerMember":11,"longMember":8000000001,"floatMember":3.25,"doubleMember":4.75,"stringMember":"first message","blobMember":"YmFy","timestampMember":1609588496,"stringEnum":"Bar","intEnum":2}"""
+                bodyMediaType: "application/json"
+            }
+            {
+                type: "response"
+                params: {
+                    heartbeatEvent: {}
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "heartbeatEvent" }
+                }
+            }
+            {
+                type: "response"
+                params: {
+                    listEvent: {
+                        strings: ["third", "fourth"]
+                        integers: [4, 5]
+                        timestamps: [1609674896, 1609761296]
+                    }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "listEvent" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"strings":["third","fourth"],"integers":[4,5],"timestamps":[1609674896,1609761296]}"""
+                bodyMediaType: "application/json"
+            }
+        ]
+    }
+])
+
+apply EventStreamResponseBlobPayload @eventStreamTests([
+    {
+        id: "RpcV2JsonEventStreamResponseBlobPayload"
+        documentation: """
+            A blob @eventPayload is written as the raw message payload, not
+            base64-encoded, and takes the application/octet-stream content
+            type. The modeled @eventHeader member is carried as a message
+            header and does not appear in the payload."""
+        protocol: rpcv2Json
+        events: [
+            {
+                type: "response"
+                params: {
+                    blobEvent: { contentType: "text/csv", data: "row1,row2" }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "blobEvent" }
+                    ":content-type": { string: "application/octet-stream" }
+                    contentType: { string: "text/csv" }
+                }
+                body: "row1,row2"
+                bodyMediaType: "application/octet-stream"
+            }
+        ]
+    }
+])
+
+apply EventStreamResponseHeaders @eventStreamTests([
+    {
+        id: "RpcV2JsonEventStreamResponseHeaders"
+        documentation: """
+            Each @eventHeader member is carried as a typed event stream message
+            header rather than in the payload, and a string @eventPayload takes
+            the text/plain content type."""
+        protocol: rpcv2Json
+        events: [
+            {
+                type: "response"
+                params: {
+                    headerEvent: {
+                        stringHeader: "headerString"
+                        integerHeader: 1234
+                        booleanHeader: true
+                        longHeader: 9000000000
+                        timestampHeader: 1609502096
+                        blobHeader: "header"
+                        body: "event payload text"
+                    }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "headerEvent" }
+                    ":content-type": { string: "text/plain" }
+                    stringHeader: { string: "headerString" }
+                    integerHeader: { integer: 1234 }
+                    booleanHeader: { boolean: true }
+                    longHeader: { long: 9000000000 }
+                    timestampHeader: { timestamp: 1609502096 }
+                    blobHeader: { blob: "aGVhZGVy" }
+                }
+                body: "event payload text"
+                bodyMediaType: "text/plain"
+            }
+        ]
+    }
+])
+
+apply EventStreamResponseImplicitPayload @eventStreamTests([
+    {
+        id: "RpcV2JsonEventStreamResponseImplicitPayload"
+        documentation: """
+            With no @eventPayload member, the remaining non-header members form
+            an implicit document payload. The @eventHeader member is excluded
+            from that payload and appears only as a message header."""
+        protocol: rpcv2Json
+        events: [
+            {
+                type: "response"
+                params: {
+                    dataEvent: {
+                        requestId: "request-91"
+                        content: "implicit payload content"
+                        count: 33
+                        nested: { stringMember: "nestedString", integerMember: 44, booleanMember: true }
+                    }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "dataEvent" }
+                    ":content-type": { string: "application/json" }
+                    requestId: { string: "request-91" }
+                }
+                body: """
+                    {"content":"implicit payload content","count":33,"nested":{"stringMember":"nestedString","integerMember":44,"booleanMember":true}}"""
+                bodyMediaType: "application/json"
+            }
+        ]
+    }
+])
+
+apply EventStreamError @eventStreamTests([
+    {
+        id: "RpcV2JsonEventStreamErrorModeled"
+        documentation: """
+            A modeled error event uses :message-type "exception" and names the
+            union member in :exception-type, and resolves to the modeled error
+            shape rather than a generic failure."""
+        protocol: rpcv2Json
+        events: [
+            {
+                type: "response"
+                params: {
+                    streamError: { message: "stream failed", code: 57 }
+                }
+                headers: {
+                    ":message-type": { string: "exception" }
+                    ":exception-type": { string: "streamError" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"message":"stream failed","code":57}"""
+                bodyMediaType: "application/json"
+            }
+        ]
+        expectation: {
+            failure: { errorId: StreamError }
+        }
+        appliesTo: "client"
+    }
+    {
+        id: "RpcV2JsonEventStreamErrorAfterMessage"
+        documentation: """
+            An error event arriving after successfully delivered events still
+            resolves to the modeled error shape, so the events preceding it
+            must not mask it."""
+        protocol: rpcv2Json
+        events: [
+            {
+                type: "response"
+                params: {
+                    messageEvent: { content: "delivered before failure", sequence: 66 }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "messageEvent" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"content":"delivered before failure","sequence":66}"""
+                bodyMediaType: "application/json"
+            }
+            {
+                type: "response"
+                params: {
+                    streamError: { message: "stream failed", code: 57 }
+                }
+                headers: {
+                    ":message-type": { string: "exception" }
+                    ":exception-type": { string: "streamError" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"message":"stream failed","code":57}"""
+                bodyMediaType: "application/json"
+            }
+        ]
+        expectation: {
+            failure: { errorId: StreamError }
+        }
+        appliesTo: "client"
+    }
+    {
+        id: "RpcV2JsonEventStreamErrorUnmodeled"
+        documentation: """
+            Clients must handle a structured but unmodeled error, which uses
+            :message-type "error" with the code and message carried entirely in
+            headers and no payload."""
+        protocol: rpcv2Json
+        events: [
+            {
+                type: "response"
+                headers: {
+                    ":message-type": { string: "error" }
+                    ":error-code": { string: "InternalFailure" }
+                    ":error-message": { string: "an unknown error occurred" }
+                }
+            }
+        ]
+        expectation: {
+            failure: {}
+        }
+        appliesTo: "client"
+    }
+])
+
+apply EventStreamRequest @eventStreamTests([
+    {
+        id: "RpcV2JsonEventStreamRequestSendMessage"
+        documentation: "Serializes a single struct-payload event onto a request stream"
+        protocol: rpcv2Json
+        events: [
+            {
+                type: "request"
+                params: {
+                    sendMessage: { content: "outbound message" }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "sendMessage" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"content":"outbound message"}"""
+                bodyMediaType: "application/json"
+            }
+        ]
+    }
+    {
+        id: "RpcV2JsonEventStreamRequestMultipleEvents"
+        documentation: """
+            Serializes a sequence of events onto a request stream, closing with
+            an empty-structure event that carries no payload and therefore no
+            :content-type header."""
+        protocol: rpcv2Json
+        events: [
+            {
+                type: "request"
+                params: {
+                    sendMessage: { content: "outbound message" }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "sendMessage" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"content":"outbound message"}"""
+                bodyMediaType: "application/json"
+            }
+            {
+                type: "request"
+                params: {
+                    sendMessage: { content: "second outbound message" }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "sendMessage" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"content":"second outbound message"}"""
+                bodyMediaType: "application/json"
+            }
+            {
+                type: "request"
+                params: {
+                    endStream: {}
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "endStream" }
+                }
+            }
+        ]
+    }
+])
+
+apply EventStreamInitialResponse @eventStreamTests([
+    {
+        id: "RpcV2JsonEventStreamInitialResponse"
+        documentation: """
+            Non-stream output members are delivered ahead of the stream. Under
+            rpcv2Json the operation's @httpHeader bindings are ignored, so they
+            travel in the payload of an initial-response event rather than in
+            HTTP response headers."""
+        protocol: rpcv2Json
+        initialResponse: {
+            code: 200
+            headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/vnd.amazon.eventstream" }
+        }
+        initialResponseParams: { sessionId: "session4a2f", timeout: 30 }
+        initialResponseShape: InitialHttpResponse
+        events: [
+            {
+                type: "response"
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "initial-response" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"sessionId":"session4a2f","timeout":30}"""
+                bodyMediaType: "application/json"
+            }
+            {
+                type: "response"
+                params: {
+                    scalarsEvent: { stringMember: "message after initial response", integerMember: 77 }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "scalarsEvent" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"stringMember":"message after initial response","integerMember":77}"""
+                bodyMediaType: "application/json"
+            }
+        ]
+    }
+])
+
+apply EventStreamInitialRequest @eventStreamTests([
+    {
+        id: "RpcV2JsonEventStreamInitialRequest"
+        documentation: """
+            Non-stream input members are sent ahead of the stream. Under rpcv2Json
+            the operation's @httpHeader bindings are ignored, so they travel in the
+            payload of an initial-request event rather than in HTTP headers."""
+        protocol: rpcv2Json
+        initialRequestParams: { requestId: "request-5f1c", priority: 7 }
+        initialRequest: {
+            method: "POST"
+            uri: "/service/RpcV2JsonCorpusTests/operation/EventStreamInitialRequest"
+            headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/vnd.amazon.eventstream", Accept: "application/json" }
+        }
+        initialRequestShape: InitialHttpRequest
+        events: [
+            {
+                type: "request"
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "initial-request" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"requestId":"request-5f1c","priority":7}"""
+                bodyMediaType: "application/json"
+            }
+            {
+                type: "request"
+                params: {
+                    sendMessage: { content: "after initial request" }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "sendMessage" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"content":"after initial request"}"""
+                bodyMediaType: "application/json"
+            }
+        ]
+    }
+])
+
+apply EventStreamDuplex @eventStreamTests([
+    {
+        id: "RpcV2JsonEventStreamDuplex"
+        documentation: """
+            A duplex stream carries both initial messages: the input members go out
+            in an initial-request event and the output members come back in an
+            initial-response event, each ahead of their own stream's events. Accept
+            and Content-Type are both the event stream media type."""
+        protocol: rpcv2Json
+        initialRequestParams: { requestId: "duplex-3ba9" }
+        initialRequest: {
+            method: "POST"
+            uri: "/service/RpcV2JsonCorpusTests/operation/EventStreamDuplex"
+            headers: {
+                "smithy-protocol": "rpc-v2-json"
+                "Content-Type": "application/vnd.amazon.eventstream"
+                Accept: "application/vnd.amazon.eventstream"
+            }
+        }
+        initialRequestShape: InitialHttpRequest
+        initialResponseParams: { sessionId: "duplex-session-77" }
+        initialResponse: {
+            code: 200
+            headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/vnd.amazon.eventstream" }
+        }
+        initialResponseShape: InitialHttpResponse
+        events: [
+            {
+                type: "request"
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "initial-request" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"requestId":"duplex-3ba9"}"""
+                bodyMediaType: "application/json"
+            }
+            {
+                type: "request"
+                params: {
+                    sendMessage: { content: "duplex outbound" }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "sendMessage" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"content":"duplex outbound"}"""
+                bodyMediaType: "application/json"
+            }
+            {
+                type: "response"
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "initial-response" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"sessionId":"duplex-session-77"}"""
+                bodyMediaType: "application/json"
+            }
+            {
+                type: "response"
+                params: {
+                    scalarsEvent: { stringMember: "duplex inbound", integerMember: 88 }
+                }
+                headers: {
+                    ":message-type": { string: "event" }
+                    ":event-type": { string: "scalarsEvent" }
+                    ":content-type": { string: "application/json" }
+                }
+                body: """
+                    {"stringMember":"duplex inbound","integerMember":88}"""
+                bodyMediaType: "application/json"
+            }
+        ]
+    }
+])

--- a/smithy-protocol-tests/model/v2/rpcv2json/httperror-test.smithy
+++ b/smithy-protocol-tests/model/v2/rpcv2json/httperror-test.smithy
@@ -1,0 +1,65 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.corpus
+
+use smithy.protocols#rpcv2Json
+use smithy.test#httpResponseTests
+
+apply HttpErrorConflict @httpResponseTests([
+    {
+        id: "RpcV2JsonHttpErrorConflictDeserialize"
+        documentation: """
+            Deserializes a client error whose @httpError(409) overrides the
+            default 400 status implied by @error("client")"""
+        protocol: rpcv2Json
+        code: 409
+        body: """
+            {
+                "__type": "smithy.protocoltests.corpus#HttpErrorConflict",
+                "message": "resource already exists"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { message: "resource already exists" }
+    }
+])
+
+apply HttpErrorGone @httpResponseTests([
+    {
+        id: "RpcV2JsonHttpErrorGoneDeserialize"
+        documentation: """
+            Deserializes a client error whose @httpError(410) overrides the
+            default 400 status, with more than one modeled member"""
+        protocol: rpcv2Json
+        code: 410
+        body: """
+            {
+                "__type": "smithy.protocoltests.corpus#HttpErrorGone",
+                "message": "resource was deleted",
+                "details": "deleted on 2021-01-01"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { message: "resource was deleted", details: "deleted on 2021-01-01" }
+    }
+])
+
+apply HttpErrorServiceUnavailable @httpResponseTests([
+    {
+        id: "RpcV2JsonHttpErrorServiceUnavailableDeserialize"
+        documentation: """
+            Deserializes a server error whose @httpError(503) overrides the
+            default 500 status implied by @error("server")"""
+        protocol: rpcv2Json
+        code: 503
+        body: """
+            {
+                "__type": "smithy.protocoltests.corpus#HttpErrorServiceUnavailable",
+                "message": "try again later",
+                "retryAfterSeconds": 42
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { message: "try again later", retryAfterSeconds: 42 }
+    }
+])

--- a/smithy-protocol-tests/model/v2/rpcv2json/main.smithy
+++ b/smithy-protocol-tests/model/v2/rpcv2json/main.smithy
@@ -1,0 +1,17 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.corpus
+
+use smithy.protocols#rpcv2Json
+
+@rpcv2Json
+@title("RpcV2 JSON Corpus Protocol Tests")
+service RpcV2JsonCorpusTests with [
+    CoreProtocolTestService
+    OptionalityProtocolTestService
+    DocumentProtocolTestService
+    EventStreamProtocolTestService
+    HttpErrorProtocolTestService
+    NamingProtocolTestService
+    MiscSerdeTraitProtocolTestService
+] {}

--- a/smithy-protocol-tests/model/v2/rpcv2json/miscserde-test.smithy
+++ b/smithy-protocol-tests/model/v2/rpcv2json/miscserde-test.smithy
@@ -1,0 +1,278 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.corpus
+
+use smithy.protocols#rpcv2Json
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+apply EndpointHostPrefix @httpRequestTests([
+    {
+        id: "RpcV2JsonEndpointHostPrefix"
+        documentation: """
+            Operations prepend a static prefix to the endpoint host when they
+            carry the @endpoint trait. Only the host is affected: the request
+            path still addresses the service and operation as usual."""
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/EndpointHostPrefix"
+        body: "{}"
+        bodyMediaType: "application/json"
+        host: "example.com"
+        resolvedHost: "data.example.com"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+    }
+])
+
+apply EndpointHostLabel @httpRequestTests([
+    {
+        id: "RpcV2JsonEndpointHostLabel"
+        documentation: """
+            The @hostLabel member is substituted into the @endpoint hostPrefix
+            AND still serialized into the request body — binding a member to
+            the host does not remove it from the payload."""
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/EndpointHostLabel"
+        body: """
+            {
+                "label": "bar"
+            }"""
+        bodyMediaType: "application/json"
+        host: "example.com"
+        resolvedHost: "data.bar.example.com"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: { label: "bar" }
+    }
+])
+
+apply IdempotencyTokenOp @httpRequestTests([
+    {
+        id: "RpcV2JsonIdempotencyTokenAutoFill"
+        documentation: "Automatically populates an idempotency token that was not set"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/IdempotencyTokenOp"
+        body: """
+            {
+                "token": "00000000-0000-4000-8000-000000000000"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        appliesTo: "client"
+    }
+    {
+        id: "RpcV2JsonIdempotencyTokenProvided"
+        documentation: "Uses an explicitly provided idempotency token as-is rather than generating one"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/IdempotencyTokenOp"
+        body: """
+            {
+                "token": "8a3e2f1c-5b6d-4e7f-8091-a2b3c4d5e6f7"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: { token: "8a3e2f1c-5b6d-4e7f-8091-a2b3c4d5e6f7" }
+    }
+])
+
+apply RequestCompressionOp @httpRequestTests([
+    {
+        id: "RpcV2JsonRequestCompressionGzip"
+        documentation: "Compression algorithm encoding is appended to the Content-Encoding header"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/RequestCompressionOp"
+        headers: {
+            "smithy-protocol": "rpc-v2-json"
+            "Content-Type": "application/json"
+            Accept: "application/json"
+            "Content-Encoding": "gzip"
+        }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            data: """
+                DET5w2onta019lTPCeLsrdlWLLmMCSRtJydsjLdmiurEenOVtdamJoWVIS5HiAuq4ly8DsLX45dgEXco
+                UXMV165WXbF1RohhGbYWMjXRaQoW9SLfcvXvf6G5mzWLKeaywnQ65KWTcdD04xy6oQS2gO4zun1GHZJf
+                2l6seEAYbD6kfDO0I6y4Hhz81qYtCzWe99dquiSrqyw3HSOZR03X3d0aA4gF7ENnlPbwxT3phKQJtfU5
+                WKVllatawTmxoIBF59Ge9PTXUIky6EJ7wRTouwdHSiYns38frHOBIzmMrMcxXK7kQn03rVf1JvXbgjsC
+                rpTcld0hGv1o1z4sSECUC0DrIr9h3GCkxEQqfQdd7oS85vVzumxHEmFANrQfwruhL9ooFX5N1hEmeggS
+                kkdnWi69rhrzfY5sCvzzUt3f579B7CBAXhvHXFhJejbQnZ6a6xmWTFKBHJ5ZcETULMXzoa7ngoi0F9Re
+                hirSRSxPXdpXPH67oxaHcaJWSG7nKoF6nfZh1xwWbr7dI1GWiKpcyhuZky2nXRxzSGsC1ycK16YfwEGM
+                RKPCCKQpFWIUrZn3bDvKWrZfo2cb8JWYDS9Sscz7oUFuboBltY8jZP7Lahw0TmCZ5LzRb8Sc4Tx81wQD
+                OdPoe5WG9gM74NfReTLIjSyzn6KEsIwMXYaUwPGSBL4jJc8oegzQwS5UphGBtD4XX0Mtl35w7OtlTQGh
+                8iwsVvbqav0mI8GHsFEPUpOerk59hYL0rBC0VLL6SWNRRE5zAoq2aA8Hh0yR1AqeasR1wU5snKyVjsGz
+                4ftR1WsKpVqNfLKBLXHveIMbycXuTcLLxA1CWD4LXzLyp3XODOhJrs3rTE1KA1F4tHc0UG36MnykEu3E
+                Bnwa1D2SntbK9XGKZ86JYX7a8GkC3ZiB309IoMd4HnWrKU02ssK6sYEvMPXX3ytEwRWjMRnSDjllYPY1
+                R4EUwnewzKOnnvMS9JtfSk6kxcai2snF3Lysnt2SdXORDMV0Wmy2wsjZt9FqgTgX5jv0F5eOGf9qrvUS
+                qAeHmT6L1wsDDkXmSnB2EwsszxxkastVjw8h6EfrGPQyIgjoJffa9NRbvKxUlG9qI7WMF2nVj68vhuWH
+                XshfIfH12RHxgwBI4o23yfHxDDw5yDmLrgkEhkKk8yObZaatLx7MOJ2YoDnpfRMiakZ6ZtB0ifFqJbPh
+                cQiORHpKQTjrdaY8sHfUdoAh0nuVPTzDXokw7DYrN9hraq0TykJe74mLcVjr61XBuuTf9SOmiG52tiCF
+                GohK9wmYNdWR3YgcQ9EUQEsfFcnMEhBgDXeXDfocZgsI3XucIRFt4C4UNCWVUyJvWMzJGhiFlYcV6bmB
+                5tX5jTn2sDnysG5hBbOgdUk1pbAY5nBg4f03mM6WRBwT4ahr80hy8fmoQVyn9e2KZpPQxvVSg4yHg75J
+                OgrpC95AtKJftph6xlCFZxsJUBHTWISfQFZKt5DqpVhgGO2Iq5IGNsaw4qLL3rVHC3edtmpFtkMJjUTc
+                juGK99fBiHs6dXAhgzlquSrk3BiAStHuN1FWNjMV15YdiHnCRexJ7j4W2XTgit5Syp2Vq4uhl93fkL5i
+                33IQT9BiqnhwYsDBZjh7q8cckZrETQ9CU1NOw8sHw3jOtTjRtIEZuPl5FnYBfbr7ROXQpcix7Hp0Q5f9
+                3YlgipkDi8t43ie8le1ZrVt9isKx5bcV4urondjdqhAj367HahTXewSkbvS32aQYs4ZO62te2COf6bol
+                lJ4u5N1oHu1te3Sx9XIjEK9xeWdpyQnACM6ClszT5L0zSD46iLFaTPggUT1emksOz7eisjVSxEtrZWn3
+                kFcpcxJU0PNK2XIGjaBZCWb9ewEX51B5GrA2LXta3IXm1EUOIaXEg1fTSrFfGRTxjEwQ5odkiLTesdtf
+                TFZ82A3Rt4MpYxkeeizMoKkS49sQWSuqQOr2qD0RHQV7jSZN7mVI4GCneD5dYHyWSxkFhkgaf7ssO7Er
+                JCcE7tt55myDxXAqaK33PhrgrCY7u5zMOzzuvktCIxIi4HEyDbLYk3npw27YzWc2CbK8zzl8CEAxcTnA
+                2daD1809BhzPXNHeKbYG2LwqMBQK2HJX2buC2Tfangk5C2IHiX1AhtXsj3OHkbushGacJRkxwzsrTRV7
+                Vq6PaYvdFgfwnuj85EaW1176UBP2HzNHpvjVE1gn55U095VQLCn3orbG1pyCKmI9KsIp5WX5xzDjLD0q
+                mCk8E1YuIZ1pFd5DMSpSj1UjvB62nPg0MxkAuQ3IcHiKk7ho7xYaOQ4DyBUZtMtvAMiXpzCHO6hrj0NL
+                opUg6lDVCI4Tvzx3hWKf068NqP6ftVpmRBXGfLbicUqYPIDhJF0XuNZrRH2DT1JH31ZPBnUjW43nRiW6
+                CToHZEoDygAFJoVwRCvL5xaKbsXKsXIvNYY7G7RbVMKHpU2m8mOY4CP1QC3ty2tYuWnEX7jXiqN4suBb
+                RQbBpJ2VeTWpBYZBRfrcASCThdrB1bd9ewl2AgYyiVsTz1VZuzACvtbHDyrmnYqHvcoq4QLfbdUGAItH
+                gJXF2smHcmDDpqBSASBuaj7kjqkBZAtVBCDQKJzp0PAxTc9GspScO6Yk7ZoFspQoRmG3cmGk8OFJFeW6
+                XhvQpnmhAOHV4iMPxhL5d5dKDgDs5R5Yawvd8yhi7Y0bK3o8jFMiifnfTlkxXCH7dCEttCO5pMtGffTX
+                DCC371LN9Zd01yo7k7gIwk7iNrPcKWT1QgWXypKYT3q7DlYE2pjmw0VP5ZvTPkLlgQjlZXM9U61x3kFo
+                Z3nQkORVTmgD2sIIKuVnYLlJejZaRCOG42jPAtKgnRdBWCjnvHnlJuToQjoudjkMAR2Os9R3j0Eek9dw
+                WOsc5XfSJxRbRxQD4zKtD3RmnFd4RHXMA0ZeU6Ixjfc905q9NXkFQ2LKF0B2jK5AlIpN3Vcq1F6XELoH
+                A692VBU2KMJ7lSm4G6DwNxQ6FdP61AF16Y1obgUZN2TDQg2BNqeqKNAR8fXZNjm0qk7QCUFXtaQgJFcg
+                k5KVJJaYD3MlhyN0R16kXJj3C9Ka0b6VY5ffPtYCEo0HyRcBnGwu3Zzns1WKOA1fbeow73PymWlIFZbA
+                n9fhtV7gqA1UgW1tJj3USQbRnq9LtqoRzXtnccztjeguy3ZTh2PAO1pOZo3a8IlLIIHWYMJr6384ANZi
+                7eJhxRlkbxLz5Nd9BRrrJuKQFYTx0sAHDUsPBdC1ZpExpcnzbB3izlyB2huWFD2Sf990tFfn6A72vZXb
+                e9YxhDuWsWMjt8PQ69jdF49lUE4Z9l7oCTEwKstTc65M9jxx0ViyXT4bx8fWil8mMMwMW5PZW1evIXiO
+                jcvL4oETa3LJjuJR6USyLWFkXM0tIKj11Q0tjFiiK1TLswNd0RYSXy3Ptl91br4XWYj3j8KterOxw7P6
+                g3Um2D5GeOw9De3YJv8Tj5wN22wNWGff5cUJuE9j8pZiKpLj6YFZXHTitiM9ESrc5Mf2DMzmNsubyUck
+                UByTtjzhRGxz4xEE4ZajTDA2q8445Ts2bDUPqr3r9Si00vcIBUmg5dUDeS2dNZkvjBVFsyQnuD2krROh
+                sXMH11XQmCdOF5wY0vTSr4c8LfTRLKO9TfjVsVL2OeJxrTGDG7tCpj3JJvBwQjLAu23OTY9Eah7nBFmU
+                exF5aCQsiYZnjG5VXAkFLhMPyUyPbkqjEDTwiNtlWzNXvNKeFTwNTLhgwWqnLsl7q5Q2QmIPdFIe7LrR
+                1PkD7zQdgNdmEUgOn0MRJMIvQuz24vf5y1xomiMmOigNXpGT8ffbqMKopYaRkySlmbK83ZjM5jHeuCkk
+                gXABE4yofg10R4pHrHOMMHSvOA6tHheZ9nQVMm9B45rllpwGXlCojpN7gHL4Ea5o2gtkOtMxBTw7wGrm
+                8kw1qoKlKeUl98u0Wpci6hc9T8dZQQ3X3WFMcxN5Bu1mUlBTWBeUIvT22c9owPcQAm2SI6mLo6it00uf
+                Ul2hjCLoMfPs3JFTdg3ah3Xg9HJoaJuXuiVCIwaaHgPWJxkVpemKVTzzT7ZmW4ONQbFic51EkPq6qQ3h
+                86zh5R3NyAnXSDNOiUThCevDNwbMlCRqK17AKLcAj0rAfsfVypHnkd9FKfTi1UqW4iat4rvDxdaXRvpa
+                OKjGOStCfZB0H0sNZsb6wILrdkbkQPfNQrI7SjL6f129RN4SUjU3Guumsxvdzug72RFQ8eT6M2vWWBso
+                xWEJlGWJzPGgaYpkJyAag9woYaWHi68hNAPlgJhzrFPLBjoEBziTpqtFCWbxGgPsMe27XOqMz47WPaOH
+                seF2cJ6qwJXkA6xzJaEIl3w2u111RvU23hfdP2zDSI3ARrS4gpJtlKFPEivurZwKNG10y04OQlkkzFkX
+                6rnWODYCfo1K0Rv6IACwJzGbZfP2c4WCH7E4oLGjuuTCjG4C87sACTHyGuzL1zpo69dnf17CkEPRkAFY
+                ZSxyXjJtuBt9ssqLsYOvcAAXce2Rz5Y5Ln4EDZ6xsDXBGeBpcLos8YvLLJoOenPjtLQcZWlkkv44jLQm
+                lMv46cfM12jrUrhhwTQMQ1lUm4JivnMU3CmnXQzUEjDpglZwGvWAqKvflHrAhC3Z8OqfW7YPiuveQcJe
+                d1k8xJJ4DPI1VqcvLjnXvbfEnQI8V8VLXSEg9bbvRMsIdJ2wekCgKBuGt8c44jAuJ9u68buugWOxx6HI
+                boeLcQaMHmsKRBLB6i8yVEGhgJWIeO3uwUnu6VBfGGeOmk0g5xgAIL7MZEHuRbIOL6HhJ6ot1MoL04yh
+                haS7Qn9uq83npjkY5SHhLhfSfHZOewI53CgJ0dlNE0yUT2cfXOq1FjMLeIogaQgSI1J6OAeJYko29bsf
+                NMW4uUvckyWksLts6brGkimFAaKQvmcmqyYyGvuC9hMZIxr78g7dpgtOgZwHZBbykog83jVjPOYoOS2m
+                evcbEV1LwDTPOTJPVlEIMjQFKe8hbNaQVdoAegkRFOBCRWTIXFtcR6RoeeCeDE1oRxlRdHn0BxUgpKzG
+                GcaSg7saU2IgqAKErONvtaYz0WKY7UBocggt0DBBEsfF7qEFvzRjCqVO7TYlMozi8aa6ftwyT51OU5AO
+                3oy8b1ECqpLrF4siIyfsZuKbauZb7h7q639nMOZrYQIaxcJbJTsIjA2ZD7J46B9Fw0iXuYRxuf0TtKhK
+                kgNz6BuAgHslFnEG9qAVIU0Ndd2GhcdHFs9XIj4XIEVjMfwSw5RNkJBhYpRxjW6DU63phbGbHECMa2JR
+                VWWh3FRzEpM52ING3MJBo0ADQfcMCzSIjOwPtmyBcgIhLOFy5EE1rQZVTuJWBPA5sEdXZ7wQijHfSCCI
+                0laD6U7Hl0oWPPzC4B0oMmAGXJuMoSSxa4VBhbY73akwAq0Z4o1tn5cKCzzwgD3X2VhpucN8r6CZ62gH
+                av9Yh5VK3BwTjBrr3geLzZRdNEK78qpTw5Re0SFr6dcpT19NcfUZuYgb6vuFTyZqPcywYo5h7xFdjh5l
+                WYdGcezH08usIwM4gQmFLPZXai33ttDT681bkZSRjeG7lHas34SoSRf8CoOmdzOtkmuucx1z5t2M9wUX
+                eBP5tPhJqdLz5RAdLQLjZJwiVFs7UDZv9zGFMeDpRtjO0CDmv1b0kCEDPFAzkTKErY2beFC1tPEfmmi3
+                kHyxpCfvi1NqjPaXJkVmV7ySY3PkXqs9sicy0Fi36c9LCVhJnmgEFslqPgChNfFOayvMs4O1iJHEHu6l
+                PZj0ydjWIJmY3oTMR2JtEAHUWNzTtzZTcl22hW7zvIibITTDkAN5ayszwWIDFYpheHuupLU3Ub45PhWc
+                wy4RTEzOFLcZ9tcDuJyfTFbkFHDcZ6Ev57LzQhtIje1uZ0ojZnVttDGqWlPhb1oEhx6yblnZwm5fCBz0
+                LDInqIibhHJkOoxd12kKCuvLF3529ur1JAdUCIEtLqRWEG4zf9tg4yCkLLLO0zr8LBeXqg8Fo5NvdAMM
+                erlP4Mw4iveQeZJmE0oYc5YDnRBFzWtIALGNY8PNUZikogqVDl6ep5hQS97Ucg3GDblOQub7hR4FxUC2
+                tp1hb1QK0L6qigWcrqoWphoeFxfdG0w2eVb6Hx8EocCmOo27IvKA1yfeiGdn01olIJbNu85wKFBFCX6U
+                tDHJb3M2oRlDOpXKCbAllELrtyS8LyNWIL40lWOByI7yp1M3HMDlZ0H5JWJHQGPaVNG2uHHf4afSse9R
+                qF3UfDfMxecRF8AhB3cwplqVx71egH6TmyHz2lQkyeSeP1NV0s4A6rDadNjeXiMiMhDgWORe0Hs19ZZy
+                HEfmCsq4CZb9TEpaHn6itMWp45JigMrWaSdlvZ3JsRT4NUQNySCTv43IrCz7kkdSfuVkyZ6sKGzUSvpO
+                DBY4tC9RBTVhZ53dJlsmjNKn9VwrMJNdOl6A6Xn2FUnIS38PzRvF4Pdm2C7KCedK6ZYReZZCEFumKSN2
+                sAnY3USiy8kkrgiSuXY27n0qh7HByNwtNPSWKyxbjQJ5EGFBBao3qLGgbO21IkRCR4nsml1wYB9zd07L
+                Cz4z6BZ08olg92PGBigAZHeyZIwZOVLVv2p3dmq3Ypp9St8uVJRn0cBRHfo5tW8BXLuWyLCBAvmmeKQ6
+                ZJQ1APnyfUPnupo1Jf2I3cpSm7QgkfCB77UN4DlTWu6xowgJ8I7qJAKCbgib7lkEwAjwJ28BiWTaZzdQ
+                mK4UR6vRZ194aVa4VeWKQVfaLd9reqnqgvZQTRrhGg5GbIMPRewE4vTugMv6UHzK7gmyTjvoZ0OcTU3u
+                2gnzRkbIeOOM14IU1IsaYsm1NinOQgWKmqm1dct9Rfge2OfCifcR7LD98EzsXCELz7hpSqeXqjtP6KLt
+                OTEqpW23EsDRJmKBqzKMMrsbQmG4XyasVDry7a3zGp0IULsmZguJQ7tw3VrQp9XJSYOtpQtLgSUANx0D
+                MfzQOGyVt5KXNOZonPeRDHzlDj08O67aoashn1c2rgghsfe8JLBQ0KqxsOqqukR68ZnsGXXxxHNIiK8w
+                KdFIlElpinKQnnzI46K8jrhqGPuS9RLVAJ9I6q111x2azkM5UCooU1TvZKgWV5fCH22PgDU7oTks8uU1
+                8NpkKGlVbPbb1QtEmYBE5fgg4w7kyLwlp8iVSD9DM1Jpa8H03nPqkvsQiJIWoSHEmOVPh2PLKc9tz8Vc
+                Cui8dZr7S2dlqxeRzcJfQksBBlVlOAGseScy6im2I4KVay6vyfR7AoIMkjBmsa778HbJNlTqhbhwirxr
+                jMo0XZBc1tRMaGFQuRAqIUPQq9HDGiGRvqRhtzovWYi6R5uN4E7eWicuPHm78MFXp9Rwb9nZhXQbuLQN
+                XWyg3Jm9H65M4u4zSbOK219fwP8FMwS9p6eZIE3mGTX5411Aj0O7tbUP8zURX3RoWKFby5Kxib796Ui6
+                xHvkH3BmgeeDGWpwo5VOli7kBb5QBUWuUXXu39MRFhTndR0KooIgJft2za3Gb6CDTW9J37UR4ZsGKjTK
+                8EktP6SduAotuFoOOUOsOzW0J9efvqfIGVVBV57Drf8iM3BmcPiVDKs5qYj6vXB8L4ROYxZlDN8Vi95t
+                ihFS8PnKoThX89VKpE892tLfQEwr5l1RH4zqo7vJJXLkFYNrdS4iNs7N5jigYk43Kavyheyaz9rRHSVr
+                JBgePbdKZqqy2surSGhRkpkQOcypb6zIBcW3Jshdw6pQTaO7Td43Lbb8T4PoXRrJxDmIuuDOOGf3TgqX
+                PPR4pwLy0gNS3UyHs6F0WijjThtH0081D4ay9JHxGZ9caCHJ0peF6daErfWC3Ykr4eoSFA6KHAR8mbHi
+                qEKJHLXGFo8H9kWAghP76PzOv2TJnw4caElApI7kcKvUyh3qvSqLnBVOjdKeL1VSIdXiFMnN7t0Kxj60
+                NzoVmsCxYQaFGTlhTERU52I0VBjaPFPSOVyP75ctBYZ9H39GDQKJVRf8fhCMcJ4M9WRUaeEEmNpJabOG
+                JB6B81voIBeOUcDPevsQoAren65q5DRIiGtdx3qrARUuRb6VSXKZYC9kxB1m7BaDyQZ0KoOhsmMOVw9w
+                XsWN5oLRPQa6P3onKfO5yQT90DuaLXXgLsEJXlwCOkh4UhXoEHYHoIiEo7mZoo0kCGvh8Dq22wtFzXun
+                Pozg29EqgKlSt4pputp2qGGDswE0O9purWwD6etQXLx0PEDrcDYMDZIXlrbAfOz8FwMF4oFoYXEPyMKy
+                kyuQjJEfFAujMwy4vkaZWldz4OWUuIZuVopv88AdVZ60s1xZ2VMSoSXnBfWmJyOKdj0sx8aRjq0rUfsZ
+                teo746FVDnhv68nXuLrXqC9q9q2NQig92WbzgBK3vfRWzihDl1uHftzeXXvNXIsMFh7uAguuq6Efs1sq
+                GIKtgRynyEymqIvJIseJYV7bHnwXmQkLdNK2WFB6NznVl2lLkxI69ZVxtifu9Hfs8xeKi0OrabVTBBSd
+                mw63GNSEczjdgbJNuTDXUffXDtXNywV7LU6DjSmSqnFnEg1eWRSoOneGXbLsq1BxU37uk48ovaQuB98G
+                KJDboTxPGOjLDCX6RTF1jQxUvSCsH3qPwFo8r3PK0KVFeYYHeWOZzwPFKbYEG8bGcmEUIrhuTL4XXljQ
+                AlMYgHvWbiDfNisfOukNzvlspTK32Vbn85CN9AVg1lKvOqqBhzPOz8umixDbXJc7fLee6toTqojl9nFc
+                my0AK0WfHGkeUzEQIHPFNmuszxKU7NBbdDVdWMCn37YEiFnD3xMs1vibyAOewTONc2QpzCgW9elVaMcp
+                eplGKAvVnQ3Zt5mjDWBJPH9HVjRdVU1kEexkPrYx9nqnywhxkMi8a0cB2OKjoWh6zdk8VfVTpENnssBI
+                j6kQ964zAVLJZ7vpzZefubVsQnHW9rcUfGSAmamDqL1WNGXraXgmN1skW4HQzvKRbMvWWvAIO9uTroqe
+                2YfHjzSEYIgLP7OmcPbx4N98bVLfBtpjjIpmXtHTuxMVohy4ilWrGKJR4UNqsih0U828KbCulApG0p4w
+                Vs179T0zzhoNdiSnJO3YGD9HxBdPLnLnafTcTimJx8TtWBaSBQrxLlcGssiX6ycZV3hQmEilphO4R2Wz
+                jQPYJ8x8DEijxHK3W4jFl7G6tHHRvn3Ng0y60RdWdV6QjDxzpCleFtVLqq51ftr4fxrlqqUg28FFDkvh
+                aZKMtyiHg48YKVL7KCPrX7XQm8nATGNwU2ssS8cwGCiA5YMJieeOrxqZS9nSJmubUUZclwmnNQGbgEUW
+                ZY8yZlc07fbLY3n14LUFBIeeUuRLakjLOE0bnnNF5Tn8ffAtbOzMyVboU3GSXhNlVE3unFu97WPxiK0X
+                Fqn9CY7tywU1jbhsZY8hoLAFbKQwjfpMJlZnetI3jiaKNu8w2xB0hEDI4QJdvtHyMUhGUfQJqYifzENo
+                sxjdtcVF9d50VPF35prVqFBokak3iHHHB3mDljUSsB7rncHABFqSlSqHhBDQc1AVKpW6cwShsaiMvNox
+                oDcrihiv05BNhxsR9m3nol0bka4Cb4Y4dVMa7eSXxlcZCvelsy7yy7dnOHlVcQSXIOZcgMr2ilKpjWoo
+                OIOEiIbsgYoPTwZNeDXlCUOjtWOu0vahNAf3Esb4wYhDzMxM6ouKjq79gUhXNIJsn54yKIdfYCahempd
+                8n9k2QiCnYopIdFNuw3UFXh8HsjKPTWJKvoJRMbs0ncstWoj1GzCjN2XW8njosw3UwhkgEPE6ghL4jMY
+                TvUQJ9HJKBFwEAtsYrKwDgq0Mw15LUCX3OaXP4bAYRxo0o7fbc66c5OTlZb9uD4lybPousMAMNrSxTuE
+                AHo0VcAK5reXVyKrqW8F9hEag2Y96Pur43cn8nkb7MRd1AuBOawzNiUTMm7yHzycBw5GRWr1DjyAcZrY
+                oanXHRWPup4zCHNY7X90QzA9EGF0HHc9cqqce4U80BjD6cPGqpyzPjiblp5DzRpHjm4O5H8apzyr52bO
+                4uMab8YLwvtbphuCg9G8PGhxaTTBaMZPnOjGRC8WE5aIZA3cA8tgcXh7oreEyoCOUv0gZ3zTmk9OjiYQ
+                Hd6fTMpNgHbzQt2Zed7lDgdSLOJDqOOfpSGLtfkuJTy0iYAb8FuyrTRoghB4j9bknumo9oVKKV1qKIyW
+                Ie0LMWtYXa4rXyrHc3dENE3oSAAUAveXBgwKxLk9BaCsFyEe6ijRyHBDIexrK7wV1KOEUfejBEPxDxHv
+                yNSzhLPDEGkQXW2XNu2smElTEBC1kMdwOk7XuCb78E4f3YVhhAtB1M8RcO5MOHcNi4dJ6D96gRExzC98
+                Z1zqFYYf36NZo0Pwr6jr66azrLqVmzXvxLbxwmNXdfER0v8mwkJp3CW7yytmJHiwDvTlIFnjGXTkJQrR
+                OITsWkpZj5TvM8Luf4EBAUcQuSX0Stt9wOxq44oo0mJN0kYyOGMPRRyHSv99vkxmVHRhq0rJRcAY7NcN
+                aBLIYT0XjNbxdOfgMuM737Bxl7lCGr9G9CpMtNBlVESehmnjDMbhlyzfWfeyGwlshNN4uHu21qgAbE9k"""
+        }
+    }
+])
+
+apply MediaTypeOp @httpRequestTests([
+    {
+        id: "RpcV2JsonMediaTypeSerialize"
+        documentation: """
+            A @mediaType string is serialized as an ordinary string. The trait
+            documents the contents for tooling and does not change the wire
+            form, so a JSON document carried in a string stays escaped rather
+            than being inlined into the surrounding body."""
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/MediaTypeOp"
+        body: """
+            {
+                "mediaTypeMember": "{\\\"nested\\\":true}"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: { mediaTypeMember: "{\"nested\":true}" }
+    }
+])
+
+apply MediaTypeOp @httpResponseTests([
+    {
+        id: "RpcV2JsonMediaTypeDeserialize"
+        documentation: "A @mediaType string is deserialized as an ordinary string, contents uninterpreted"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "mediaTypeMember": "{\\\"nested\\\":true}"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: { mediaTypeMember: "{\"nested\":true}" }
+    }
+])

--- a/smithy-protocol-tests/model/v2/rpcv2json/naming-test.smithy
+++ b/smithy-protocol-tests/model/v2/rpcv2json/naming-test.smithy
@@ -1,0 +1,513 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.corpus
+
+use smithy.protocols#rpcv2Json
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+apply NamedScalarMembers @httpRequestTests([
+    {
+        id: "RpcV2JsonNamedScalarMembersSerialize"
+        documentation: """
+            rpcv2Json ignores @jsonName and @xmlName, so every member
+            serializes under its own name even though both traits are present
+            on all of them"""
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/NamedScalarMembers"
+        body: """
+            {
+                "booleanMember": true,
+                "byteMember": 7,
+                "shortMember": 300,
+                "integerMember": 70000,
+                "longMember": 9000000000,
+                "floatMember": 3.25,
+                "doubleMember": 6.125,
+                "stringMember": "named",
+                "blobMember": "YmFy",
+                "timestampMember": 1609502096,
+                "enumMember": "Bar",
+                "intEnumMember": 2
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            booleanMember: true
+            byteMember: 7
+            shortMember: 300
+            integerMember: 70000
+            longMember: 9000000000
+            floatMember: 3.25
+            doubleMember: 6.125
+            stringMember: "named"
+            blobMember: "bar"
+            timestampMember: 1609502096
+            enumMember: "Bar"
+            intEnumMember: 2
+        }
+    }
+])
+
+apply NamedScalarMembers @httpResponseTests([
+    {
+        id: "RpcV2JsonNamedScalarMembersDeserialize"
+        documentation: """
+            rpcv2Json ignores @jsonName and @xmlName, so every member
+            deserializes from its own name even though both traits are present
+            on all of them"""
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "booleanMember": true,
+                "byteMember": 7,
+                "shortMember": 300,
+                "integerMember": 70000,
+                "longMember": 9000000000,
+                "floatMember": 3.25,
+                "doubleMember": 6.125,
+                "stringMember": "named",
+                "blobMember": "YmFy",
+                "timestampMember": 1609502096,
+                "enumMember": "Bar",
+                "intEnumMember": 2
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            booleanMember: true
+            byteMember: 7
+            shortMember: 300
+            integerMember: 70000
+            longMember: 9000000000
+            floatMember: 3.25
+            doubleMember: 6.125
+            stringMember: "named"
+            blobMember: "bar"
+            timestampMember: 1609502096
+            enumMember: "Bar"
+            intEnumMember: 2
+        }
+    }
+])
+
+apply NamedStructOfScalars @httpRequestTests([
+    {
+        id: "RpcV2JsonNamedStructOfScalarsSerialize"
+        documentation: "Serializes a nested structure whose members carry naming traits, which rpcv2Json ignores"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/NamedStructOfScalars"
+        body: """
+            {
+                "nested": {
+                    "stringMember": "nestedNamed",
+                    "integerMember": 91,
+                    "booleanMember": true,
+                    "timestampMember": 1609588496
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            nested: { stringMember: "nestedNamed", integerMember: 91, booleanMember: true, timestampMember: 1609588496 }
+        }
+    }
+])
+
+apply NamedStructOfScalars @httpResponseTests([
+    {
+        id: "RpcV2JsonNamedStructOfScalarsDeserialize"
+        documentation: "Deserializes a nested structure whose members carry naming traits, which rpcv2Json ignores"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "nested": {
+                    "stringMember": "nestedNamed",
+                    "integerMember": 91,
+                    "booleanMember": true,
+                    "timestampMember": 1609588496
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            nested: { stringMember: "nestedNamed", integerMember: 91, booleanMember: true, timestampMember: 1609588496 }
+        }
+    }
+])
+
+apply NamedListOfScalars @httpRequestTests([
+    {
+        id: "RpcV2JsonNamedListOfScalarsSerialize"
+        documentation: "Serializes lists under their member names, ignoring @jsonName and @xmlName"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/NamedListOfScalars"
+        body: """
+            {
+                "strings": ["alpha", "beta"],
+                "integers": [11, 22],
+                "timestamps": [1609502096, 1609588496]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            strings: ["alpha", "beta"]
+            integers: [11, 22]
+            timestamps: [1609502096, 1609588496]
+        }
+    }
+])
+
+apply NamedListOfScalars @httpResponseTests([
+    {
+        id: "RpcV2JsonNamedListOfScalarsDeserialize"
+        documentation: "Deserializes lists under their member names, ignoring @jsonName and @xmlName"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "strings": ["alpha", "beta"],
+                "integers": [11, 22],
+                "timestamps": [1609502096, 1609588496]
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            strings: ["alpha", "beta"]
+            integers: [11, 22]
+            timestamps: [1609502096, 1609588496]
+        }
+    }
+])
+
+apply NamedMapOfScalars @httpRequestTests([
+    {
+        id: "RpcV2JsonNamedMapOfScalarsSerialize"
+        documentation: "Serializes maps under their member names, ignoring @jsonName and @xmlName"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/NamedMapOfScalars"
+        body: """
+            {
+                "strings": {
+                    "stringKeyOne": "gamma",
+                    "stringKeyTwo": "delta"
+                },
+                "integers": {
+                    "integerKeyOne": 33,
+                    "integerKeyTwo": 44
+                },
+                "timestamps": {
+                    "timestampKeyOne": 1609674896,
+                    "timestampKeyTwo": 1609761296
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            strings: { stringKeyOne: "gamma", stringKeyTwo: "delta" }
+            integers: { integerKeyOne: 33, integerKeyTwo: 44 }
+            timestamps: { timestampKeyOne: 1609674896, timestampKeyTwo: 1609761296 }
+        }
+    }
+])
+
+apply NamedMapOfScalars @httpResponseTests([
+    {
+        id: "RpcV2JsonNamedMapOfScalarsDeserialize"
+        documentation: "Deserializes maps under their member names, ignoring @jsonName and @xmlName"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "strings": {
+                    "stringKeyOne": "gamma",
+                    "stringKeyTwo": "delta"
+                },
+                "integers": {
+                    "integerKeyOne": 33,
+                    "integerKeyTwo": 44
+                },
+                "timestamps": {
+                    "timestampKeyOne": 1609674896,
+                    "timestampKeyTwo": 1609761296
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            strings: { stringKeyOne: "gamma", stringKeyTwo: "delta" }
+            integers: { integerKeyOne: 33, integerKeyTwo: 44 }
+            timestamps: { timestampKeyOne: 1609674896, timestampKeyTwo: 1609761296 }
+        }
+    }
+])
+
+apply NamedUnionMembers @httpRequestTests([
+    {
+        id: "RpcV2JsonNamedUnionStringSerialize"
+        documentation: "Serializes the string variant of a union whose members carry naming traits, which rpcv2Json ignores"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/NamedUnionMembers"
+        body: """
+            {
+                "value": {
+                    "stringMember": "unionString"
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: { stringMember: "unionString" }
+        }
+    }
+    {
+        id: "RpcV2JsonNamedUnionIntegerSerialize"
+        documentation: "Serializes the integer variant of a union whose members carry naming traits, which rpcv2Json ignores"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/NamedUnionMembers"
+        body: """
+            {
+                "value": {
+                    "integerMember": 55
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: { integerMember: 55 }
+        }
+    }
+    {
+        id: "RpcV2JsonNamedUnionBooleanSerialize"
+        documentation: "Serializes the boolean variant of a union whose members carry naming traits, which rpcv2Json ignores"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/NamedUnionMembers"
+        body: """
+            {
+                "value": {
+                    "booleanMember": true
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: { booleanMember: true }
+        }
+    }
+    {
+        id: "RpcV2JsonNamedUnionListSerialize"
+        documentation: "Serializes the list variant of a union whose members carry naming traits, which rpcv2Json ignores"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/NamedUnionMembers"
+        body: """
+            {
+                "value": {
+                    "listMember": ["epsilon", "zeta"]
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: {
+                listMember: ["epsilon", "zeta"]
+            }
+        }
+    }
+    {
+        id: "RpcV2JsonNamedUnionMapSerialize"
+        documentation: "Serializes the map variant of a union whose members carry naming traits, which rpcv2Json ignores"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/NamedUnionMembers"
+        body: """
+            {
+                "value": {
+                    "mapMember": {
+                        "mapKeyOne": "eta",
+                        "mapKeyTwo": "theta"
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: {
+                mapMember: { mapKeyOne: "eta", mapKeyTwo: "theta" }
+            }
+        }
+    }
+    {
+        id: "RpcV2JsonNamedUnionStructSerialize"
+        documentation: "Serializes the structure variant of a union whose members carry naming traits, which rpcv2Json ignores"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/NamedUnionMembers"
+        body: """
+            {
+                "value": {
+                    "structMember": {
+                        "stringMember": "unionNested",
+                        "integerMember": 63,
+                        "booleanMember": true,
+                        "timestampMember": 1609674896
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            value: {
+                structMember: { stringMember: "unionNested", integerMember: 63, booleanMember: true, timestampMember: 1609674896 }
+            }
+        }
+    }
+])
+
+apply NamedUnionMembers @httpResponseTests([
+    {
+        id: "RpcV2JsonNamedUnionStringDeserialize"
+        documentation: "Deserializes the string variant of a union whose members carry naming traits, which rpcv2Json ignores"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "stringMember": "unionString"
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: { stringMember: "unionString" }
+        }
+    }
+    {
+        id: "RpcV2JsonNamedUnionIntegerDeserialize"
+        documentation: "Deserializes the integer variant of a union whose members carry naming traits, which rpcv2Json ignores"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "integerMember": 55
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: { integerMember: 55 }
+        }
+    }
+    {
+        id: "RpcV2JsonNamedUnionBooleanDeserialize"
+        documentation: "Deserializes the boolean variant of a union whose members carry naming traits, which rpcv2Json ignores"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "booleanMember": true
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: { booleanMember: true }
+        }
+    }
+    {
+        id: "RpcV2JsonNamedUnionListDeserialize"
+        documentation: "Deserializes the list variant of a union whose members carry naming traits, which rpcv2Json ignores"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "listMember": ["epsilon", "zeta"]
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: {
+                listMember: ["epsilon", "zeta"]
+            }
+        }
+    }
+    {
+        id: "RpcV2JsonNamedUnionMapDeserialize"
+        documentation: "Deserializes the map variant of a union whose members carry naming traits, which rpcv2Json ignores"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "mapMember": {
+                        "mapKeyOne": "eta",
+                        "mapKeyTwo": "theta"
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: {
+                mapMember: { mapKeyOne: "eta", mapKeyTwo: "theta" }
+            }
+        }
+    }
+    {
+        id: "RpcV2JsonNamedUnionStructDeserialize"
+        documentation: "Deserializes the structure variant of a union whose members carry naming traits, which rpcv2Json ignores"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "value": {
+                    "structMember": {
+                        "stringMember": "unionNested",
+                        "integerMember": 63,
+                        "booleanMember": true,
+                        "timestampMember": 1609674896
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            value: {
+                structMember: { stringMember: "unionNested", integerMember: 63, booleanMember: true, timestampMember: 1609674896 }
+            }
+        }
+    }
+])

--- a/smithy-protocol-tests/model/v2/rpcv2json/optionality-test.smithy
+++ b/smithy-protocol-tests/model/v2/rpcv2json/optionality-test.smithy
@@ -1,0 +1,499 @@
+$version: "2.0"
+
+namespace smithy.protocoltests.corpus
+
+use smithy.protocols#rpcv2Json
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+apply DefaultScalars @httpRequestTests([
+    {
+        id: "RpcV2JsonDefaultScalarsOmitsDefaults"
+        tags: ["top-level-default-omission"]
+        documentation: """
+            Client does not synthesize top-level input defaults. The members are
+            absent from params, so nothing is serialized: an explicitly provided
+            value is always sent, even when it equals the default, so this case
+            asserts the client does not fill them in on the caller's behalf."""
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/DefaultScalars"
+        body: """
+            {}"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        appliesTo: "client"
+        params: {}
+    }
+    {
+        id: "RpcV2JsonDefaultScalarsSerializeNonDefaults"
+        tags: ["explicit-over-default"]
+        documentation: "Serializes members when explicitly set to non-default values"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/DefaultScalars"
+        body: """
+            {
+                "defaultBoolean": true,
+                "defaultByte": 5,
+                "defaultShort": 10,
+                "defaultInteger": 42,
+                "defaultLong": 100,
+                "defaultFloat": 1.5,
+                "defaultDouble": 2.5,
+                "defaultString": "custom",
+                "defaultBlob": "aGVsbG8=",
+                "defaultEnum": "Bar",
+                "defaultIntEnum": 2,
+                "zeroBoolean": true,
+                "zeroByte": 1,
+                "zeroShort": 1,
+                "zeroInteger": 1,
+                "zeroLong": 1,
+                "zeroFloat": 1.0,
+                "zeroDouble": 1.0,
+                "emptyString": "not empty",
+                "emptyBlob": "YWJj"
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            defaultBoolean: true
+            defaultByte: 5
+            defaultShort: 10
+            defaultInteger: 42
+            defaultLong: 100
+            defaultFloat: 1.5
+            defaultDouble: 2.5
+            defaultString: "custom"
+            defaultBlob: "hello"
+            defaultEnum: "Bar"
+            defaultIntEnum: 2
+            zeroBoolean: true
+            zeroByte: 1
+            zeroShort: 1
+            zeroInteger: 1
+            zeroLong: 1
+            zeroFloat: 1.0
+            zeroDouble: 1.0
+            emptyString: "not empty"
+            emptyBlob: "abc"
+        }
+    }
+])
+
+apply DefaultScalars @httpResponseTests([
+    {
+        id: "RpcV2JsonDefaultScalarsPopulatesDefaultsOnDeserialize"
+        documentation: "Client fills default values when members are absent in response"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {}"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        appliesTo: "client"
+        params: {
+            defaultBoolean: false
+            defaultByte: 0
+            defaultShort: 0
+            defaultInteger: 0
+            defaultLong: 0
+            defaultFloat: 0
+            defaultDouble: 0
+            defaultString: ""
+            defaultBlob: ""
+            defaultEnum: "Foo"
+            defaultIntEnum: 1
+            zeroBoolean: false
+            zeroByte: 0
+            zeroShort: 0
+            zeroInteger: 0
+            zeroLong: 0
+            zeroFloat: 0
+            zeroDouble: 0
+            emptyString: ""
+            emptyBlob: ""
+        }
+    }
+])
+
+apply DefaultCollections @httpRequestTests([
+    {
+        id: "RpcV2JsonDefaultCollectionsOmitsEmptyDefaults"
+        tags: ["top-level-default-omission"]
+        documentation: """
+            Client does not synthesize the top-level empty list/map defaults. The
+            members are absent from params rather than explicitly set to [] and
+            {}, which would have to be serialized."""
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/DefaultCollections"
+        body: """
+            {}"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        appliesTo: "client"
+        params: {}
+    }
+    {
+        id: "RpcV2JsonDefaultCollectionsSerializeNonEmpty"
+        tags: ["explicit-over-default"]
+        documentation: "Serializes non-empty list and map"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/DefaultCollections"
+        body: """
+            {
+                "defaultList": ["a", "b"],
+                "defaultMap": {"key1": "value1", "key2": "value2"}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            defaultList: ["a", "b"]
+            defaultMap: { key1: "value1", key2: "value2" }
+        }
+    }
+])
+
+apply NestedDefaults @httpRequestTests([
+    {
+        id: "RpcV2JsonNestedDefaultsSerialize"
+        documentation: "Serializes nested structs with defaults populated"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/NestedDefaults"
+        body: """
+            {
+                "topLevel": {
+                    "nested": {
+                        "greeting": "hello",
+                        "count": 0,
+                        "inner": {
+                            "farewell": "goodbye"
+                        }
+                    },
+                    "nestedList": [
+                        {
+                            "greeting": "hi",
+                            "count": 5,
+                            "inner": {
+                                "farewell": "bye"
+                            }
+                        },
+                        {
+                            "greeting": "yo",
+                            "count": 6,
+                            "inner": {
+                                "farewell": "later"
+                            }
+                        }
+                    ],
+                    "nestedMap": {
+                        "entry1": {
+                            "greeting": "hey",
+                            "count": 10,
+                            "inner": {
+                                "farewell": "ciao"
+                            }
+                        },
+                        "entry2": {
+                            "greeting": "sup",
+                            "count": 11,
+                            "inner": {
+                                "farewell": "adios"
+                            }
+                        }
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            topLevel: {
+                nested: {
+                    greeting: "hello"
+                    count: 0
+                    inner: { farewell: "goodbye" }
+                }
+                nestedList: [
+                    {
+                        greeting: "hi"
+                        count: 5
+                        inner: { farewell: "bye" }
+                    }
+                    {
+                        greeting: "yo"
+                        count: 6
+                        inner: { farewell: "later" }
+                    }
+                ]
+                nestedMap: {
+                    entry1: {
+                        greeting: "hey"
+                        count: 10
+                        inner: { farewell: "ciao" }
+                    }
+                    entry2: {
+                        greeting: "sup"
+                        count: 11
+                        inner: { farewell: "adios" }
+                    }
+                }
+            }
+        }
+    }
+])
+
+apply NestedDefaults @httpResponseTests([
+    {
+        id: "RpcV2JsonNestedDefaultsDeserializePopulatesDefaults"
+        documentation: "Client fills defaults for absent nested fields"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "topLevel": {
+                    "nested": {},
+                    "nestedList": [{}, {}],
+                    "nestedMap": {
+                        "entry1": {},
+                        "entry2": {}
+                    }
+                }
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        appliesTo: "client"
+        params: {
+            topLevel: {
+                nested: { greeting: "hello", count: 0 }
+                nestedList: [
+                    {
+                        greeting: "hello"
+                        count: 0
+                    }
+                    {
+                        greeting: "hello"
+                        count: 0
+                    }
+                ]
+                nestedMap: {
+                    entry1: { greeting: "hello", count: 0 }
+                    entry2: { greeting: "hello", count: 0 }
+                }
+            }
+        }
+    }
+])
+
+apply RequiredMembers @httpRequestTests([
+    {
+        id: "RpcV2JsonRequiredMembersSerialize"
+        documentation: "Serializes all required fields"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/RequiredMembers"
+        body: """
+            {
+                "requiredString": "hello",
+                "requiredInteger": 42,
+                "requiredBoolean": true,
+                "requiredList": ["a", "b"],
+                "requiredMap": {"key1": "value1", "key2": "value2"},
+                "requiredStringWithDefault": "custom",
+                "requiredIntegerWithDefault": 5,
+                "requiredBooleanWithDefault": true,
+                "requiredListWithDefault": ["c", "d"],
+                "requiredMapWithDefault": {"k1": "v1", "k2": "v2"}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            requiredString: "hello"
+            requiredInteger: 42
+            requiredBoolean: true
+            requiredList: ["a", "b"]
+            requiredMap: { key1: "value1", key2: "value2" }
+            requiredStringWithDefault: "custom"
+            requiredIntegerWithDefault: 5
+            requiredBooleanWithDefault: true
+            requiredListWithDefault: ["c", "d"]
+            requiredMapWithDefault: { k1: "v1", k2: "v2" }
+        }
+    }
+])
+
+apply RequiredMembers @httpResponseTests([
+    {
+        id: "RpcV2JsonRequiredMembersDeserializeZeroValues"
+        tags: ["error-correction"]
+        documentation: "Client fills zero-values for required fields without defaults when server omits them"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {}"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        appliesTo: "client"
+        params: {
+            requiredString: ""
+            requiredInteger: 0
+            requiredBoolean: false
+            requiredList: []
+            requiredMap: {}
+            requiredStringWithDefault: "default"
+            requiredIntegerWithDefault: 0
+            requiredBooleanWithDefault: false
+            requiredListWithDefault: []
+            requiredMapWithDefault: {}
+        }
+    }
+    {
+        id: "RpcV2JsonRequiredMembersDeserializeDefaults"
+        tags: ["error-correction"]
+        documentation: "Client fills defaults for required fields with @default when server omits them"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "requiredString": "provided",
+                "requiredInteger": 1,
+                "requiredBoolean": true,
+                "requiredList": ["x", "y"],
+                "requiredMap": {"a": "b", "c": "d"}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        appliesTo: "client"
+        params: {
+            requiredString: "provided"
+            requiredInteger: 1
+            requiredBoolean: true
+            requiredList: ["x", "y"]
+            requiredMap: { a: "b", c: "d" }
+            requiredStringWithDefault: "default"
+            requiredIntegerWithDefault: 0
+            requiredBooleanWithDefault: false
+            requiredListWithDefault: []
+            requiredMapWithDefault: {}
+        }
+    }
+])
+
+apply NullSparseMembers @httpRequestTests([
+    {
+        id: "RpcV2JsonNullSparseMembersSerialize"
+        documentation: "Null values in sparse collections are serialized as JSON null"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/NullSparseMembers"
+        body: """
+            {
+                "sparseStringList": [null, "hello", null, "world", null],
+                "sparseStringMap": {"key1": null, "key2": "value", "key3": "value2"},
+                "sparseStructList": [null, {"stringMember": "a", "integerMember": 1, "booleanMember": true}, null, {"stringMember": "b", "integerMember": 2, "booleanMember": false}],
+                "sparseStructMap": {"key1": null, "key2": {"stringMember": "a", "integerMember": 1, "booleanMember": true}, "key3": {"stringMember": "b", "integerMember": 2, "booleanMember": false}}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        params: {
+            sparseStringList: [null, "hello", null, "world", null]
+            sparseStringMap: { key1: null, key2: "value", key3: "value2" }
+            sparseStructList: [
+                null
+                {
+                    stringMember: "a"
+                    integerMember: 1
+                    booleanMember: true
+                }
+                null
+                {
+                    stringMember: "b"
+                    integerMember: 2
+                    booleanMember: false
+                }
+            ]
+            sparseStructMap: {
+                key1: null
+                key2: { stringMember: "a", integerMember: 1, booleanMember: true }
+                key3: { stringMember: "b", integerMember: 2, booleanMember: false }
+            }
+        }
+    }
+])
+
+apply NullSparseMembers @httpResponseTests([
+    {
+        id: "RpcV2JsonNullSparseMembersDeserialize"
+        documentation: "Null values in sparse collections are preserved on deserialization"
+        protocol: rpcv2Json
+        code: 200
+        body: """
+            {
+                "sparseStringList": [null, "hello", null, "world", null],
+                "sparseStringMap": {"key1": null, "key2": "value", "key3": "value2"},
+                "sparseStructList": [null, {"stringMember": "a", "integerMember": 1, "booleanMember": true}, null, {"stringMember": "b", "integerMember": 2, "booleanMember": false}],
+                "sparseStructMap": {"key1": null, "key2": {"stringMember": "a", "integerMember": 1, "booleanMember": true}, "key3": {"stringMember": "b", "integerMember": 2, "booleanMember": false}}
+            }"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json" }
+        params: {
+            sparseStringList: [null, "hello", null, "world", null]
+            sparseStringMap: { key1: null, key2: "value", key3: "value2" }
+            sparseStructList: [
+                null
+                {
+                    stringMember: "a"
+                    integerMember: 1
+                    booleanMember: true
+                }
+                null
+                {
+                    stringMember: "b"
+                    integerMember: 2
+                    booleanMember: false
+                }
+            ]
+            sparseStructMap: {
+                key1: null
+                key2: { stringMember: "a", integerMember: 1, booleanMember: true }
+                key3: { stringMember: "b", integerMember: 2, booleanMember: false }
+            }
+        }
+    }
+])
+
+apply ClientOptionalDefaults @httpRequestTests([
+    {
+        id: "RpcV2JsonClientOptionalDefaultsNotPopulated"
+        tags: ["client-optional-default"]
+        documentation: "Client does not populate defaults for @clientOptional members"
+        protocol: rpcv2Json
+        method: "POST"
+        uri: "/service/RpcV2JsonCorpusTests/operation/ClientOptionalDefaults"
+        body: """
+            {}"""
+        bodyMediaType: "application/json"
+        headers: { "smithy-protocol": "rpc-v2-json", "Content-Type": "application/json", Accept: "application/json" }
+        requireHeaders: ["Content-Length"]
+        forbidHeaders: ["X-Amz-Target"]
+        appliesTo: "client"
+        params: {}
+    }
+])


### PR DESCRIPTION
Adds a new rpcv2json (+querycompatible) protocol test suite under our new corpus strategy.

Note that the models here do not build w/o https://github.com/smithy-lang/smithy/pull/3248.

Generated and ran these new tests against https://github.com/aws/smithy-go/pull/695.