### PR TITLE
Add basic endpoint rulesets for benchmark model

### DIFF
--- a/smithy-benchmark-models/build.gradle.kts
+++ b/smithy-benchmark-models/build.gradle.kts
@@ -17,6 +17,8 @@ dependencies {
     api(project(":smithy-aws-traits"))
     api(project(":smithy-protocol-test-traits"))
     api(project(":smithy-protocol-traits"))
+    api(project(":smithy-rules-engine"))
+    api(project(":smithy-aws-endpoints"))
 }
 
 tasks.sourcesJar {

--- a/smithy-benchmark-models/model/serde/AwsJsonRpc1_0DataPlane.smithy
+++ b/smithy-benchmark-models/model/serde/AwsJsonRpc1_0DataPlane.smithy
@@ -5,11 +5,36 @@ namespace smithy.benchmark.serde
 use aws.api#service
 use aws.auth#sigv4
 use aws.protocols#awsJson1_0
+use smithy.rules#endpointRuleSet
 
 @title("AWS JSON RPC 1.0 Data Plane")
-@sigv4(name: "awsjsonrpc10dataplane")
+@sigv4(name: "example")
 @awsJson1_0
 @service(sdkId: "JsonRpc10DataPlane")
+@endpointRuleSet({
+    version: "1.0"
+    parameters: {
+        Region: {
+            builtIn: "AWS::Region"
+            required: false
+            documentation: "The AWS region used to dispatch the request. Unused."
+            type: "String"
+        }
+        Endpoint: {
+            builtIn: "SDK::Endpoint"
+            required: false
+            documentation: "Override the endpoint used to send this request. Unused."
+            type: "String"
+        }
+    }
+    rules: [
+        {
+            conditions: []
+            endpoint: { url: "https://example.com" }
+            type: "endpoint"
+        }
+    ]
+})
 service AwsJsonRpc10DataPlane {
     version: "1999-12-31"
     operations: [

--- a/smithy-benchmark-models/model/serde/AwsQueryDataPlane.smithy
+++ b/smithy-benchmark-models/model/serde/AwsQueryDataPlane.smithy
@@ -5,12 +5,37 @@ namespace smithy.benchmark.serde
 use aws.api#service
 use aws.auth#sigv4
 use aws.protocols#awsQuery
+use smithy.rules#endpointRuleSet
 
 @title("AWS Query Data Plane")
-@sigv4(name: "awsquerydataplane")
+@sigv4(name: "example")
 @awsQuery
 @xmlNamespace(uri: "https://awsquerydataplane.amazonaws.com")
 @service(sdkId: "QueryDataPlane")
+@endpointRuleSet({
+    version: "1.0"
+    parameters: {
+        Region: {
+            builtIn: "AWS::Region"
+            required: false
+            documentation: "The AWS region used to dispatch the request. Unused."
+            type: "String"
+        }
+        Endpoint: {
+            builtIn: "SDK::Endpoint"
+            required: false
+            documentation: "Override the endpoint used to send this request. Unused."
+            type: "String"
+        }
+    }
+    rules: [
+        {
+            conditions: []
+            endpoint: { url: "https://example.com" }
+            type: "endpoint"
+        }
+    ]
+})
 service AwsQueryDataPlane {
     version: "1999-12-31"
     operations: [

--- a/smithy-benchmark-models/model/serde/AwsRestJsonDataPlane.smithy
+++ b/smithy-benchmark-models/model/serde/AwsRestJsonDataPlane.smithy
@@ -5,11 +5,36 @@ namespace smithy.benchmark.serde
 use aws.api#service
 use aws.auth#sigv4
 use aws.protocols#restJson1
+use smithy.rules#endpointRuleSet
 
 @title("AWS REST JSON Data Plane")
-@sigv4(name: "awsrestjsondataplane")
+@sigv4(name: "example")
 @restJson1
 @service(sdkId: "RestJsonDataPlane")
+@endpointRuleSet({
+    version: "1.0"
+    parameters: {
+        Region: {
+            builtIn: "AWS::Region"
+            required: false
+            documentation: "The AWS region used to dispatch the request. Unused."
+            type: "String"
+        }
+        Endpoint: {
+            builtIn: "SDK::Endpoint"
+            required: false
+            documentation: "Override the endpoint used to send this request. Unused."
+            type: "String"
+        }
+    }
+    rules: [
+        {
+            conditions: []
+            endpoint: { url: "https://example.com" }
+            type: "endpoint"
+        }
+    ]
+})
 service AwsRestJsonDataPlane {
     version: "1999-12-31"
     operations: [

--- a/smithy-benchmark-models/model/serde/AwsRestXmlDataPlane.smithy
+++ b/smithy-benchmark-models/model/serde/AwsRestXmlDataPlane.smithy
@@ -5,12 +5,37 @@ namespace smithy.benchmark.serde
 use aws.api#service
 use aws.auth#sigv4
 use aws.protocols#restXml
+use smithy.rules#endpointRuleSet
 
 @title("AWS REST XML Data Plane")
-@sigv4(name: "awsrestxmldataplane")
+@sigv4(name: "example")
 @restXml
 @xmlNamespace(uri: "https://awsrestxmldataplane.amazonaws.com")
 @service(sdkId: "RestXmlDataPlane")
+@endpointRuleSet({
+    version: "1.0"
+    parameters: {
+        Region: {
+            builtIn: "AWS::Region"
+            required: false
+            documentation: "The AWS region used to dispatch the request. Unused."
+            type: "String"
+        }
+        Endpoint: {
+            builtIn: "SDK::Endpoint"
+            required: false
+            documentation: "Override the endpoint used to send this request. Unused."
+            type: "String"
+        }
+    }
+    rules: [
+        {
+            conditions: []
+            endpoint: { url: "https://example.com" }
+            type: "endpoint"
+        }
+    ]
+})
 service AwsRestXmlDataPlane {
     version: "1999-12-31"
     operations: [

--- a/smithy-benchmark-models/model/serde/SmithyRpcV2CborDataPlane.smithy
+++ b/smithy-benchmark-models/model/serde/SmithyRpcV2CborDataPlane.smithy
@@ -5,11 +5,36 @@ namespace smithy.benchmark.serde
 use aws.api#service
 use aws.auth#sigv4
 use smithy.protocols#rpcv2Cbor
+use smithy.rules#endpointRuleSet
 
 @title("Smithy RPC v2 CBOR Data Plane")
-@sigv4(name: "smithyrpcv2cbordataplane")
+@sigv4(name: "example")
 @rpcv2Cbor
 @service(sdkId: "RpcCborDataPlane")
+@endpointRuleSet({
+    version: "1.0"
+    parameters: {
+        Region: {
+            builtIn: "AWS::Region"
+            required: false
+            documentation: "The AWS region used to dispatch the request. Unused."
+            type: "String"
+        }
+        Endpoint: {
+            builtIn: "SDK::Endpoint"
+            required: false
+            documentation: "Override the endpoint used to send this request. Unused."
+            type: "String"
+        }
+    }
+    rules: [
+        {
+            conditions: []
+            endpoint: { url: "https://example.com" }
+            type: "endpoint"
+        }
+    ]
+})
 service SmithyRpcV2CborDataPlane {
     version: "1999-12-31"
     operations: [


### PR DESCRIPTION
#### Background
* What do these changes do? 
Add basic endpoint rulesets with fixed, short endpoint urls + short/consistent `signingName` for benchmark model
* Why are they important?
During E2E testing of the SERDE models that the `endpointUrls` and signing names used can influence the overall results. Adding basic endpoint rulesets to ensure they are consistent between SDKs and between protocols

#### Testing
* How did you test these changes?
Run it with Kotlin benchmark harness

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
