### PR TITLE
Parse closure documentation

### DIFF
--- a/.changes/next-release/bugfix-7f0ff59d427665eae6f42779c59d8ae736414347.json
+++ b/.changes/next-release/bugfix-7f0ff59d427665eae6f42779c59d8ae736414347.json
@@ -1,5 +1,7 @@
 {
   "type": "bugfix",
   "description": "Fixed an issue where closure documentation was not being parsed.",
-  "pull_requests": []
+  "pull_requests": [
+    "[#3276](https://github.com/smithy-lang/smithy/pull/3276)"
+  ]
 }

--- a/.changes/next-release/bugfix-7f0ff59d427665eae6f42779c59d8ae736414347.json
+++ b/.changes/next-release/bugfix-7f0ff59d427665eae6f42779c59d8ae736414347.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "description": "Fixed an issue where closure documentation was not being parsed.",
+  "pull_requests": []
+}

--- a/smithy-model/src/main/java/software/amazon/smithy/model/metadata/ShapeClosure.java
+++ b/smithy-model/src/main/java/software/amazon/smithy/model/metadata/ShapeClosure.java
@@ -72,7 +72,8 @@ public final class ShapeClosure implements ToNode, ToSmithyBuilder<ShapeClosure>
         object.expectStringMember("id", builder::id)
                 .getArrayMember("includeNamespaces", StringNode::getValue, builder::includeNamespaces)
                 .getStringMember("includeBySelector", builder::includeBySelector)
-                .getObjectMember("rename", rename -> builder.rename(renamesFromNode(rename)));
+                .getObjectMember("rename", rename -> builder.rename(renamesFromNode(rename)))
+                .getStringMember("documentation", builder::documentation);
         return builder.build();
     }
 
@@ -187,6 +188,7 @@ public final class ShapeClosure implements ToNode, ToSmithyBuilder<ShapeClosure>
             rename.forEach((from, to) -> renameBuilder.withMember(from.toString(), to));
             builder.withMember("rename", renameBuilder.build());
         }
+        builder.withOptionalMember("documentation", getDocumentation().map(Node::from));
         return builder.build();
     }
 
@@ -197,7 +199,8 @@ public final class ShapeClosure implements ToNode, ToSmithyBuilder<ShapeClosure>
                 .id(id)
                 .includeNamespaces(includeNamespaces)
                 .includeBySelector(includeBySelector)
-                .rename(rename);
+                .rename(rename)
+                .documentation(documentation);
     }
 
     @Override
@@ -209,12 +212,13 @@ public final class ShapeClosure implements ToNode, ToSmithyBuilder<ShapeClosure>
         return id.equals(that.id)
                 && includeNamespaces.equals(that.includeNamespaces)
                 && Objects.equals(includeBySelector, that.includeBySelector)
-                && rename.equals(that.rename);
+                && rename.equals(that.rename)
+                && Objects.equals(documentation, that.documentation);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, includeNamespaces, includeBySelector, rename);
+        return Objects.hash(id, includeNamespaces, includeBySelector, rename, documentation);
     }
 
     /**

--- a/smithy-model/src/test/java/software/amazon/smithy/model/metadata/ShapeClosureTest.java
+++ b/smithy-model/src/test/java/software/amazon/smithy/model/metadata/ShapeClosureTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
 import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
 
@@ -56,6 +57,7 @@ public class ShapeClosureTest {
         assertThat(primary.getIncludeNamespaces(), contains("com.example"));
         assertThat(primary.getIncludeBySelector(), equalTo(Optional.of("string")));
         assertThat(primary.getRename(), equalTo(expectedRename));
+        assertThat(primary.getDocumentation(), equalTo(Optional.of("Primary closure documentation.")));
         assertThat(ShapeClosure.fromNode(primary.toNode()), equalTo(primary));
         assertThat(primary.toBuilder().build(), equalTo(primary));
     }
@@ -80,6 +82,40 @@ public class ShapeClosureTest {
         assertFalse(serialized.getMember("includeNamespaces").isPresent());
         assertFalse(serialized.getMember("includeBySelector").isPresent());
         assertFalse(serialized.getMember("rename").isPresent());
+        assertFalse(serialized.getMember("documentation").isPresent());
+    }
+
+    @Test
+    public void readsDocumentationFromNode() {
+        ShapeClosure closure = ShapeClosure.fromNode(Node.objectNodeBuilder()
+                .withMember("id", "com.example#documented")
+                .withMember("documentation", "Closure documentation.")
+                .build());
+
+        assertThat(closure.getDocumentation(), equalTo(Optional.of("Closure documentation.")));
+    }
+
+    @Test
+    public void roundTripsDocumentationThroughNode() {
+        ShapeClosure closure = ShapeClosure.builder()
+                .id("com.example#documented")
+                .documentation("Closure documentation.")
+                .build();
+
+        ShapeClosure roundTripped = ShapeClosure.fromNode(closure.toNode());
+
+        assertThat(roundTripped.getDocumentation(), equalTo(Optional.of("Closure documentation.")));
+    }
+
+    @Test
+    public void copiesDocumentationToBuilder() {
+        ShapeClosure closure = ShapeClosure.builder()
+                .id("com.example#documented")
+                .documentation("Closure documentation.")
+                .build();
+
+        assertThat(closure.toBuilder().build().getDocumentation(),
+                equalTo(Optional.of("Closure documentation.")));
     }
 
     @Test

--- a/smithy-model/src/test/resources/software/amazon/smithy/model/metadata/shape-closure-test.smithy
+++ b/smithy-model/src/test/resources/software/amazon/smithy/model/metadata/shape-closure-test.smithy
@@ -8,6 +8,8 @@ metadata shapeClosures = [
         rename: {
             "com.example#Foo": "RenamedFoo"
         }
+        documentation: """
+            Primary closure documentation."""
     }
     {
         id: "com.example#secondary"


### PR DESCRIPTION
This fixes an issue where closures weren't parsing their documented documentation member.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
