### PR TITLE
Improve isTraitApplied performance on hot paths

### DIFF
--- a/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/Model.java
@@ -681,7 +681,8 @@ public final class Model implements ToSmithyBuilder<Model> {
      * @return Returns true if the trait was used in the model.
      */
     public boolean isTraitApplied(Class<? extends Trait> trait) {
-        return !getShapesWithTrait(trait).isEmpty();
+        Map<Class<? extends Trait>, Set<Shape>> mappings = getTraitCache().traitsToShapes;
+        return mappings.containsKey(trait);
     }
 
     /**


### PR DESCRIPTION


#### Background
Avoid constructing an immutable `Set` and the extra `getOrDefault`/`isEmpty` calls in `isTraitApplied`. By construction, the `traitsToShapes` cache only contains a key when at least one shape has that trait applied, so a simple `containsKey` check is equivalent and cheaper.

#### Testing
* How did you test these changes?

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
