### PR TITLE
Better gradle practices for adding Smithy generated content to the so…

### DIFF
--- a/docs/source-2.0/languages/java/client/generating-clients.rst
+++ b/docs/source-2.0/languages/java/client/generating-clients.rst
@@ -110,20 +110,12 @@ Gradle build script:
 
     // Add generated Java sources to the main sourceSet so they are compiled alongside
     // any other Java code in your package
-    afterEvaluate {
-        val clientPath = smithy.getPluginProjectionPath(smithy.sourceProjection.get(), "java-codegen")
-        sourceSets {
-            main {
-                java {
-                    srcDir(clientPath)
-                }
-            }
-        }
-    }
+    val javaCodegenDir = smithy.outputDirectory.dir(smithy.sourceProjection.map { "$it/java-codegen" })
+    val smithyBuild = tasks.named<SmithyBuildTask>("smithyBuild")
 
-    // Ensure client files are generated before java compilation is executed.
-    tasks.named("compileJava") {
-        dependsOn("smithyBuild")
+    sourceSets.main {
+        java.srcDir(files(javaCodegenDir.map { it.dir("java") }).builtBy(smithyBuild))
+        resources.srcDir(files(javaCodegenDir.map { it.dir("resources") }).builtBy(smithyBuild))
     }
 
 ---------------


### PR DESCRIPTION
…urceSets

This version is lazy and avoids the bad practice of using `dependsOn` and `afterEvaluate`


#### Background
* What do these changes do? 
 Use lazy evaluation and avoid Gradle bad practices.
* Why are they important?
 Improve compatibility with Gradle's configuration cache

#### Testing
* How did you test these changes?
 As these are recommendations for your project build scripts, these are what I use instead of the previous recommendations.
 
#### Links
* Links to additional context, if necessary
https://docs.gradle.org/current/userguide/best_practices_general.html#avoid_after_evaluate
https://docs.gradle.org/current/userguide/best_practices_tasks.html#avoid_depends_on

* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
