### PR TITLE
Fix input compatibility detection for required fields

### DIFF
--- a/.changes/next-release/bugfix-62f84c697df4536320c419bead3d9ca60d698904.json
+++ b/.changes/next-release/bugfix-62f84c697df4536320c419bead3d9ca60d698904.json
@@ -1,5 +1,7 @@
 {
   "type": "bugfix",
   "description": "Fixed smithy-diff to report adding `@required` to an existing member of an `@input` structure as backward-incompatible because it tightens authoritative input validation.",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3259](https://github.com/smithy-lang/smithy/pull/3259)"
+  ]
 }

--- a/.changes/next-release/bugfix-62f84c697df4536320c419bead3d9ca60d698904.json
+++ b/.changes/next-release/bugfix-62f84c697df4536320c419bead3d9ca60d698904.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "description": "Fixed smithy-diff to report adding `@required` to an existing member of an `@input` structure as backward-incompatible because it tightens authoritative input validation.",
+  "pull_requests": []
+}

--- a/designs/defaults-and-model-evolution.md
+++ b/designs/defaults-and-model-evolution.md
@@ -496,6 +496,13 @@ non-nullable because those members can never remove the `@required` trait.
 Not observing these optionality affordances runs the risk of previously
 generated code breaking when a model is updated in the future.
 
+Implicit client optionality only controls generated types. It does not weaken
+the `@required` trait during authoritative validation. Adding `@required` to an
+existing member of an `@input` structure is therefore backward incompatible if
+the service previously accepted requests that omitted the member. A service
+that is only correcting its model to describe an already-enforced requirement
+can explicitly suppress the corresponding compatibility event.
+
 Organizations that want stricter optionality controls over inputs can choose to
 not use the `@input` trait.
 

--- a/docs/source-2.0/guides/evolving-models.rst
+++ b/docs/source-2.0/guides/evolving-models.rst
@@ -66,8 +66,8 @@ The following changes to structure shapes are backward-compatible:
 #. Removing the :ref:`required-trait` from a structure member that is
    marked with the :ref:`clientOptional-trait`.
 #. Adding the :ref:`required-trait` to a member of a structure if the member
-   is marked as ``clientOptional`` or the structure is marked with the ``input``
-   trait.
+   is explicitly marked as ``clientOptional`` and the service already requires
+   the member.
 #. Adding or removing the :ref:`input-trait` from a structure is generally
    backward incompatible.
 
@@ -84,8 +84,10 @@ The following changes to a structure are not backward-compatible:
 #. Renaming a member.
 #. Removing a member.
 #. Changing the shape targeted by a member.
-#. Adding the :ref:`required-trait` to a member that was not previously
-   marked with the :ref:`clientOptional-trait`.
+#. Adding the :ref:`required-trait` to an existing member if this tightens
+   authoritative validation. This can cause previously valid data to be
+   rejected regardless of whether the member is explicitly or implicitly
+   :ref:`clientOptional <clientOptional-trait>`.
 #. Removing the :ref:`default-trait` from a member.
 #. Adding the :ref:`default-trait` to a member that was not previously marked
    with the :ref:`required-trait`.

--- a/docs/source-2.0/spec/type-refinement-traits.rst
+++ b/docs/source-2.0/spec/type-refinement-traits.rst
@@ -449,6 +449,11 @@ as well). This gives service teams the ability to remove the ``@required``
 trait from top-level input members and loosen requirements without risking
 breaking previously generated clients.
 
