### PR TITLE
Resolve endpoint rule-set components against the model's classloader

### DIFF
--- a/.changes/next-release/bugfix-1dfc85864a034d3dbcb1279b8e90b667c767cddd.json
+++ b/.changes/next-release/bugfix-1dfc85864a034d3dbcb1279b8e90b667c767cddd.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Resolve endpoint rule-set components against the model's classloader",
+  "pull_requests": [
+    "[#3267](https://github.com/smithy-lang/smithy/pull/3267)"
+  ]
+}

--- a/adr/0001-endpoint-rule-set-classloader-resolution.md
+++ b/adr/0001-endpoint-rule-set-classloader-resolution.md
@@ -1,0 +1,155 @@
+# 0001. Resolve endpoint rule-set components against the model's classloader
+
+* Status: Accepted
+* Date: 2026-08-26
+* Deciders: Smithy maintainers
+
+## Context and Problem Statement
+
+Endpoint rule-set functions (for example `aws.partition`), built-in parameters
+(for example `AWS::Region`), and auth-scheme validators (for example `sigv4`)
+are contributed by `EndpointRuleSetExtension` service providers discovered
+through the JDK `ServiceLoader`. The AWS providers live in `smithy-aws-endpoints`,
+separate from `smithy-rules-engine`.
+
+`EndpointRuleSet` discovered these providers using
+`EndpointRuleSet.class.getClassLoader()`, that is, the classloader that loaded
+the rules engine itself. When a caller assembles a model with an explicit
+classloader (`Model.assembler(classLoader)`) whose closure contains the
+providers, that closure classloader is typically a child of the classloader
+that loaded the rules engine. A parent classloader cannot see providers that
+exist only in a child. As a result, assembling such a model failed with
+`` `aws.partition` is not a valid function `` and
+`` `AWS::Region` built-in used is not registered ``, and produced spurious
+`Did not find a validator for the `sigv4` auth scheme` warnings.
+
+This affects any consumer that assembles models with a custom classpath: build
+tools that isolate a dependency closure, IDEs, application servers, and services
+that assemble user-supplied models at runtime.
+
+## Decision Drivers
+
+* Must work out of the box. Smithy is a library; consumers cannot be required to
+  learn about a rules-engine classloading quirk or add extra dependencies.
+* No global mutable state, and safe under concurrency. Model validation runs on
+  a parallel stream over `ForkJoinPool`, so any solution must be correct when
+  invoked from pool worker threads.
+* Must not pin closure classloaders for the lifetime of the JVM. Long-lived
+  processes assemble many models against many closures; retained classloaders
+  are a memory leak.
+* Backwards compatible. No public method signatures may be removed or changed.
+
+## Considered Options
+
+1. Add `smithy-aws-endpoints` to the consumer's runtime classpath. Rejected: it
+   masks the underlying bug, only fixes the AWS providers, and every consumer
+   must rediscover and repeat it.
+
+2. Discover providers from the thread context classloader (TCCL). Rejected:
+   validators run on `ForkJoinPool.commonPool()` worker threads, which do not
+   inherit the submitting thread's TCCL, so the closure classloader would not be
+   seen at validation time. This holds even if the caller sets the TCCL around
+   the assemble call.
+
+3. Add a static, settable classloader override on `EndpointRuleSet`. Rejected:
+   global mutable state is unsafe for a shared library used by concurrent
+   callers, and it couples unrelated assemblies.
+
+4. Keep a static `Map<ClassLoader, EndpointComponentFactory>` cache. Rejected:
+   the map strongly pins every closure classloader for the life of the JVM. A
+   weak-keyed map does not help, because the cached factory holds provider
+   instances that were loaded by the key classloader, so the value transitively
+   references the key and defeats weak collection.
+
+5. Thread the model's classloader into trait creation and resolve components
+   through it, memoizing the resolved factory on the trait instance. Chosen.
+
+## Decision
+
+Thread the classloader that assembled the model down to the point where
+endpoint components are resolved, and carry the resolved factory rather than the
+raw classloader.
+
+* `TraitService` gains a defaulted
+  `createTrait(ShapeId target, Node value, ClassLoader classLoader)` overload.
+  The default delegates to the existing two-argument method, so existing
+  providers are unaffected.
+* `TraitFactory` captures the classloader passed to
+  `Model.assembler(ClassLoader)` and supplies it to providers through the new
+  overload.
+* Both `EndpointRuleSetTrait` and `EndpointBddTrait` build one
+  `EndpointComponentFactory` from that classloader and memoize it on the trait
+  instance. The factory wraps the classloader and caches the discovered
+  components.
+* The factory is threaded through rule-set deserialization
+  (`EndpointRuleSet.fromNode(Node, EndpointComponentFactory)`, then `Rule`,
+  `Condition`, `Endpoint`, and `Expression`/`FunctionNode`, including functions
+  nested as arguments), through the equivalent `EndpointBddTrait` deserialization
+  path, and through the `RuleSetBuiltInValidator` and
+  `RuleSetAuthSchemesValidator` validators, which read it from the trait. The
+  factory is also carried on `EndpointRuleSet`, `Cfg`, and `EndpointBddTrait` so
+  programmatic transforms that round-trip a rule-set or compile it to a BDD
+  re-resolve functions against the same classloader. Every transform that
+  rebuilds an `EndpointRuleSet` must carry the factory (through
+  `EndpointRuleSet.toBuilder()`, an explicit `componentFactory(...)` on a fresh
+  builder, or `fromNode(node, factory)`); a transform that rebuilds via a bare
+  `EndpointRuleSet.builder()` silently resets the factory to the default and
+  defeats the fix for everything downstream of it. The transforms that carry it
+  today are `CfgBuilder`, `CoalesceTransform`, `IsSetBooleanCoalesceTransform`,
+  the `TreeMapper`-based transforms, and `EndpointBddTrait.from(Cfg)`; the
+  `EndpointPathCollector` reads it from the trait.
+* When no distinct classloader is present (none supplied, or one equal to the
+  rules engine's own loader), a single shared default factory is reused so
+  `ServiceLoader` is not re-run for the common case.
+
+## Consequences
+
+* Positive: correct for any closure classloader, with no consumer changes
+  required; no static per-loader retention, so closure classloaders are not
+  pinned; thread-safe without locks on a shared cache, because the resolved
+  factory travels as data on the trait rather than through thread state; purely
+  additive, so no caller breaks.
+* Negative: `ServiceLoader` runs once per trait instance instead of once per
+  classloader across a whole process. This is acceptable because discovery is
+  bounded and the shared default factory covers the common same-classpath case.
+* Testing caveat: the classloader-driven resolution is guarded end to end for
+  the condition and nested-argument paths of both `@endpointRuleSet` and
+  `@endpointBdd` by an integration test that assembles a model under a
+  classloader that hides the AWS endpoints extension (see
+  `smithy-aws-endpoints/src/it`). Two threaded paths are correct by construction
+  but not covered by a test that would fail on the pre-fix code: the
+  `Cfg`/`CfgBuilder` re-parse during BDD compilation (the BDD fixture must be
+  built with the extension visible, so the hidden-loader case cannot be
+  exercised without a synthetic string-returning extension), and functions used
+  directly in an endpoint URL, header, or error (the AWS functions return
+  records, not strings, so no realistic model exercises them). Adding a synthetic
+  `EndpointRuleSetExtension` that contributes a string-returning function would
+  close both gaps if they ever warrant a regression test.
+* Trade-off accepted on purpose: we chose no classloader retention over
+  cross-assembly cache reuse. A process that assembles many models against the
+  same non-default closure classloader will run discovery once per model rather
+  than sharing a single cached factory. If that ever becomes a measured cost,
+  introduce an explicitly scoped cache with a defined lifecycle rather than a
+  static map.
+
+## Pattern for future work
+
+A `TraitService` whose node value must resolve components discovered through its
+own service-provider interface (functions, validators, or nested extensions)
+should follow this pattern so it works with caller-supplied classloaders:
+
+1. Override `createTrait(ShapeId, Node, ClassLoader)` and capture the
+   classloader.
+2. Build and memoize any discovery factory on the trait instance, not in a
+   static field, so it is collected with the model and does not pin the
+   classloader.
+3. Thread the resolved factory, not a raw `ClassLoader`, through the value's
+   deserialization and any validators, so discovery runs once and is reused. If
+   the value is rebuilt by transforms, ensure every transform carries the
+   factory forward; a single transform that rebuilds via a bare builder resets
+   it to the default and silently defeats the fix downstream.
+4. Fall back to a shared default factory when the classloader is null or equal
+   to the owning class's loader.
+
+Reference implementation: `EndpointRuleSetTrait` and `EndpointBddTrait`
+together with `EndpointComponentFactory` in `smithy-rules-engine`.

--- a/adr/README.md
+++ b/adr/README.md
@@ -1,0 +1,85 @@
+# Architecture Decision Records
+
+This directory holds Architecture Decision Records (ADRs) for Smithy. An ADR
+captures a single architectural or design decision, the context that forced the
+decision, the options that were considered, and the consequences of the choice.
+ADRs are immutable once accepted: to change a decision, add a new ADR that
+supersedes the old one rather than editing history.
+
+## ADRs vs designs
+
+Smithy already has a top-level `designs/` directory for longer design
+narratives (for example a new language feature). ADRs are different in scope:
+
+* An ADR records one decision and its trade-offs in a page or two. It answers
+  "why is it built this way, and what did we reject?"
+* A design document explores a feature or subsystem in depth, often before
+  implementation, and may contain many decisions.
+
+If a change is large enough to need a design document, write one in `designs/`
+and, if it also locks in a sharp, reversible-at-a-cost decision, cross-link a
+short ADR here.
+
+## When to write an ADR
+
+Write an ADR when a change does any of the following:
+
+* Chooses between multiple viable approaches where the reasons are not obvious
+  from the code (for example, picking one concurrency or classloading strategy
+  over another).
+* Introduces or extends a public extension point (an SPI, a service-provider
+  interface, a new trait contract) that others are expected to follow.
+* Makes a trade-off that a future reader might otherwise "fix" without knowing
+  why it exists (for example, deliberately not caching to avoid a memory leak).
+* Establishes a pattern intended to be reused across the codebase.
+* Is costly or disruptive to reverse.
+
+## When not to write an ADR
+
+Skip an ADR when:
+
+* The change is a routine bug fix, refactor, or dependency bump with no
+  lasting architectural consequence.
+* The reasoning is fully evident from the code and its tests.
+* The decision is easily reversible and low impact.
+* It belongs in user-facing documentation instead. ADRs record internal
+  rationale; they are not a substitute for the docs in `docs/`.
+
+When in doubt, prefer a short ADR over none: the cost is low and the record is
+most valuable years later when the original context has been forgotten.
+
+## Format
+
+ADRs use the [MADR](https://adr.github.io/madr/) layout. Copy `template.md` to a
+new file named `NNNN-short-title.md`, where `NNNN` is the next zero-padded
+sequence number (for example `0002-...`). Keep the title short and phrased as
+the decision, not the problem.
+
+Required sections:
+
+* Title, status, and date.
+* Context and Problem Statement.
+* Decision Drivers.
+* Considered Options, including the ones that were rejected and why.
+* Decision.
+* Consequences, both positive and negative, and any trade-off recorded on
+  purpose.
+
+Optional but encouraged when relevant:
+
+* A "Pattern for future work" section describing how other code should follow
+  the decision, with a pointer to the reference implementation. This is what
+  turns a one-off record into a reusable convention.
+
+## Status values
+
+* `Proposed`: under review, not yet agreed.
+* `Accepted`: agreed and in effect.
+* `Superseded by NNNN`: replaced by a later ADR. Leave the original in place and
+  link forward.
+* `Deprecated`: no longer relevant, but kept for history.
+
+## Index
+
+* [0001](0001-endpoint-rule-set-classloader-resolution.md) - Resolve endpoint
+  rule-set components against the model's classloader.

--- a/adr/template.md
+++ b/adr/template.md
@@ -1,0 +1,43 @@
+# NNNN. Short title phrased as the decision
+
+* Status: Proposed | Accepted | Superseded by NNNN | Deprecated
+* Date: YYYY-MM-DD
+* Deciders: names or team
+
+## Context and Problem Statement
+
+Describe the situation and the problem that forces a decision. State the
+symptom or requirement concretely. A reader who was not present should be able
+to understand why a decision was needed.
+
+## Decision Drivers
+
+* The constraints and goals that shaped the choice.
+* For example: backwards compatibility, thread-safety, memory behavior,
+  usability for external consumers.
+
+## Considered Options
+
+1. Option one. Why it was or was not chosen.
+2. Option two. Why it was or was not chosen.
+3. Option three (chosen). Marked as chosen here or in the Decision section.
+
+Record the rejected options honestly. The rejected options and the reasons are
+often the most valuable part of the record.
+
+## Decision
+
+State the decision in a few sentences. Name the concrete types, methods, or
+extension points involved so the record ties back to the code.
+
+## Consequences
+
+* Positive consequences.
+* Negative consequences.
+* Trade-offs accepted on purpose, so a future reader does not undo them without
+  understanding the cost.
+
+## Pattern for future work
+
+Optional. If this decision establishes a convention others should follow,
+describe the steps and point to the reference implementation.

--- a/smithy-aws-endpoints/src/it/java/software/amazon/smithy/rulesengine/aws/language/functions/EndpointRuleSetClassLoaderIntegrationTest.java
+++ b/smithy-aws-endpoints/src/it/java/software/amazon/smithy/rulesengine/aws/language/functions/EndpointRuleSetClassLoaderIntegrationTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.rulesengine.aws.language.functions;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.loader.ModelAssembler;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.validation.Severity;
+import software.amazon.smithy.model.validation.ValidatedResult;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.rulesengine.logic.cfg.Cfg;
+import software.amazon.smithy.rulesengine.traits.EndpointBddTrait;
+import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
+
+/**
+ * End-to-end verification that endpoint rule-set functions contributed by an
+ * {@link software.amazon.smithy.rulesengine.language.EndpointRuleSetExtension} in
+ * {@code smithy-aws-endpoints} (here, {@code aws.partition}) are resolved based on the classloader
+ * supplied to {@link Model#assembler(ClassLoader)}, not the classloader that loaded the rules
+ * engine.
+ *
+ * <p>This reproduces the failure seen when a model is assembled against a dependency-closure
+ * classloader: the AWS endpoints extension lives only in that closure, and the rules engine used to
+ * discover functions from its own classloader, so {@code aws.partition} was reported as an invalid
+ * function. The test drives both directions:
+ *
+ * <ul>
+ *   <li>Assembling with a classloader that can see the extension resolves the rule-set with no
+ *       errors.</li>
+ *   <li>Assembling with a classloader that hides the extension reproduces the original failure,
+ *       proving the resolution really is driven by the supplied classloader.</li>
+ * </ul>
+ */
+class EndpointRuleSetClassLoaderIntegrationTest {
+
+    private static final String PARTITION_MODEL =
+            "software/amazon/smithy/rulesengine/aws/language/functions/errorfiles/valid/partition-fn.smithy";
+
+    private static final String EXTENSION_SERVICE =
+            "META-INF/services/software.amazon.smithy.rulesengine.language.EndpointRuleSetExtension";
+
+    private static final String NESTED_FN_MODEL =
+            "software/amazon/smithy/rulesengine/aws/language/functions/nested-parse-arn.smithy";
+
+    // The rules-engine trait definitions (smithy.rules#endpointRuleSet, #endpointBdd,
+    // #clientContextParams, ...). Added explicitly instead of discoverModels() so the S3 model on
+    // the integration-test classpath is not pulled in, which would add unrelated aws.partition
+    // errors and mask the specific failures under assertion.
+    private static final String RULES_TRAITS_MODEL = "META-INF/smithy/smithy.rules.smithy";
+
+    private static final String AWS_EXTENSION_PACKAGE = "software.amazon.smithy.rulesengine.aws.";
+
+    @Test
+    void resolvesAwsPartitionWhenExtensionVisibleToSuppliedClassLoader() {
+        ClassLoader loader = EndpointRuleSetClassLoaderIntegrationTest.class.getClassLoader();
+
+        ValidatedResult<Model> result = Model.assembler(loader)
+                .addImport(loader.getResource(RULES_TRAITS_MODEL))
+                .addImport(loader.getResource(PARTITION_MODEL))
+                .assemble();
+
+        List<ValidationEvent> errors = result.getValidationEvents(Severity.ERROR);
+        assertThat(errorMessages(errors), is(empty()));
+    }
+
+    @Test
+    void reportsAwsPartitionInvalidWhenExtensionHiddenFromSuppliedClassLoader() {
+        ClassLoader appLoader = EndpointRuleSetClassLoaderIntegrationTest.class.getClassLoader();
+        // A classloader that can load the rules engine and model classes but hides the AWS
+        // endpoints extension's service registration, mimicking a closure that does not include
+        // the smithy-aws-endpoints endpoint functions.
+        ClassLoader hidingLoader = new AwsEndpointsHidingClassLoader(appLoader);
+
+        // With the extension hidden from the supplied classloader, aws.partition cannot be
+        // resolved. The failure may surface as an ERROR event or a thrown exception depending on
+        // validator scheduling; assembleFailureText captures both.
+        String failure = assembleFailureText(hidingLoader, PARTITION_MODEL, null);
+
+        assertThat(failure, containsString("`aws.partition` is not a valid function"));
+    }
+
+    @Test
+    void resolvesNestedFunctionArgumentFromSuppliedClassLoader() {
+        // aws.parseArn is used nested as an argument to getAttr. This guards that nested function
+        // arguments are resolved against the supplied classloader, not only the top-level fn.
+        ClassLoader loader = EndpointRuleSetClassLoaderIntegrationTest.class.getClassLoader();
+
+        ValidatedResult<Model> result = Model.assembler(loader)
+                .addImport(loader.getResource(RULES_TRAITS_MODEL))
+                .addImport(loader.getResource(NESTED_FN_MODEL))
+                .assemble();
+
+        assertThat(errorMessages(result.getValidationEvents(Severity.ERROR)), is(empty()));
+    }
+
+    @Test
+    void reportsNestedFunctionInvalidWhenExtensionHiddenFromSuppliedClassLoader() {
+        ClassLoader appLoader = EndpointRuleSetClassLoaderIntegrationTest.class.getClassLoader();
+        ClassLoader hidingLoader = new AwsEndpointsHidingClassLoader(appLoader);
+
+        // The nested aws.parseArn must fail to resolve when the extension is hidden, proving nested
+        // arguments follow the supplied classloader too.
+        String failure = assembleFailureText(hidingLoader, NESTED_FN_MODEL, null);
+
+        assertThat(failure, containsString("`aws.parseArn` is not a valid function"));
+    }
+
+    @Test
+    void resolvesAwsPartitionInBddTraitFromSuppliedClassLoader() {
+        // The @endpointBdd trait path must also resolve functions against the supplied classloader.
+        ClassLoader loader = EndpointRuleSetClassLoaderIntegrationTest.class.getClassLoader();
+
+        ValidatedResult<Model> result = Model.assembler(loader)
+                .addImport(loader.getResource(RULES_TRAITS_MODEL))
+                .addUnparsedModel("bdd.smithy", bddModel(loader))
+                .assemble();
+
+        assertThat(errorMessages(result.getValidationEvents(Severity.ERROR)), is(empty()));
+    }
+
+    @Test
+    void reportsAwsPartitionInvalidInBddTraitWhenExtensionHidden() {
+        ClassLoader appLoader = EndpointRuleSetClassLoaderIntegrationTest.class.getClassLoader();
+        ClassLoader hidingLoader = new AwsEndpointsHidingClassLoader(appLoader);
+        String model = bddModel(appLoader);
+
+        String failure = assembleFailureText(hidingLoader, null, model);
+
+        assertThat(failure, containsString("`aws.partition` is not a valid function"));
+    }
+
+    // Builds a model whose service carries an @endpointBdd trait compiled from the aws.partition
+    // rule-set. The BDD is generated (and serialized) with the given classloader so the extension
+    // is available while producing the fixture; the assertions above then control which classloader
+    // is used to re-parse it.
+    private static String bddModel(ClassLoader loader) {
+        Model ruleSetModel = Model.assembler(loader)
+                .addImport(loader.getResource(RULES_TRAITS_MODEL))
+                .addImport(loader.getResource(PARTITION_MODEL))
+                .assemble()
+                .unwrap();
+        EndpointRuleSetTrait ruleSetTrait = ruleSetModel
+                .getServiceShapesWithTrait(EndpointRuleSetTrait.class)
+                .iterator()
+                .next()
+                .expectTrait(EndpointRuleSetTrait.class);
+        EndpointBddTrait bddTrait = EndpointBddTrait.from(Cfg.from(ruleSetTrait.getEndpointRuleSet()));
+        String bddJson = Node.printJson(bddTrait.toNode());
+        return "$version: \"2.0\"\n"
+                + "namespace example\n"
+                + "use smithy.rules#endpointBdd\n"
+                + "@endpointBdd(" + bddJson + ")\n"
+                + "service BddService {}\n";
+    }
+
+    private static List<String> errorMessages(List<ValidationEvent> events) {
+        return events.stream().map(ValidationEvent::getMessage).collect(Collectors.toList());
+    }
+
+    // Assembles and returns all failure text, whether the failure surfaces as ERROR validation
+    // events or as an exception thrown from assemble(). Endpoint function-resolution failures can
+    // surface either way depending on which validator materializes the trait first (validators run
+    // on a parallel stream), so a robust assertion must consider both.
+    private static String assembleFailureText(ClassLoader loader, String modelResource, String unparsedModel) {
+        StringBuilder sb = new StringBuilder();
+        try {
+            ModelAssembler assembler = Model.assembler(loader)
+                    .addImport(loader.getResource(RULES_TRAITS_MODEL));
+            if (modelResource != null) {
+                assembler.addImport(loader.getResource(modelResource));
+            }
+            if (unparsedModel != null) {
+                assembler.addUnparsedModel("test.smithy", unparsedModel);
+            }
+            ValidatedResult<Model> result = assembler.assemble();
+            for (ValidationEvent event : result.getValidationEvents(Severity.ERROR)) {
+                sb.append(event.getMessage()).append('\n');
+            }
+        } catch (RuntimeException e) {
+            for (Throwable t = e; t != null; t = t.getCause()) {
+                sb.append(t.getMessage()).append('\n');
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * A classloader that behaves like its parent, except it hides the {@code smithy-aws-endpoints}
+     * {@link software.amazon.smithy.rulesengine.language.EndpointRuleSetExtension} service
+     * registration. This makes {@code aws.partition} undiscoverable through it, reproducing a
+     * dependency closure that does not contribute the AWS endpoint functions, while leaving every
+     * other service (traits, validators) and class loadable so the model still assembles far enough
+     * to reach function resolution.
+     *
+     * <p>Only the AWS extension's service manifest (the one that lists a class in
+     * {@code software.amazon.smithy.rulesengine.aws.*}) is filtered out; the rules engine's own
+     * {@code CoreExtension} manifest, which lives in a separate jar under the same resource path, is
+     * left intact so core functions such as {@code getAttr} still resolve.
+     */
+    private static final class AwsEndpointsHidingClassLoader extends ClassLoader {
+        AwsEndpointsHidingClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            Enumeration<URL> all = super.getResources(name);
+            if (!name.equals(EXTENSION_SERVICE)) {
+                return all;
+            }
+            // Keep only manifests that do not register an AWS endpoints extension.
+            List<URL> kept = new ArrayList<>();
+            while (all.hasMoreElements()) {
+                URL url = all.nextElement();
+                if (!registersAwsExtension(url)) {
+                    kept.add(url);
+                }
+            }
+            return Collections.enumeration(kept);
+        }
+
+        private static boolean registersAwsExtension(URL url) {
+            try (InputStream in = url.openStream()) {
+                String contents = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+                return contents.contains(AWS_EXTENSION_PACKAGE);
+            } catch (IOException e) {
+                return false;
+            }
+        }
+    }
+}

--- a/smithy-aws-endpoints/src/it/resources/software/amazon/smithy/rulesengine/aws/language/functions/nested-parse-arn.smithy
+++ b/smithy-aws-endpoints/src/it/resources/software/amazon/smithy/rulesengine/aws/language/functions/nested-parse-arn.smithy
@@ -1,0 +1,51 @@
+$version: "2.0"
+
+namespace example
+
+use smithy.rules#endpointRuleSet
+
+// Uses the closure-only AWS function aws.parseArn nested as an argument to getAttr. This guards
+// that nested function arguments resolve against the classloader supplied to the assembler, not
+// just the top-level condition function. The parsed ARN is bound with `assign` and proven set
+// before indexing into it, so the model is type-valid when the function resolves.
+@endpointRuleSet({
+  "version": "1.3"
+  "parameters": {
+    "Arn": {
+      "type": "string"
+      "required": true
+      "documentation": "an ARN"
+    }
+  }
+  "rules": [
+    {
+      "documentation": "parse the ARN"
+      "conditions": [
+        {
+          "fn": "aws.parseArn"
+          "argv": [{ "ref": "Arn" }]
+          "assign": "parsedArn"
+        }
+      ]
+      "rules": [
+        {
+          "documentation": "extract the region from the parsed ARN (getAttr over a nested parse)"
+          "conditions": [
+            {
+              "fn": "getAttr"
+              "argv": [{ "ref": "parsedArn" }, "region"]
+              "assign": "arnRegion"
+            }
+          ]
+          "endpoint": { "url": "https://{arnRegion}.example.com" }
+          "type": "endpoint"
+        }
+      ]
+      "type": "tree"
+    }
+  ]
+})
+@smithy.rules#clientContextParams(
+  Arn: { type: "string", documentation: "an ARN passed as a client context param" }
+)
+service NestedFn {}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitFactory.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitFactory.java
@@ -30,16 +30,24 @@ public interface TraitFactory {
     Optional<Trait> createTrait(ShapeId id, ShapeId target, Node value);
 
     /**
+     * @return the classloader used to discover trait providers, or null if unknown.
+     *
+     * <p>Factories created via {@link #createServiceFactory(ClassLoader)} return that classloader
+     * so it can be threaded into providers that need it (see
+     * {@link TraitService#createTrait(ShapeId, Node, ClassLoader)}). The default returns null.
+     */
+    default ClassLoader traitClassLoader() {
+        return null;
+    }
+
+    /**
      * Creates a TraitFactory that uses a List of TraitService provider instances.
      *
      * @param services List of TraitService provider instances.
      * @return Returns the created TraitFactory.
      */
     static TraitFactory createServiceFactory(Iterable<TraitService> services) {
-        Map<ShapeId, TraitService> serviceMap = new HashMap<>();
-        services.forEach(service -> serviceMap.put(service.getShapeId(), service));
-        return (name, target, value) -> Optional.ofNullable(serviceMap.get(name))
-                .map(provider -> provider.createTrait(target, value));
+        return new ServiceFactory(services, null);
     }
 
     /**
@@ -60,6 +68,34 @@ public interface TraitFactory {
      * @return Returns the created TraitFactory.
      */
     static TraitFactory createServiceFactory(ClassLoader classLoader) {
-        return createServiceFactory(ServiceLoader.load(TraitService.class, classLoader));
+        return new ServiceFactory(ServiceLoader.load(TraitService.class, classLoader), classLoader);
+    }
+
+    /**
+     * Default {@link TraitFactory} backed by a map of {@link TraitService} providers.
+     *
+     * <p>Retains the classloader used to discover the providers (when known) and passes it to
+     * {@link TraitService#createTrait(ShapeId, Node, ClassLoader)} so providers can resolve
+     * classloader-sensitive components from the same closure the model is assembled against.
+     */
+    final class ServiceFactory implements TraitFactory {
+        private final Map<ShapeId, TraitService> serviceMap = new HashMap<>();
+        private final ClassLoader classLoader;
+
+        private ServiceFactory(Iterable<TraitService> services, ClassLoader classLoader) {
+            services.forEach(service -> serviceMap.put(service.getShapeId(), service));
+            this.classLoader = classLoader;
+        }
+
+        @Override
+        public Optional<Trait> createTrait(ShapeId id, ShapeId target, Node value) {
+            return Optional.ofNullable(serviceMap.get(id))
+                    .map(provider -> provider.createTrait(target, value, classLoader));
+        }
+
+        @Override
+        public ClassLoader traitClassLoader() {
+            return classLoader;
+        }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitFactory.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitFactory.java
@@ -30,17 +30,6 @@ public interface TraitFactory {
     Optional<Trait> createTrait(ShapeId id, ShapeId target, Node value);
 
     /**
-     * @return the classloader used to discover trait providers, or null if unknown.
-     *
-     * <p>Factories created via {@link #createServiceFactory(ClassLoader)} return that classloader
-     * so it can be threaded into providers that need it (see
-     * {@link TraitService#createTrait(ShapeId, Node, ClassLoader)}). The default returns null.
-     */
-    default ClassLoader traitClassLoader() {
-        return null;
-    }
-
-    /**
      * Creates a TraitFactory that uses a List of TraitService provider instances.
      *
      * @param services List of TraitService provider instances.
@@ -91,11 +80,6 @@ public interface TraitFactory {
         public Optional<Trait> createTrait(ShapeId id, ShapeId target, Node value) {
             return Optional.ofNullable(serviceMap.get(id))
                     .map(provider -> provider.createTrait(target, value, classLoader));
-        }
-
-        @Override
-        public ClassLoader traitClassLoader() {
-            return classLoader;
         }
     }
 }

--- a/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitService.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/traits/TraitService.java
@@ -29,4 +29,26 @@ public interface TraitService {
      * @return Returns the created trait.
      */
     Trait createTrait(ShapeId target, Node value);
+
+    /**
+     * Creates the trait from a node value, providing the classloader that was used to discover
+     * trait providers.
+     *
+     * <p>Most providers ignore the classloader; the default implementation delegates to
+     * {@link #createTrait(ShapeId, Node)}. Providers whose trait value references components
+     * discovered through their own SPIs (for example endpoint rule-set functions contributed by an
+     * {@code EndpointRuleSetExtension}) can override this to resolve those components from
+     * {@code classLoader} rather than the classloader that loaded the provider. This matters when
+     * the model is assembled with a caller-supplied classloader (see
+     * {@code Model.assembler(ClassLoader)}) whose closure contains extensions that are not visible
+     * to the provider's own classloader.
+     *
+     * @param target The shape targeted by the trait.
+     * @param value The value of the trait.
+     * @param classLoader The classloader used to discover trait providers, or null if unknown.
+     * @return Returns the created trait.
+     */
+    default Trait createTrait(ShapeId target, Node value, ClassLoader classLoader) {
+        return createTrait(target, value);
+    }
 }

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/Endpoint.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/Endpoint.java
@@ -31,6 +31,7 @@ import software.amazon.smithy.rulesengine.language.syntax.expressions.Expression
 import software.amazon.smithy.rulesengine.language.syntax.expressions.literal.Literal;
 import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.StringUtils;
 import software.amazon.smithy.utils.ToSmithyBuilder;
@@ -78,10 +79,27 @@ public final class Endpoint implements FromSourceLocation, ToNode, ToSmithyBuild
      * @return the node as an {@link Endpoint}.
      */
     public static Endpoint fromNode(Node node) {
+        return fromNode(node, null);
+    }
+
+    /**
+     * Constructs an {@link Endpoint} from a {@link Node}, resolving any functions in the URL and
+     * header expressions using the given {@link EndpointComponentFactory}.
+     *
+     * <p>When {@code factory} is {@code null}, the default statically-discovered function factory is
+     * used. Passing the factory ensures functions used directly in an endpoint URL or header
+     * resolve against the same classloader as the enclosing rule-set.
+     *
+     * @param node the object node.
+     * @param factory the factory used to resolve functions, or null.
+     * @return the node as an {@link Endpoint}.
+     */
+    @SmithyInternalApi
+    public static Endpoint fromNode(Node node, EndpointComponentFactory factory) {
         ObjectNode objectNode = node.expectObjectNode();
         Builder builder = builder().sourceLocation(node);
 
-        builder.url(Expression.fromNode(objectNode.expectMember(URL, "URL must be included in endpoint")));
+        builder.url(Expression.fromNode(objectNode.expectMember(URL, "URL must be included in endpoint"), factory));
         objectNode.expectNoAdditionalProperties(Arrays.asList(PROPERTIES, HEADERS, URL));
 
         objectNode.getObjectMember(PROPERTIES, properties -> {
@@ -95,7 +113,7 @@ public final class Endpoint implements FromSourceLocation, ToNode, ToSmithyBuild
                 builder.putHeader(header.getKey(),
                         header.getValue()
                                 .expectArrayNode("header values should be an array")
-                                .getElementsAs(Expression::fromNode));
+                                .getElementsAs(headerNode -> Expression.fromNode(headerNode, factory)));
             }
         });
 

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/EndpointRuleSet.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/EndpointRuleSet.java
@@ -28,7 +28,6 @@ import software.amazon.smithy.rulesengine.language.evaluation.type.Type;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.FunctionNode;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.LibraryFunction;
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameters;
-import software.amazon.smithy.rulesengine.language.syntax.rule.EndpointRule;
 import software.amazon.smithy.rulesengine.language.syntax.rule.Rule;
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait;
 import software.amazon.smithy.rulesengine.validators.AuthSchemeValidator;
@@ -49,9 +48,32 @@ public final class EndpointRuleSet implements FromSourceLocation, ToNode, ToSmit
     private static final String PARAMETERS = "parameters";
     private static final String RULES = "rules";
 
-    private static final class LazyEndpointComponentFactoryHolder {
-        static final EndpointComponentFactory INSTANCE = EndpointComponentFactory.createServiceFactory(
-                EndpointRuleSet.class.getClassLoader());
+    // Default endpoint components discovered from this class's own classloader, used when no
+    // EndpointComponentFactory is supplied. A caller assembling a model with an explicit closure
+    // classloader threads its own factory through fromNode instead (see
+    // EndpointRuleSetTrait#getComponentFactory), so extensions living only in that closure (e.g.
+    // smithy-aws-endpoints, which registers aws.partition) are found. Lazily initialized via the
+    // holder idiom so ServiceLoader runs at most once for the default.
+    private static final class DefaultComponentFactoryHolder {
+        private static final EndpointComponentFactory INSTANCE =
+                EndpointComponentFactory.createServiceFactory(EndpointRuleSet.class.getClassLoader());
+    }
+
+    private static EndpointComponentFactory defaultComponentFactory() {
+        return DefaultComponentFactoryHolder.INSTANCE;
+    }
+
+    /**
+     * Gets the shared {@link EndpointComponentFactory} discovered from this class's own classloader.
+     *
+     * <p>Reused for any rule-set that does not need a distinct classloader (no explicit loader, or a
+     * loader equal to this class's own), so those cases avoid re-running service discovery.
+     *
+     * @return the shared default component factory.
+     */
+    @SmithyInternalApi
+    public static EndpointComponentFactory getDefaultComponentFactory() {
+        return defaultComponentFactory();
     }
 
     private final Parameters parameters;
@@ -59,6 +81,7 @@ public final class EndpointRuleSet implements FromSourceLocation, ToNode, ToSmit
     private final SourceLocation sourceLocation;
     private final String version;
     private final RulesVersion rulesVersion;
+    private final EndpointComponentFactory componentFactory;
 
     private EndpointRuleSet(Builder builder) {
         super();
@@ -67,6 +90,25 @@ public final class EndpointRuleSet implements FromSourceLocation, ToNode, ToSmit
         sourceLocation = SmithyBuilder.requiredState("source", builder.getSourceLocation());
         version = SmithyBuilder.requiredState(VERSION, builder.version);
         rulesVersion = RulesVersion.of(version);
+        componentFactory = builder.componentFactory != null
+                ? builder.componentFactory
+                : defaultComponentFactory();
+    }
+
+    /**
+     * Gets the {@link EndpointComponentFactory} used to resolve this rule-set's functions and
+     * built-ins.
+     *
+     * <p>Captured from the classloader-aware {@link #fromNode(Node, EndpointComponentFactory)} (the
+     * classloader used to assemble the model) and carried across {@link #toBuilder()}, so transforms
+     * that round-trip a rule-set through the node form re-resolve functions against the same
+     * classloader. Defaults to the shared factory discovered from this class's own loader.
+     *
+     * @return the component factory for this rule-set.
+     */
+    @SmithyInternalApi
+    public EndpointComponentFactory getComponentFactory() {
+        return componentFactory;
     }
 
     /**
@@ -85,15 +127,55 @@ public final class EndpointRuleSet implements FromSourceLocation, ToNode, ToSmit
      * @return the created EndpointRuleSet.
      */
     public static EndpointRuleSet fromNode(Node node) throws RuleError {
+        return fromNode(node, defaultComponentFactory());
+    }
+
+    /**
+     * Creates an {@link EndpointRuleSet} from the given Node, discovering endpoint functions and
+     * built-ins using the given {@code classLoader}.
+     *
+     * <p>Convenience overload that builds an {@link EndpointComponentFactory} from
+     * {@code classLoader} (or this class's own loader when null). Prefer
+     * {@link #fromNode(Node, EndpointComponentFactory)} when a factory is already available so it
+     * can be reused across the deserialization and validation of the same rule-set.
+     *
+     * @param node the node to deserialize.
+     * @param classLoader the classloader used to discover endpoint extensions, or null.
+     * @return the created EndpointRuleSet.
+     */
+    public static EndpointRuleSet fromNode(Node node, ClassLoader classLoader) throws RuleError {
+        return fromNode(node,
+                classLoader != null
+                        ? EndpointComponentFactory.createServiceFactory(classLoader)
+                        : defaultComponentFactory());
+    }
+
+    /**
+     * Creates an {@link EndpointRuleSet} from the given Node, resolving endpoint functions and
+     * built-ins using the given {@link EndpointComponentFactory}.
+     *
+     * <p>The factory wraps the classloader used to discover {@link EndpointRuleSetExtension}s and
+     * caches the discovered components, so a caller can build it once (typically from a
+     * dependency-closure classloader) and reuse it. When {@code factory} is {@code null}, the
+     * default factory discovered from this class's own loader is used.
+     *
+     * @param node the node to deserialize.
+     * @param factory the factory used to resolve endpoint components, or null.
+     * @return the created EndpointRuleSet.
+     */
+    @SmithyInternalApi
+    public static EndpointRuleSet fromNode(Node node, EndpointComponentFactory factory) throws RuleError {
+        EndpointComponentFactory resolved = factory != null ? factory : defaultComponentFactory();
         return RuleError.context("when parsing endpoint ruleset", () -> {
             ObjectNode objectNode = node.expectObjectNode("The root of a ruleset must be an object");
 
             EndpointRuleSet.Builder builder = new Builder(node);
+            builder.componentFactory(resolved);
             builder.parameters(Parameters.fromNode(objectNode.expectObjectMember(PARAMETERS)));
             objectNode.expectStringMember(VERSION, builder::version);
 
             for (Node element : objectNode.expectArrayMember(RULES).getElements()) {
-                builder.addRule(context("while parsing rule", element, () -> EndpointRule.fromNode(element)));
+                builder.addRule(context("while parsing rule", element, () -> Rule.fromNode(element, resolved)));
             }
 
             return builder.build();
@@ -208,7 +290,7 @@ public final class EndpointRuleSet implements FromSourceLocation, ToNode, ToSmit
      */
     @SmithyInternalApi
     public static boolean hasBuiltIn(String name) {
-        return LazyEndpointComponentFactoryHolder.INSTANCE.hasBuiltIn(name);
+        return defaultComponentFactory().hasBuiltIn(name);
     }
 
     /**
@@ -218,7 +300,7 @@ public final class EndpointRuleSet implements FromSourceLocation, ToNode, ToSmit
      */
     @SmithyInternalApi
     public static String getKeyString() {
-        return LazyEndpointComponentFactoryHolder.INSTANCE.getKeyString();
+        return defaultComponentFactory().getKeyString();
     }
 
     /**
@@ -228,7 +310,7 @@ public final class EndpointRuleSet implements FromSourceLocation, ToNode, ToSmit
      */
     @SmithyInternalApi
     public static Function<FunctionNode, Optional<LibraryFunction>> createFunctionFactory() {
-        return LazyEndpointComponentFactoryHolder.INSTANCE.createFunctionFactory();
+        return defaultComponentFactory().createFunctionFactory();
     }
 
     /**
@@ -238,7 +320,7 @@ public final class EndpointRuleSet implements FromSourceLocation, ToNode, ToSmit
      */
     @SmithyInternalApi
     public static List<AuthSchemeValidator> getAuthSchemeValidators() {
-        return LazyEndpointComponentFactoryHolder.INSTANCE.getAuthSchemeValidators();
+        return defaultComponentFactory().getAuthSchemeValidators();
     }
 
     /**
@@ -249,6 +331,7 @@ public final class EndpointRuleSet implements FromSourceLocation, ToNode, ToSmit
         private Parameters parameters;
         // Default the version to the latest.
         private String version = LATEST_VERSION;
+        private EndpointComponentFactory componentFactory;
 
         /**
          * Construct a builder from a {@link SourceLocation}.
@@ -264,6 +347,21 @@ public final class EndpointRuleSet implements FromSourceLocation, ToNode, ToSmit
             this.parameters = ruleSet.parameters;
             this.version = ruleSet.version;
             this.rules.setBorrowed(ruleSet.rules);
+            this.componentFactory = ruleSet.componentFactory;
+        }
+
+        /**
+         * Sets the {@link EndpointComponentFactory} used to resolve functions and built-ins when a
+         * rule-set built from this builder is later round-tripped through the node form. May be
+         * null, in which case the shared default factory is used.
+         *
+         * @param componentFactory the factory, or null.
+         * @return the {@link Builder}
+         */
+        @SmithyInternalApi
+        public Builder componentFactory(EndpointComponentFactory componentFactory) {
+            this.componentFactory = componentFactory;
+            return this;
         }
 
         /**
@@ -341,9 +439,11 @@ public final class EndpointRuleSet implements FromSourceLocation, ToNode, ToSmit
         private static final String TYPE = "type";
         private final Map<String, Endpoint> visitedEndpoints = new HashMap();
         private final ObjectNode endpointRuleSet;
+        private final EndpointComponentFactory componentFactory;
 
         private EndpointPathCollector(EndpointRuleSetTrait endpointRuleSetTrait) {
             this.endpointRuleSet = endpointRuleSetTrait.getRuleSet().expectObjectNode();
+            this.componentFactory = endpointRuleSetTrait.getComponentFactory();
         }
 
         /**
@@ -375,7 +475,7 @@ public final class EndpointRuleSet implements FromSourceLocation, ToNode, ToSmit
                             .orElse(false))
                     .orElse(false);
             if (isEndpointRuleObject) {
-                Endpoint endpoint = Endpoint.fromNode(node.expectMember(ENDPOINT));
+                Endpoint endpoint = Endpoint.fromNode(node.expectMember(ENDPOINT), componentFactory);
                 visitedEndpoints.put(parentPath + "/" + ENDPOINT, endpoint);
                 return;
             }

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/expressions/Expression.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/expressions/Expression.java
@@ -17,6 +17,7 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.node.ToNode;
+import software.amazon.smithy.rulesengine.language.EndpointComponentFactory;
 import software.amazon.smithy.rulesengine.language.error.InnerParseError;
 import software.amazon.smithy.rulesengine.language.evaluation.Scope;
 import software.amazon.smithy.rulesengine.language.evaluation.TypeCheck;
@@ -26,6 +27,7 @@ import software.amazon.smithy.rulesengine.language.syntax.SyntaxElement;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.FunctionNode;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.GetAttr;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.literal.Literal;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
@@ -74,6 +76,23 @@ public abstract class Expression extends SyntaxElement implements FromSourceLoca
      * @return the expression.
      */
     public static Expression fromNode(Node node) {
+        return fromNode(node, null);
+    }
+
+    /**
+     * Constructs an expression from the provided {@link Node}, resolving any functions (including
+     * functions nested as arguments) using the given {@link EndpointComponentFactory}.
+     *
+     * <p>When {@code factory} is {@code null}, the default statically-discovered function factory is
+     * used. Threading the factory here ensures functions used as arguments to other functions are
+     * resolved against the same classloader as the enclosing rule-set.
+     *
+     * @param node the node to construct the expression from.
+     * @param factory the factory used to resolve functions, or null.
+     * @return the expression.
+     */
+    @SmithyInternalApi
+    public static Expression fromNode(Node node, EndpointComponentFactory factory) {
         if (node.asObjectNode().isPresent()) {
             ObjectNode on = node.asObjectNode().get();
             Optional<Node> ref = on.getMember("ref");
@@ -85,7 +104,7 @@ public abstract class Expression extends SyntaxElement implements FromSourceLoca
             if (ref.isPresent()) {
                 return getReference(Identifier.of(ref.get().expectStringNode("ref must be a string")), ref.get());
             }
-            return context("while parsing fn", node, () -> FunctionNode.fromNode(on).createFunction());
+            return context("while parsing fn", node, () -> FunctionNode.fromNode(on, factory).createFunction(factory));
         } else {
             return Literal.fromNode(node);
         }

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/expressions/functions/FunctionNode.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/expressions/functions/FunctionNode.java
@@ -8,6 +8,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
 import software.amazon.smithy.model.FromSourceLocation;
 import software.amazon.smithy.model.SourceException;
 import software.amazon.smithy.model.SourceLocation;
@@ -16,6 +18,7 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.node.ToNode;
+import software.amazon.smithy.rulesengine.language.EndpointComponentFactory;
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
 import software.amazon.smithy.rulesengine.language.RulesComponentBuilder;
 import software.amazon.smithy.rulesengine.language.error.RuleError;
@@ -23,6 +26,7 @@ import software.amazon.smithy.rulesengine.language.syntax.ToExpression;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.Expression;
 import software.amazon.smithy.utils.BuilderRef;
 import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -93,9 +97,26 @@ public final class FunctionNode implements FromSourceLocation, ToNode, ToSmithyB
      * @return the {@link FunctionNode}.
      */
     public static FunctionNode fromNode(ObjectNode function) {
+        return fromNode(function, null);
+    }
+
+    /**
+     * Constructs a {@link FunctionNode} from the provided {@link ObjectNode}, resolving argument
+     * functions using the given {@link EndpointComponentFactory}.
+     *
+     * <p>When {@code factory} is {@code null}, the default statically-discovered function factory is
+     * used. Passing the factory ensures functions nested as arguments resolve against the same
+     * classloader as the enclosing rule-set.
+     *
+     * @param function the node describing the function.
+     * @param factory the factory used to resolve argument functions, or null.
+     * @return the {@link FunctionNode}.
+     */
+    @SmithyInternalApi
+    public static FunctionNode fromNode(ObjectNode function, EndpointComponentFactory factory) {
         List<Expression> arguments = new ArrayList<>();
         for (Node node : function.expectArrayMember(ARGV).getElements()) {
-            arguments.add(Expression.fromNode(node));
+            arguments.add(Expression.fromNode(node, factory));
         }
         return builder()
                 .sourceLocation(function)
@@ -110,7 +131,25 @@ public final class FunctionNode implements FromSourceLocation, ToNode, ToSmithyB
      * @return this function as an expression.
      */
     public LibraryFunction createFunction() {
-        return EndpointRuleSet.createFunctionFactory()
+        return createFunction(null);
+    }
+
+    /**
+     * Returns an expression representing this function, resolving the function definition using the
+     * given {@link EndpointComponentFactory}.
+     *
+     * <p>Use this overload when the function may be contributed by an endpoint extension that lives
+     * in a caller-supplied classloader. When {@code factory} is {@code null}, the function is
+     * resolved using the default, statically-discovered function factory.
+     *
+     * @param factory the factory used to resolve the function, or null to use the default.
+     * @return this function as an expression.
+     */
+    @SmithyInternalApi
+    public LibraryFunction createFunction(EndpointComponentFactory factory) {
+        Function<FunctionNode, Optional<LibraryFunction>> functionFactory =
+                factory != null ? factory.createFunctionFactory() : EndpointRuleSet.createFunctionFactory();
+        return functionFactory
                 .apply(this)
                 .orElseThrow(() -> new RuleError(new SourceException(
                         String.format("`%s` is not a valid function", name),

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/rule/Condition.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/rule/Condition.java
@@ -14,6 +14,7 @@ import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.ToNode;
+import software.amazon.smithy.rulesengine.language.EndpointComponentFactory;
 import software.amazon.smithy.rulesengine.language.evaluation.Scope;
 import software.amazon.smithy.rulesengine.language.evaluation.TypeCheck;
 import software.amazon.smithy.rulesengine.language.evaluation.type.Type;
@@ -23,6 +24,7 @@ import software.amazon.smithy.rulesengine.language.syntax.expressions.Expression
 import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.FunctionNode;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.functions.LibraryFunction;
 import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
@@ -58,10 +60,24 @@ public final class Condition extends SyntaxElement implements TypeCheck, FromSou
      * @return the condition instance.
      */
     public static Condition fromNode(Node node) {
+        return fromNode(node, null);
+    }
+
+    /**
+     * Constructs a condition from the given node, resolving any function using the given
+     * {@link EndpointComponentFactory}. When {@code factory} is {@code null}, the default
+     * statically-discovered function factory is used.
+     *
+     * @param node the node.
+     * @param factory the factory used to resolve the condition's function, or null.
+     * @return the condition instance.
+     */
+    @SmithyInternalApi
+    public static Condition fromNode(Node node, EndpointComponentFactory factory) {
         Builder builder = new Builder();
         ObjectNode objectNode = node.expectObjectNode("condition must be an object node");
 
-        builder.fn(FunctionNode.fromNode(objectNode).createFunction());
+        builder.fn(FunctionNode.fromNode(objectNode, factory).createFunction(factory));
         // This needs to go directly through the node to maintain source locations.
         if (objectNode.containsMember(ASSIGN)) {
             builder.result(Identifier.of(objectNode.expectStringMember(ASSIGN)));

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/rule/Rule.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/language/syntax/rule/Rule.java
@@ -20,12 +20,14 @@ import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.node.ToNode;
 import software.amazon.smithy.rulesengine.language.Endpoint;
+import software.amazon.smithy.rulesengine.language.EndpointComponentFactory;
 import software.amazon.smithy.rulesengine.language.evaluation.Scope;
 import software.amazon.smithy.rulesengine.language.evaluation.TypeCheck;
 import software.amazon.smithy.rulesengine.language.evaluation.type.Type;
 import software.amazon.smithy.rulesengine.language.syntax.ToCondition;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.Expression;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.literal.Literal;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.StringUtils;
 
@@ -80,23 +82,38 @@ public abstract class Rule implements TypeCheck, ToNode, FromSourceLocation {
      * @return the created Rule.
      */
     public static Rule fromNode(Node node) {
+        return fromNode(node, null);
+    }
+
+    /**
+     * Creates a {@link Rule} instance from the given Node, resolving any functions in conditions
+     * using the given {@link EndpointComponentFactory}. When {@code factory} is {@code null}, the
+     * default statically-discovered function factory is used.
+     *
+     * @param node the node to deserialize.
+     * @param factory the factory used to resolve functions, or null.
+     * @return the created Rule.
+     */
+    @SmithyInternalApi
+    public static Rule fromNode(Node node, EndpointComponentFactory factory) {
         ObjectNode objectNode = node.expectObjectNode();
 
         Builder builder = new Builder(node);
         objectNode.getStringMember(DOCUMENTATION, builder::description);
 
         objectNode.getArrayMember(CONDITIONS).ifPresent(conds -> {
-            builder.conditions(conds.getElementsAs(Condition::fromNode));
+            builder.conditions(conds.getElementsAs(condNode -> Condition.fromNode(condNode, factory)));
         });
 
         String type = objectNode.expectStringMember(TYPE).getValue();
         switch (type) {
             case ENDPOINT:
-                return builder.endpoint(Endpoint.fromNode(objectNode.expectMember(ENDPOINT)));
+                return builder.endpoint(Endpoint.fromNode(objectNode.expectMember(ENDPOINT), factory));
             case ERROR:
-                return builder.error(objectNode.expectMember(ERROR));
+                return builder.error(Expression.fromNode(objectNode.expectMember(ERROR), factory));
             case TREE:
-                return builder.treeRule(objectNode.expectArrayMember(RULES).getElementsAs(Rule::fromNode));
+                return builder.treeRule(objectNode.expectArrayMember(RULES)
+                        .getElementsAs(ruleNode -> Rule.fromNode(ruleNode, factory)));
             default:
                 throw new IllegalStateException("Unexpected rule type: " + type);
         }

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/logic/cfg/Cfg.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/logic/cfg/Cfg.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
+import software.amazon.smithy.rulesengine.language.EndpointComponentFactory;
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
 import software.amazon.smithy.rulesengine.language.RulesVersion;
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameters;
@@ -26,6 +27,7 @@ import software.amazon.smithy.rulesengine.language.syntax.rule.ErrorRule;
 import software.amazon.smithy.rulesengine.language.syntax.rule.Rule;
 import software.amazon.smithy.rulesengine.language.syntax.rule.TreeRule;
 import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
  * A Control Flow Graph (CFG) representation of endpoint rule decision logic.
@@ -48,18 +50,36 @@ public final class Cfg implements Iterable<CfgNode> {
     private Condition[] conditions;
     private Map<Condition, Integer> conditionToIndex;
     private final RulesVersion version;
+    private final EndpointComponentFactory componentFactory;
 
     Cfg(EndpointRuleSet ruleSet, CfgNode root) {
         this(
                 ruleSet == null ? Parameters.builder().build() : ruleSet.getParameters(),
                 root,
-                ruleSet == null ? RulesVersion.V1_1 : ruleSet.getRulesVersion());
+                ruleSet == null ? RulesVersion.V1_1 : ruleSet.getRulesVersion(),
+                ruleSet == null ? null : ruleSet.getComponentFactory());
     }
 
     Cfg(Parameters parameters, CfgNode root, RulesVersion version) {
+        this(parameters, root, version, null);
+    }
+
+    Cfg(Parameters parameters, CfgNode root, RulesVersion version, EndpointComponentFactory componentFactory) {
         this.root = SmithyBuilder.requiredState("root", root);
         this.version = version;
         this.parameters = parameters;
+        this.componentFactory = componentFactory;
+    }
+
+    /**
+     * Gets the component factory of the source rule-set, used to resolve endpoint functions when a
+     * BDD compiled from this CFG is later re-parsed. May be null.
+     *
+     * @return the component factory, or null.
+     */
+    @SmithyInternalApi
+    public EndpointComponentFactory getComponentFactory() {
+        return componentFactory;
     }
 
     /**

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/logic/cfg/CfgBuilder.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/logic/cfg/CfgBuilder.java
@@ -121,7 +121,9 @@ public final class CfgBuilder {
         // Deep-copy via serialization to get fresh Expression objects.
         // This avoids sharing expressions that may have cached types from
         // being type-checked in different scopes during EndpointRuleSet.build().
-        canonical = Condition.fromNode(canonical.toNode());
+        // Re-parse with the rule-set's own component factory so functions contributed by an
+        // extension in a caller-supplied classloader still resolve during BDD compilation.
+        canonical = Condition.fromNode(canonical.toNode(), ruleSet.getComponentFactory());
 
         // Track bindings for future isSet consolidation
         if (canonical.getResult().isPresent()) {

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/logic/cfg/CoalesceTransform.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/logic/cfg/CoalesceTransform.java
@@ -61,6 +61,7 @@ final class CoalesceTransform {
                 .parameters(ruleSet.getParameters())
                 .rules(transformedRules)
                 .version(ruleSet.getVersion())
+                .componentFactory(ruleSet.getComponentFactory())
                 .build();
     }
 

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/logic/cfg/IsSetBooleanCoalesceTransform.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/logic/cfg/IsSetBooleanCoalesceTransform.java
@@ -62,7 +62,7 @@ final class IsSetBooleanCoalesceTransform extends TreeMapper {
         }
         builder.withMember("rules", rulesBuilder.build());
 
-        return EndpointRuleSet.fromNode(builder.build());
+        return EndpointRuleSet.fromNode(builder.build(), ruleSet.getComponentFactory());
     }
 
     /**

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointBddTrait.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointBddTrait.java
@@ -22,6 +22,9 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.rulesengine.language.EndpointComponentFactory;
+import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
+import software.amazon.smithy.rulesengine.language.EndpointRuleSetExtension;
 import software.amazon.smithy.rulesengine.language.RulesVersion;
 import software.amazon.smithy.rulesengine.language.evaluation.Scope;
 import software.amazon.smithy.rulesengine.language.evaluation.type.Type;
@@ -34,6 +37,7 @@ import software.amazon.smithy.rulesengine.logic.bdd.BddCompiler;
 import software.amazon.smithy.rulesengine.logic.cfg.Cfg;
 import software.amazon.smithy.utils.SetUtils;
 import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
 /**
@@ -57,6 +61,8 @@ public final class EndpointBddTrait extends AbstractTrait implements ToSmithyBui
     private final List<Condition> conditions;
     private final List<Rule> results;
     private final Bdd bdd;
+    private final ClassLoader classLoader;
+    private volatile EndpointComponentFactory componentFactory;
 
     private EndpointBddTrait(Builder builder) {
         super(ID, builder.getSourceLocation());
@@ -65,6 +71,8 @@ public final class EndpointBddTrait extends AbstractTrait implements ToSmithyBui
         this.conditions = SmithyBuilder.requiredState("conditions", builder.conditions);
         this.results = SmithyBuilder.requiredState("results", builder.results);
         this.bdd = SmithyBuilder.requiredState("bdd", builder.bdd);
+        this.classLoader = builder.classLoader;
+        this.componentFactory = builder.componentFactory;
 
         if (version.compareTo(MIN_VERSION) < 0) {
             throw new IllegalArgumentException("Rules engine version for endpointBdd trait must be >= " + MIN_VERSION);
@@ -96,6 +104,7 @@ public final class EndpointBddTrait extends AbstractTrait implements ToSmithyBui
                 .parameters(cfg.getParameters())
                 .conditions(compiler.getOrderedConditions())
                 .results(compiler.getIndexedResults())
+                .componentFactory(cfg.getComponentFactory())
                 .bdd(bdd)
                 .build();
     }
@@ -149,6 +158,8 @@ public final class EndpointBddTrait extends AbstractTrait implements ToSmithyBui
                 .parameters(parameters)
                 .conditions(newConditions)
                 .results(results)
+                .classLoader(classLoader)
+                .componentFactory(componentFactory)
                 .bdd(new Bdd(bdd
                         .getRootRef(), newConditions.size(), bdd.getResultCount(), bdd.getNodeCount(), newNodes))
                 .build();
@@ -197,6 +208,32 @@ public final class EndpointBddTrait extends AbstractTrait implements ToSmithyBui
      */
     public RulesVersion getVersion() {
         return version;
+    }
+
+    /**
+     * Gets the {@link EndpointComponentFactory} used to resolve this BDD's functions, built-ins,
+     * and auth-scheme validators.
+     *
+     * <p>Built lazily from the classloader captured when this trait was created (the classloader
+     * used to assemble the model) and cached, so endpoint extensions living only in a
+     * caller-supplied closure classloader are discovered. When no distinct classloader is present,
+     * the shared default factory is reused.
+     *
+     * @return the factory used to resolve endpoint components.
+     */
+    @SmithyInternalApi
+    public EndpointComponentFactory getComponentFactory() {
+        EndpointComponentFactory result = componentFactory;
+        if (result == null) {
+            ClassLoader ownLoader = EndpointRuleSet.class.getClassLoader();
+            if (classLoader == null || classLoader == ownLoader) {
+                result = EndpointRuleSet.getDefaultComponentFactory();
+            } else {
+                result = EndpointComponentFactory.createServiceFactory(classLoader);
+            }
+            componentFactory = result;
+        }
+        return result;
     }
 
     /**
@@ -251,13 +288,35 @@ public final class EndpointBddTrait extends AbstractTrait implements ToSmithyBui
      * @return the BddTrait
      */
     public static EndpointBddTrait fromNode(Node node) {
+        return fromNode(node, (ClassLoader) null);
+    }
+
+    /**
+     * Creates a BddTrait from a Node representation, discovering endpoint functions and built-ins
+     * using the given {@code classLoader}.
+     *
+     * <p>When {@code classLoader} is {@code null}, discovery falls back to this class's own loader.
+     * Use this overload when the BDD may reference functions contributed by an
+     * {@link EndpointRuleSetExtension} that lives in a caller-supplied classloader.
+     *
+     * @param node the node to parse.
+     * @param classLoader the classloader used to discover endpoint extensions, or null.
+     * @return the BddTrait.
+     */
+    @SmithyInternalApi
+    public static EndpointBddTrait fromNode(Node node, ClassLoader classLoader) {
+        EndpointComponentFactory factory = classLoader != null
+                ? EndpointComponentFactory.createServiceFactory(classLoader)
+                : EndpointRuleSet.getDefaultComponentFactory();
         ObjectNode obj = node.expectObjectNode();
         obj.warnIfAdditionalProperties(ALLOWED_PROPERTIES);
         RulesVersion version = RulesVersion.of(obj.expectStringMember("version").getValue());
         Parameters params = Parameters.fromNode(obj.expectObjectMember("parameters"));
-        List<Condition> conditions = obj.expectArrayMember("conditions").getElementsAs(Condition::fromNode);
+        List<Condition> conditions = obj.expectArrayMember("conditions")
+                .getElementsAs(condNode -> Condition.fromNode(condNode, factory));
 
-        List<Rule> serializedResults = obj.expectArrayMember("results").getElementsAs(Rule::fromNode);
+        List<Rule> serializedResults = obj.expectArrayMember("results")
+                .getElementsAs(ruleNode -> Rule.fromNode(ruleNode, factory));
         List<Rule> results = new ArrayList<>();
         results.add(NoMatchRule.INSTANCE); // Always add no-match at index 0
         results.addAll(serializedResults);
@@ -284,6 +343,7 @@ public final class EndpointBddTrait extends AbstractTrait implements ToSmithyBui
                 .parameters(params)
                 .conditions(conditions)
                 .results(results)
+                .classLoader(classLoader)
                 .bdd(bdd)
                 .build();
         trait.setNodeCache(node);
@@ -344,6 +404,8 @@ public final class EndpointBddTrait extends AbstractTrait implements ToSmithyBui
                 .parameters(parameters)
                 .conditions(conditions)
                 .results(results)
+                .classLoader(classLoader)
+                .componentFactory(componentFactory)
                 .bdd(bdd);
     }
 
@@ -356,6 +418,8 @@ public final class EndpointBddTrait extends AbstractTrait implements ToSmithyBui
         private List<Condition> conditions;
         private List<Rule> results;
         private Bdd bdd;
+        private ClassLoader classLoader;
+        private EndpointComponentFactory componentFactory;
 
         private Builder() {}
 
@@ -414,6 +478,32 @@ public final class EndpointBddTrait extends AbstractTrait implements ToSmithyBui
             return this;
         }
 
+        /**
+         * Sets the classloader used to discover endpoint extensions when the BDD is materialized.
+         * Typically the classloader used to assemble the model. May be null.
+         *
+         * @param classLoader the classloader, or null.
+         * @return this builder
+         */
+        @SmithyInternalApi
+        public Builder classLoader(ClassLoader classLoader) {
+            this.classLoader = classLoader;
+            return this;
+        }
+
+        /**
+         * Sets the component factory used to resolve endpoint functions when this BDD is later
+         * re-parsed. Typically propagated from the source rule-set. May be null.
+         *
+         * @param componentFactory the factory, or null.
+         * @return this builder
+         */
+        @SmithyInternalApi
+        public Builder componentFactory(EndpointComponentFactory componentFactory) {
+            this.componentFactory = componentFactory;
+            return this;
+        }
+
         @Override
         public EndpointBddTrait build() {
             EndpointBddTrait trait = new EndpointBddTrait(this);
@@ -441,7 +531,12 @@ public final class EndpointBddTrait extends AbstractTrait implements ToSmithyBui
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
-            EndpointBddTrait trait = EndpointBddTrait.fromNode(value);
+            return createTrait(target, value, null);
+        }
+
+        @Override
+        public Trait createTrait(ShapeId target, Node value, ClassLoader classLoader) {
+            EndpointBddTrait trait = EndpointBddTrait.fromNode(value, classLoader);
             trait.setNodeCache(value);
             return trait;
         }

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointRuleSetTrait.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/traits/EndpointRuleSetTrait.java
@@ -9,8 +9,10 @@ import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.AbstractTrait;
 import software.amazon.smithy.model.traits.AbstractTraitBuilder;
 import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.rulesengine.language.EndpointComponentFactory;
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
 import software.amazon.smithy.utils.SmithyBuilder;
+import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 import software.amazon.smithy.utils.ToSmithyBuilder;
 
@@ -22,11 +24,14 @@ public final class EndpointRuleSetTrait extends AbstractTrait implements ToSmith
     public static final ShapeId ID = ShapeId.from("smithy.rules#endpointRuleSet");
 
     private final Node ruleSet;
+    private final ClassLoader classLoader;
+    private volatile EndpointComponentFactory componentFactory;
     private EndpointRuleSet endpointRuleSet;
 
     private EndpointRuleSetTrait(Builder builder) {
         super(ID, builder.getSourceLocation());
         ruleSet = SmithyBuilder.requiredState("ruleSet", builder.ruleSet);
+        classLoader = builder.classLoader;
     }
 
     public static Builder builder() {
@@ -37,11 +42,45 @@ public final class EndpointRuleSetTrait extends AbstractTrait implements ToSmith
         return ruleSet;
     }
 
+    /**
+     * Gets the {@link EndpointComponentFactory} used to resolve this rule-set's functions,
+     * built-ins, and auth-scheme validators.
+     *
+     * <p>Built lazily from the classloader captured when this trait was created (the classloader
+     * used to assemble the model) and cached, so endpoint extensions are discovered once and reused
+     * across deserialization and validation. Extensions living only in a caller-supplied closure
+     * classloader (for example {@code smithy-aws-endpoints}, which registers {@code aws.partition})
+     * are found because that closure classloader is used here.
+     *
+     * @return the factory used to resolve endpoint components.
+     */
+    @SmithyInternalApi
+    public EndpointComponentFactory getComponentFactory() {
+        EndpointComponentFactory result = componentFactory;
+        if (result == null) {
+            // Reuse the shared default factory when this rule-set does not need a distinct
+            // classloader: either no loader was captured, or it is the same loader that would back
+            // the default. This avoids a redundant ServiceLoader scan for the common case where many
+            // models resolve against the same (app/default) classpath. A closure classloader
+            // different from the default gets its own factory, cached on this trait instance.
+            ClassLoader ownLoader = EndpointRuleSet.class.getClassLoader();
+            if (classLoader == null || classLoader == ownLoader) {
+                result = EndpointRuleSet.getDefaultComponentFactory();
+            } else {
+                result = EndpointComponentFactory.createServiceFactory(classLoader);
+            }
+            componentFactory = result;
+        }
+        return result;
+    }
+
     public EndpointRuleSet getEndpointRuleSet() {
         // EndpointRuleSet creation loads an SPI of functions, builtins, and more.
         // That work is deferred until necessary, usually when a ruleset is being validated.
+        // The component factory (built from the classloader captured at trait-creation time) is
+        // passed so functions contributed by extensions in a caller-supplied closure are resolved.
         if (endpointRuleSet == null) {
-            endpointRuleSet = EndpointRuleSet.fromNode(ruleSet);
+            endpointRuleSet = EndpointRuleSet.fromNode(ruleSet, getComponentFactory());
         }
         return endpointRuleSet;
     }
@@ -55,6 +94,7 @@ public final class EndpointRuleSetTrait extends AbstractTrait implements ToSmith
     public Builder toBuilder() {
         return builder()
                 .sourceLocation(getSourceLocation())
+                .classLoader(classLoader)
                 .ruleSet(ruleSet);
     }
 
@@ -65,8 +105,14 @@ public final class EndpointRuleSetTrait extends AbstractTrait implements ToSmith
 
         @Override
         public Trait createTrait(ShapeId target, Node value) {
+            return createTrait(target, value, null);
+        }
+
+        @Override
+        public Trait createTrait(ShapeId target, Node value, ClassLoader classLoader) {
             EndpointRuleSetTrait trait = builder().sourceLocation(value)
                     .ruleSet(value)
+                    .classLoader(classLoader)
                     .build();
             trait.setNodeCache(value);
             return trait;
@@ -75,11 +121,25 @@ public final class EndpointRuleSetTrait extends AbstractTrait implements ToSmith
 
     public static final class Builder extends AbstractTraitBuilder<EndpointRuleSetTrait, Builder> {
         private Node ruleSet;
+        private ClassLoader classLoader;
 
         private Builder() {}
 
         public Builder ruleSet(Node ruleSet) {
             this.ruleSet = ruleSet;
+            return this;
+        }
+
+        /**
+         * Sets the classloader used to discover endpoint extensions when the rule-set is later
+         * materialized. Typically the classloader used to assemble the model. May be null.
+         *
+         * @param classLoader the classloader, or null.
+         * @return this builder.
+         */
+        @SmithyInternalApi
+        public Builder classLoader(ClassLoader classLoader) {
+            this.classLoader = classLoader;
             return this;
         }
 

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/validators/RuleSetAuthSchemesValidator.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/validators/RuleSetAuthSchemesValidator.java
@@ -15,6 +15,7 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import software.amazon.smithy.rulesengine.language.Endpoint;
+import software.amazon.smithy.rulesengine.language.EndpointComponentFactory;
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
 import software.amazon.smithy.rulesengine.language.syntax.Identifier;
 import software.amazon.smithy.rulesengine.language.syntax.expressions.literal.Literal;
@@ -42,34 +43,46 @@ public final class RuleSetAuthSchemesValidator extends AbstractValidator {
 
     private void visitRuleset(List<ValidationEvent> events, ServiceShape serviceShape, EndpointRuleSetTrait trait) {
         if (trait != null) {
+            EndpointComponentFactory factory = trait.getComponentFactory();
             for (Rule rule : trait.getEndpointRuleSet().getRules()) {
-                traverse(events, serviceShape, rule);
+                traverse(events, serviceShape, rule, factory);
             }
         }
     }
 
     private void visitBdd(List<ValidationEvent> events, ServiceShape serviceShape, EndpointBddTrait trait) {
         if (trait != null) {
+            EndpointComponentFactory factory = trait.getComponentFactory();
             for (Rule result : trait.getResults()) {
                 if (result instanceof EndpointRule) {
-                    visitEndpoint(events, serviceShape, (EndpointRule) result);
+                    visitEndpoint(events, serviceShape, (EndpointRule) result, factory);
                 }
             }
         }
     }
 
-    private void traverse(List<ValidationEvent> events, ServiceShape service, Rule rule) {
+    private void traverse(
+            List<ValidationEvent> events,
+            ServiceShape service,
+            Rule rule,
+            EndpointComponentFactory factory
+    ) {
         if (rule instanceof EndpointRule) {
-            visitEndpoint(events, service, (EndpointRule) rule);
+            visitEndpoint(events, service, (EndpointRule) rule, factory);
         } else if (rule instanceof TreeRule) {
             TreeRule treeRule = (TreeRule) rule;
             for (Rule child : treeRule.getRules()) {
-                traverse(events, service, child);
+                traverse(events, service, child, factory);
             }
         }
     }
 
-    private void visitEndpoint(List<ValidationEvent> events, ServiceShape service, EndpointRule endpointRule) {
+    private void visitEndpoint(
+            List<ValidationEvent> events,
+            ServiceShape service,
+            EndpointRule endpointRule,
+            EndpointComponentFactory factory
+    ) {
         Endpoint endpoint = endpointRule.getEndpoint();
         Literal authSchemes = endpoint.getProperties().get(Identifier.of("authSchemes"));
 
@@ -102,7 +115,7 @@ public final class RuleSetAuthSchemesValidator extends AbstractValidator {
                     if (!authSchemeNames.add(schemeName)) {
                         duplicateAuthSchemeNames.add(schemeName);
                     }
-                    validateAuthScheme(events, service, schemeName, authSchemeMap, authSchemeEntry);
+                    validateAuthScheme(events, service, schemeName, authSchemeMap, authSchemeEntry, factory);
                 }
             }
 
@@ -152,10 +165,14 @@ public final class RuleSetAuthSchemesValidator extends AbstractValidator {
             ServiceShape service,
             String schemeName,
             Map<Identifier, Literal> authScheme,
-            FromSourceLocation sourceLocation
+            FromSourceLocation sourceLocation,
+            EndpointComponentFactory factory
     ) {
         boolean validatedAuth = false;
-        for (AuthSchemeValidator authSchemeValidator : EndpointRuleSet.getAuthSchemeValidators()) {
+        List<AuthSchemeValidator> authSchemeValidators = factory != null
+                ? factory.getAuthSchemeValidators()
+                : EndpointRuleSet.getAuthSchemeValidators();
+        for (AuthSchemeValidator authSchemeValidator : authSchemeValidators) {
             if (authSchemeValidator.test(schemeName)) {
                 events.addAll(authSchemeValidator.validateScheme(authScheme,
                         sourceLocation,

--- a/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/validators/RuleSetBuiltInValidator.java
+++ b/smithy-rules-engine/src/main/java/software/amazon/smithy/rulesengine/validators/RuleSetBuiltInValidator.java
@@ -13,6 +13,7 @@ import software.amazon.smithy.model.node.StringNode;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.rulesengine.language.EndpointComponentFactory;
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet;
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter;
 import software.amazon.smithy.rulesengine.traits.EndpointBddTrait;
@@ -30,11 +31,13 @@ public final class RuleSetBuiltInValidator extends AbstractValidator {
         List<ValidationEvent> events = new ArrayList<>();
 
         for (ServiceShape s : model.getServiceShapesWithTrait(EndpointBddTrait.class)) {
-            validateParams(events, s, s.expectTrait(EndpointBddTrait.class).getParameters());
+            EndpointBddTrait trait = s.expectTrait(EndpointBddTrait.class);
+            validateParams(events, s, trait.getParameters(), trait.getComponentFactory());
         }
 
         for (ServiceShape s : model.getServiceShapesWithTrait(EndpointRuleSetTrait.class)) {
-            validateParams(events, s, s.expectTrait(EndpointRuleSetTrait.class).getEndpointRuleSet().getParameters());
+            EndpointRuleSetTrait trait = s.expectTrait(EndpointRuleSetTrait.class);
+            validateParams(events, s, trait.getEndpointRuleSet().getParameters(), trait.getComponentFactory());
         }
 
         for (ServiceShape s : model.getServiceShapesWithTrait(EndpointTestsTrait.class)) {
@@ -44,10 +47,15 @@ public final class RuleSetBuiltInValidator extends AbstractValidator {
         return events;
     }
 
-    private void validateParams(List<ValidationEvent> events, ServiceShape service, Iterable<Parameter> params) {
+    private void validateParams(
+            List<ValidationEvent> events,
+            ServiceShape service,
+            Iterable<Parameter> params,
+            EndpointComponentFactory factory
+    ) {
         for (Parameter parameter : params) {
             if (parameter.isBuiltIn()) {
-                validateBuiltIn(events, service, parameter.getBuiltIn().get(), parameter, "RuleSet");
+                validateBuiltIn(events, service, parameter.getBuiltIn().get(), factory, parameter, "RuleSet");
             }
         }
     }
@@ -61,6 +69,7 @@ public final class RuleSetBuiltInValidator extends AbstractValidator {
                     validateBuiltIn(events,
                             service,
                             builtInNode.getValue(),
+                            null,
                             operationInput,
                             "TestCase",
                             String.valueOf(testIndex),
@@ -77,13 +86,18 @@ public final class RuleSetBuiltInValidator extends AbstractValidator {
             List<ValidationEvent> events,
             ServiceShape service,
             String name,
+            EndpointComponentFactory factory,
             FromSourceLocation source,
             String... eventIdSuffixes
     ) {
-        if (!EndpointRuleSet.hasBuiltIn(name)) {
+        boolean registered = factory != null
+                ? factory.hasBuiltIn(name)
+                : EndpointRuleSet.hasBuiltIn(name);
+        if (!registered) {
+            String validBuiltIns = factory != null ? factory.getKeyString() : EndpointRuleSet.getKeyString();
             String msg = String.format("The `%s` built-in used is not registered, valid built-ins: %s",
                     name,
-                    EndpointRuleSet.getKeyString());
+                    validBuiltIns);
             events.add(error(service, source, msg, String.join(".", Arrays.asList(eventIdSuffixes))));
         }
     }


### PR DESCRIPTION
#### Background

Endpoint rule-set components (functions like `aws.partition`, built-ins like `AWS::Region`, auth-scheme validators like `sigv4`) are contributed by `EndpointRuleSetExtension` providers found via `ServiceLoader`. The rules engine discovered them using `EndpointRuleSet.class.getClassLoader()` instead of the classloader passed to `Model.assembler(ClassLoader)`. When a model is assembled against a dependency-closure classloader (a child of the rules-engine loader) that holds the providers, a parent loader cannot see a child's providers, so assembly failed with `` `aws.partition` is not a valid function ``, `` `AWS::Region` built-in used is not registered ``, and spurious `sigv4` auth-scheme warnings.

This threads the model's discovery classloader into component resolution as a resolved `EndpointComponentFactory`:

* `TraitService` gains a defaulted `createTrait(ShapeId, Node, ClassLoader)` overload; `TraitFactory` captures the loader from `Model.assembler(ClassLoader)` and passes it to providers.
* `EndpointRuleSetTrait` and `EndpointBddTrait` build and memoize one factory from that loader and thread it through deserialization (`fromNode` into `Rule`/`Condition`/`Endpoint`/`Expression`/`FunctionNode`, including nested-argument functions and functions in URLs, headers, and errors) and the `RuleSetBuiltIn`/`RuleSetAuthSchemes` validators.
* The factory is carried on `EndpointRuleSet`, `Cfg`, and `EndpointBddTrait` so transforms that round-trip a rule-set or compile a BDD (`CfgBuilder`, `CoalesceTransform`, `IsSetBooleanCoalesceTransform`, the `TreeMapper` transforms, `EndpointBddTrait.from(Cfg)`) and `EndpointPathCollector` re-resolve against the same classloader.
* Resolution is cached per trait instance; a shared default factory is reused when no distinct classloader is present, so closure classloaders are not pinned.

Any consumer that assembles models with a custom classpath (build tools isolating a dependency closure, IDEs, application servers, runtime model-assembly services) can now validate models whose endpoint functions live only in that closure. All changes are additive overloads with defaults: no public signature changes, and `equals`/`hashCode`/`toNode`/serialization are unaffected. `adr/0001` records the decision, rejected alternatives, and the pattern for future traits.

#### Testing

* New integration test `smithy-aws-endpoints/src/it/EndpointRuleSetClassLoaderIntegrationTest`: assembles models using `aws.partition` (`@endpointRuleSet` and `@endpointBdd`) and nested `aws.parseArn`, under a classloader that sees the extension (0 errors) and one that hides it (reproduces the failure). The negative cases fail on the pre-fix code.
* `smithy-rules-engine:test` (421) and `smithy-model:test` (2672) pass on `--rerun-tasks`, including the BDD/CFG round-trip and equivalence suites.
* `compileJava`, `spotbugsMain`, `spotlessJavaCheck` pass for both modules.
* Not guarded by a failing-on-pre-fix test (documented in the ADR): the `Cfg`/`CfgBuilder` re-parse during BDD compilation and functions used directly in a URL, header, or error. Both are correct by construction; the fixtures cannot isolate them without a synthetic string-returning extension.

#### Links

* ADR: `adr/0001-endpoint-rule-set-classloader-resolution.md`
* Issue #:
