### PR TITLE
Update stale error message for AddedRequiredMember

### DIFF
--- a/.changes/next-release/feature-91e1d87e4ea4ee39e7ef915c49abcfc2fef2288d.json
+++ b/.changes/next-release/feature-91e1d87e4ea4ee39e7ef915c49abcfc2fef2288d.json
@@ -1,0 +1,7 @@
+{
+  "type": "feature",
+  "description": "Update stale error message for AddedRequiredMember",
+  "pull_requests": [
+    "[#3261](https://github.com/smithy-lang/smithy/pull/3261)"
+  ]
+}

--- a/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedRequiredMember.java
+++ b/smithy-diff/src/main/java/software/amazon/smithy/diff/evaluators/AddedRequiredMember.java
@@ -49,7 +49,8 @@ public class AddedRequiredMember extends AbstractDiffEvaluator {
                 .id(getEventId())
                 .shape(memberShape)
                 .message("Adding a new member with the `required` trait "
-                        + "but not the `default` trait is backwards-incompatible.")
+                        + "but not the `default` trait or the `clientOptional` trait "
+                        + "is backwards-incompatible.")
                 .severity(Severity.ERROR)
                 .build();
     }

--- a/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedRequiredMemberTest.java
+++ b/smithy-diff/src/test/java/software/amazon/smithy/diff/evaluators/AddedRequiredMemberTest.java
@@ -53,7 +53,7 @@ public class AddedRequiredMemberTest {
                 equalTo("smithy.example#A$foo"));
         assertThat(TestHelper.findEvents(result.getDiffEvents(), "AddedRequiredMember").get(0).getMessage(),
                 equalTo("Adding a new member with the `required` trait " +
-                        "but not the `default` trait is backwards-incompatible."));
+                        "but not the `default` trait or the `clientOptional` trait is backwards-incompatible."));
         assertThat(TestHelper.findEvents(result.getDiffEvents(), "AddedRequiredMember").get(0).getSourceLocation(),
                 equalTo(source));
     }


### PR DESCRIPTION
#### Background
Current error message only mentioned about adding new required member without default trait, #3166 added condition check for `clientOptional` but the error message did not mention about this. This PR updated the error message so that customers can have correct options to remedy the `AddedRequiredMember` violation.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
