### PR TITLE
Remove redundant plexus-utils constraint

### DIFF
--- a/smithy-cli/build.gradle.kts
+++ b/smithy-cli/build.gradle.kts
@@ -45,14 +45,6 @@ fun requireJava25ForImage() {
 }
 
 dependencies {
-    constraints {
-        implementation("org.codehaus.plexus:plexus-utils:3.6.1") {
-            because(
-                "CVE-2025-67030: directory traversal in Expand.extractFile (CVSS 8.8), fixed in 3.6.1 via https://github.com/codehaus-plexus/plexus-utils/pull/304",
-            )
-        }
-    }
-
     // Keeps these as exported transitive dependencies.
     implementation(project(":smithy-model"))
     implementation(project(":smithy-build"))


### PR DESCRIPTION
maven-resolver-provider 3.9.16 already resolves plexus-utils 3.6.1, which includes the required security fix.

Security fix introduced in https://github.com/apache/maven/releases/tag/maven-3.9.15.

This change was introduced in #3060.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