+Implicit client optionality only affects generated types; it does not make the
+``@required`` trait optional during authoritative validation. Adding
+``@required`` to an existing input member is therefore backward incompatible if
+the service previously accepted requests that omitted the member.
+
 
 .. smithy-trait:: smithy.api#output
 .. _output-trait:

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedNullability.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/ChangedNullability.java
@@ -16,6 +16,7 @@ import software.amazon.smithy.diff.Differences;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.knowledge.NullableIndex;
+import software.amazon.smithy.model.knowledge.NullableIndex.CheckMode;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -32,8 +33,10 @@ import software.amazon.smithy.model.validation.ValidationEvent;
 /**
  * Validates that only backward compatible changes are made to
  * structure member nullability to ensure that if something was
- * previously nullable to clients then it continue to be nullable
- * and vice versa.
+ * previously nullable to clients then it continues to be nullable
+ * and vice versa. Also detects when a member of an input structure
+ * becomes required for authoritative validation while remaining
+ * optional in generated types.
  */
 public final class ChangedNullability extends AbstractDiffEvaluator {
     @Override
@@ -47,13 +50,21 @@ public final class ChangedNullability extends AbstractDiffEvaluator {
                 differences.changedShapes(MemberShape.class),
                 // Get members of structures that added/removed the input trait.
                 changedInputMembers(differences)).forEach(change -> {
-                    // If NullableIndex says the nullability of a member changed, then that's a breaking change.
+                    // Detect changes to generated type nullability using the default client mode.
                     MemberShape oldShape = change.getOldShape();
                     MemberShape newShape = change.getNewShape();
                     boolean wasNullable = oldIndex.isMemberNullable(oldShape);
                     boolean isNowNullable = newIndex.isMemberNullable(newShape);
+                    // Input members remain client-optional after adding required, but authoritative
+                    // validation becomes stricter when the member did not already have a default.
+                    boolean becameRequiredForValidation = hasInputTrait(differences.getNewModel(), newShape)
+                            && change.isTraitAdded(RequiredTrait.ID)
+                            && oldIndex.isMemberNullable(oldShape, CheckMode.SERVER)
+                            && !newIndex.isMemberNullable(newShape, CheckMode.SERVER);
                     if (wasNullable != isNowNullable) {
                         createErrors(differences, change, wasNullable, events);
+                    } else if (becameRequiredForValidation) {
+                        addAddedRequiredTraitToInput(change, events);
                     }
                 });
 
@@ -161,6 +172,22 @@ public final class ChangedNullability extends AbstractDiffEvaluator {
         }
 
         events.addAll(eventsToAdd);
+    }
+
+    private void addAddedRequiredTraitToInput(
+            ChangedShape<MemberShape> change,
+            Collection<ValidationEvent> events
+    ) {
+        MemberShape oldMember = change.getOldShape();
+        events.add(emit(
+                Severity.ERROR,
+                "AddedRequiredTraitToInput",
+                change.getShapeId(),
+                oldMember.getSourceLocation(),
+                String.format(
+                        "Member `%s` changed from optional to required for authoritative validation",
+                        oldMember.getMemberName()),
+                "Previously valid requests that omit this member may now be rejected."));
     }
 
     private void addRemovedInputTrait(

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedNullabilityTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/ChangedNullabilityTest.java
@@ -135,6 +135,91 @@ public class ChangedNullabilityTest {
     }
 
     @Test
+    public void detectsAddingRequiredTraitToInputMember() {
+        SourceLocation memberSource = new SourceLocation("a.smithy", 5, 6);
+        StringShape target = StringShape.builder().id("smithy.example#Str").build();
+        StructureShape oldInput = StructureShape.builder()
+                .addTrait(new InputTrait())
+                .id("smithy.example#OperationInput")
+                .addMember("id", target.getId(), member -> member.source(memberSource))
+                .build();
+        StructureShape newInput = oldInput.toBuilder()
+                .addMember("id", target.getId(), member -> {
+                    member.source(memberSource);
+                    member.addTrait(new RequiredTrait());
+                })
+                .build();
+        Model oldModel = Model.builder().addShapes(target, oldInput).build();
+        Model newModel = Model.builder().addShapes(target, newInput).build();
+
+        ModelDiff.Result result = ModelDiff.builder().oldModel(oldModel).newModel(newModel).compare();
+        List<ValidationEvent> events = TestHelper.findEvents(
+                result.getDiffEvents(),
+                "ChangedNullability.AddedRequiredTraitToInput");
+
+        assertThat(result.isDiffBreaking(), is(true));
+        assertThat(events, hasSize(1));
+        assertThat(events.get(0).getSeverity(), is(Severity.ERROR));
+        assertThat(events.get(0).getShapeId().get(), is(oldInput.getMember("id").get().getId()));
+        assertThat(events.get(0).getSourceLocation(), is(memberSource));
+        assertThat(events.get(0).getMessage(),
+                equalTo("Member `id` changed from optional to required for authoritative validation: "
+                        + "Previously valid requests that omit this member may now be rejected."));
+    }
+
+    @Test
+    public void detectsAddingRequiredTraitToInlineInputMember() {
+        String oldModelText = "$version: \"2\"\n"
+                + "namespace smithy.example\n"
+                + "operation GetItem {\n"
+                + "    input := {\n"
+                + "        id: String\n"
+                + "    }\n"
+                + "}\n";
+        String newModelText = "$version: \"2\"\n"
+                + "namespace smithy.example\n"
+                + "operation GetItem {\n"
+                + "    input := {\n"
+                + "        @required\n"
+                + "        id: String\n"
+                + "    }\n"
+                + "}\n";
+        Model oldModel = Model.assembler().addUnparsedModel("old.smithy", oldModelText).assemble().unwrap();
+        Model newModel = Model.assembler().addUnparsedModel("new.smithy", newModelText).assemble().unwrap();
+
+        ModelDiff.Result result = ModelDiff.builder().oldModel(oldModel).newModel(newModel).compare();
+        List<ValidationEvent> events = TestHelper.findEvents(
+                result.getDiffEvents(),
+                "ChangedNullability.AddedRequiredTraitToInput");
+
+        assertThat(result.isDiffBreaking(), is(true));
+        assertThat(events, hasSize(1));
+        assertThat(events.get(0).getShapeId().get(), is(ShapeId.from("smithy.example#GetItemInput$id")));
+    }
+
+    @Test
+    public void addingRequiredTraitToInputMemberWithDefaultIsOk() {
+        StringShape target = StringShape.builder().id("smithy.example#Str").build();
+        StructureShape oldInput = StructureShape.builder()
+                .addTrait(new InputTrait())
+                .id("smithy.example#OperationInput")
+                .addMember("id", target.getId(), member -> member.addTrait(new DefaultTrait(Node.from("default"))))
+                .build();
+        StructureShape newInput = oldInput.toBuilder()
+                .addMember("id", target.getId(), member -> {
+                    member.addTrait(new DefaultTrait(Node.from("default")));
+                    member.addTrait(new RequiredTrait());
+                })
+                .build();
+        Model oldModel = Model.builder().addShapes(target, oldInput).build();
+        Model newModel = Model.builder().addShapes(target, newInput).build();
+
+        List<ValidationEvent> events = ModelDiff.compare(oldModel, newModel);
+
+        assertThat(TestHelper.findEvents(events, "ChangedNullability.AddedRequiredTraitToInput"), empty());
+    }
+
+    @Test
     public void detectsInvalidRemovalOfRequired() {
         SourceLocation memberSource = new SourceLocation("a.smithy", 7, 7);
         StringShape s = StringShape.builder().id("smithy.example#Str").build();


### PR DESCRIPTION
#### Background
* What do these changes do?
* Why are they important? 

Fixed `smithy-diff` to report adding `@required` to an existing member of an `@input` structure as backward-incompatible because it tightens authoritative input validation.

Checkout #3203 for some context, it does feel like it is a bug to me:
- when adding a `@required` to field in the `@input`, it is marked as breaking change
- when first adding a member to the `@input` and then later marking it as `@required` isn't considered a breaking change (the same outcome essentially - these who didn't provide the field will be rejected)

It does feel marking an existing field as required should be a breaking change because none of the existing calls which do not provide such now "required" field will be rejected by the authoritative validation.

If the maintainers don't think it is a breaking change, could you provide some context on this please? Probably in the ticket since it has more context and might be searchable by others.

Thanks!

#### Testing
* How did you test these changes?

Added tests.

#### Links
* Links to additional context, if necessary
* Issue #3203, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
