### PR TITLE
Unmarked `contentMediaType` as unsupported in 3.1 OpenApi Spec

### DIFF
--- a/.changes/next-release/bugfix-64f105267f8bfcc3e749afb0fae0040cdbc1b33e.json
+++ b/.changes/next-release/bugfix-64f105267f8bfcc3e749afb0fae0040cdbc1b33e.json
@@ -1,0 +1,7 @@
+{
+  "type": "bugfix",
+  "description": "Unmarked `contentMediaType` as unsupported in 3.1 OpenApi Spec",
+  "pull_requests": [
+    "[#3275](https://github.com/smithy-lang/smithy/pull/3275)"
+  ]
+}

--- a/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiVersion.java
+++ b/smithy-openapi/src/main/java/software/amazon/smithy/openapi/OpenApiVersion.java
@@ -20,7 +20,7 @@ public enum OpenApiVersion {
     VERSION_3_1_0("3.1.0",
             true,
             JsonSchemaVersion.DRAFT2020_12,
-            SetUtils.of("contentMediaType"));
+            SetUtils.of());
 
     private final String version;
     private final boolean supportsContentEncodingKeyword;

--- a/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/openapi-3-1-0.openapi.json
+++ b/smithy-openapi/src/test/resources/software/amazon/smithy/openapi/fromsmithy/openapi-3-1-0.openapi.json
@@ -60,7 +60,8 @@
           },
           "file": {
             "type": "string",
-            "contentEncoding": "byte"
+            "contentEncoding": "byte",
+            "contentMediaType": "video/quicktime"
           }
         }
       },


### PR DESCRIPTION
#### Background
* What do these changes do? 
* Why are they important?

OpenApi Spec 3.1 allows to specify `contentMediaType` keyword for schemas (see https://spec.openapis.org/oas/v3.1.0.html#considerations-for-file-uploads), but was wrongly marked as "unsupported" in https://github.com/smithy-lang/smithy/pull/1905.

The link in the code (https://swagger.io/docs/specification/v3_0/data-models/keywords/) correctly points to 3.0.2 spec, which still doesn't support `contentMediaType`.

#### Testing
* How did you test these changes?

Adjusted tests.

#### Links

- 3.1.0 spec https://spec.openapis.org/oas/v3.1.0.html#considerations-for-file-uploads

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
